### PR TITLE
Fixes several CMake problems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,20 @@
 # We require version 2.8.12 only because that's the lowest version of CMake on which
 # we've validate this repository.
 cmake_minimum_required (VERSION 2.8.12)
-cmake_policy(VERSION 2.8.12)
 
-project (ngraph
-    LANGUAGES CXX
-    )
+# Suppress an OS X-specific warning.
+if (POLICY CMP0042)
+    cmake_policy(SET CMP0042 OLD)
+endif()
 
+# Suppress a warning about not using the `project` command's `VERSION` argument.
+# Once we bump `cmake_minimum_required` to something >= 3.0, we can remove this
+# suppression and change how we specify the project's version number.
+if (POLICY CMP0048)
+    cmake_policy(SET CMP0048 OLD)
+endif()
+
+project (ngraph CXX)
 set(NGRAPH_VERSION 0.1)
 
 # These variables are undocumented but useful.
@@ -28,6 +36,29 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
 # set directory where the custom finders live
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
+#-----------------------------------------------------------------------------------------------
+# Compiler-specific logic...
+#-----------------------------------------------------------------------------------------------
+
+# Default values...
+set(NGRAPH_CXX_WARNING_FLAGS "")
+
+# Compiler-specific logic...
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    include( cmake/clang_4_0_flags.cmake )
+else()
+    message(WARNING "CMAKE_CXX_COMPILER_ID='${CMAKE_CXX_COMPILER_ID}'.  CMAKE_CXX_COMPILER='${CMAKE_CXX_COMPILER}'.  The only supported compiler is 'clang', but the selected compiler is '${CMAKE_CXX_COMPILER}'.")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+
+FOREACH(F IN LISTS NGRAPH_CXX_WARNING_FLAGS)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${F}")
+ENDFOREACH()
+
+#-----------------------------------------------------------------------------------------------
 
 # The following 'add_subdirectory' call:
 # - defines the 'libgtest' target.

--- a/cmake/external_gtest.cmake
+++ b/cmake/external_gtest.cmake
@@ -14,17 +14,38 @@
 # Enable ExternalProject CMake module
 include(ExternalProject)
 
-# Download and install GoogleTest
-ExternalProject_Add(
-    gtest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG     release-1.8.0
-    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
-    # Disable install step
-    INSTALL_COMMAND ""
-    UPDATE_COMMAND ""
-    BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/gtest/src/gtest-build/googlemock/gtest/libgtest.a"
-    )
+#----------------------------------------------------------------------------------------------------------
+# Download and install GoogleTest ...
+#----------------------------------------------------------------------------------------------------------
+
+SET(GTEST_GIT_REPO_URL https://github.com/google/googletest.git)
+SET(GTEST_GIT_LABEL release-1.8.0)
+
+# The 'BUILD_BYPRODUCTS' argument was introduced in CMake 3.2.
+if (${CMAKE_VERSION} VERSION_LESS 3.2)
+    ExternalProject_Add(
+        gtest
+        GIT_REPOSITORY ${GTEST_GIT_REPO_URL}
+        GIT_TAG ${GTEST_GIT_LABEL}
+        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
+        # Disable install step
+        INSTALL_COMMAND ""
+        UPDATE_COMMAND ""
+        )
+else()
+    ExternalProject_Add(
+        gtest
+        GIT_REPOSITORY ${GTEST_GIT_REPO_URL}
+        GIT_TAG ${GTEST_GIT_LABEL}
+        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
+        # Disable install step
+        INSTALL_COMMAND ""
+        UPDATE_COMMAND ""
+        BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/gtest/src/gtest-build/googlemock/gtest/libgtest.a"
+        )
+endif()
+
+#----------------------------------------------------------------------------------------------------------
 
 # Get GTest source and binary directories from CMake project
 ExternalProject_Get_Property(gtest source_dir binary_dir)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,29 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#-----------------------------------------------------------------------------------------------
-# Compiler-specific logic...
-#-----------------------------------------------------------------------------------------------
-
-# Default values...
-set(NGRAPH_CXX_WARNING_FLAGS "")
-
-# Compiler-specific logic...
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    include( ../cmake/clang_4_0_flags.cmake )
-else()
-    message(WARNING "CMAKE_CXX_COMPILER_ID='${CMAKE_CXX_COMPILER_ID}'.  CMAKE_CXX_COMPILER='${CMAKE_CXX_COMPILER}'.  The only supported compiler is 'clang', but the selected compiler is '${CMAKE_CXX_COMPILER}'.")
-endif()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-
-FOREACH(F IN LISTS NGRAPH_CXX_WARNING_FLAGS)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${F}")
-ENDFOREACH()
-
-#-----------------------------------------------------------------------------------------------
-
 get_filename_component( NGRAPH_INCLUDE_DIR . ABSOLUTE)
 set(NGRAPH_INCLUDE_DIR "${NGRAPH_INCLUDE_DIR}" PARENT_SCOPE)
 


### PR DESCRIPTION
- On OS X, cmake complains about CMP0042.
- When using cmake versions below 3.0, errors regarding how the project version number
  is specified.