### PR TITLE
Update TensorFlow example code in readme

### DIFF
--- a/ngraph/frontends/tensorflow/readme.md
+++ b/ngraph/frontends/tensorflow/readme.md
@@ -15,7 +15,7 @@ f = x + y
 
 # import
 importer = TFImporter()
-importer.parse_graph_def(tf.Session().graph_def)
+importer.parse_graph_def(tf.get_default_graph().as_graph_def())
 
 # get handle
 f_ng = importer.get_op_handle(f)


### PR DESCRIPTION
Using `tf.get_default_graph()` is a more direct way to access the `GraphDef` than creating (and discarding) a `tf.Session`.