### PR TITLE
Fixes #22 - Change supported platform to Ubuntu 16.04.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,26 +11,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# We require version 2.8.12 only because that's the lowest version of CMake on which
+# We require version 3.5.1 only because that's the lowest version of CMake on which
 # we've validate this repository.
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5.1)
 
 # Suppress an OS X-specific warning.
 if (POLICY CMP0042)
     cmake_policy(SET CMP0042 OLD)
 endif()
 
-# Suppress a warning about not using the `project` command's `VERSION` argument.
-# Once we bump `cmake_minimum_required` to something >= 3.0, we can remove this
-# suppression and change how we specify the project's version number.
-if (POLICY CMP0048)
-    cmake_policy(SET CMP0048 OLD)
+if ("${CMAKE_CXX_COMPILER}" STREQUAL "")
+    # The user didn't indicate a compiler preference, to pick the compiler based on
+    # the personal preferences and convenience of the project's developers...
+    find_program(
+        CXX_COMPILER
+        NAMES
+        clang++-4.0
+        clang++-3.9
+        clang++
+        c++
+        NAMES_PER_DIR
+        DOC "Which C++ compiler to use when building `libngraph` and the tests."
+        )
+
+    if ("${CXX_COMPILER}" STREQUAL "CXX_COMPILER-NOTFOUND")
+        message(FATAL_ERROR "Unable to find a suitable c++ compiler.")
+    else()
+        message(STATUS "Using C++ compiler: '${CXX_COMPILER}'")
+        set(CMAKE_CXX_COMPILER "${CXX_COMPILER}")
+    endif()
 endif()
 
-set(CMAKE_CXX_COMPILER "clang++")
-
-project (ngraph CXX)
-set(NGRAPH_VERSION 0.1)
+project (ngraph
+    LANGUAGES CXX
+    VERSION 0.1
+    )
 
 # These variables are undocumented but useful.
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ TODO
 
 ## Build Environments
 
-| Operating System            | Compiler  | Status    | Additional packages required      |
-| --------------------------- | --------  | --------- | --------------------------------- |
-| Ubuntu 14.04.5 (LTS) 64-bit | CLang 3.9 | supported | `build-essential cmake clang-3.9` |
+| Operating System            | Compiler  | Build system           | Status                 | Additional packages required      |
+| --------------------------- | --------- | ---------------------- | ---------------------- | --------------------------------- |
+| Ubuntu 16.04 (LTS) 64-bit   | CLang 3.9 | CMake 3.5.1 + GNU Make | supported              | `build-essential cmake clang-3.9` |
+| Ubuntu 16.04 (LTS) 64-bit   | CLang 4.0 | CMake 3.5.1 + GNU Make | unsupported, but works | `build-essential cmake clang-4.0` |
 
 ## Steps
 

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <vector>
 #include <initializer_list>
 #include <iostream>


### PR DESCRIPTION
* Updates documentation regarding supported platform.

* Increments minimum CMake version to 3.5.1 (the version
  provided by Ubuntu 16.04).

* Adds support for Clang 4.0, while retaining support for Clang 3.9.