### PR TITLE
cmake: Add the gtest library as a 'BUILD_BYPRODUCT'

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ ExternalProject_Add(
     # Disable install step
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
+    BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/gtest/src/gtest-build/googlemock/gtest/libgtest.a"
 )
 
 # Get GTest source and binary directories from CMake project


### PR DESCRIPTION
This is needed when using build tools like ninja instead of make since they need fine-grained dependencies