### PR TITLE
CMake: Use 'patch' instead of 'git am'

### DIFF
--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -29,7 +29,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             ext_mkldnn
             GIT_REPOSITORY ${MKLDNN_GIT_REPO_URL}
             UPDATE_COMMAND ""
-            PATCH_COMMAND git am ${CMAKE_SOURCE_DIR}/third-party/patches/mkldnn-cmake-openmp.patch
+            PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/third-party/patches/mkldnn-cmake-openmp.patch
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
             )
     else()


### PR DESCRIPTION
Git invocations without an available gitconfig (ex. a test environment)
will fail whereas patch should always work. This adds a build dependecy on patch.