### PR TITLE
individual install path for external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,25 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 
 #-----------------------------------------------------------------------------------------------
+# External projects install directory
+#-----------------------------------------------------------------------------------------------
+
+# Root for external installs, when using `make`, e.g.
+# ${EXTERNAL_INSTALL_DIR}
+# ├── eigen               <-- ${EIGEN_INSTALL_DIR}
+# │   ├── include
+# │   │   └── eigen3      <-- ${EIGEN_INCLUDE_DIR}
+# │   │       ├── Eigen
+# │   ...
+# │
+# └── mkldnn              <-- ${MKLDNN_INSTALL_DIR}
+#     ├── include         <-- ${MKLDNN_INCLUDE_DIR}
+#     │   ├── mkldnn.h
+#     │   ...
+#     ├── lib             <-- ${MKLDNN_LIB_DIR}
+#     │   ├── libiomp5.so
+#     ...
+set(EXTERNAL_INSTALL_DIR ${CMAKE_BINARY_DIR}/external)
 
 # The following 'add_subdirectory' call:
 # - defines the 'libgtest' target.

--- a/cmake/external_eigen.cmake
+++ b/cmake/external_eigen.cmake
@@ -14,7 +14,7 @@
 # Enable ExternalProject CMake module
 include(ExternalProject)
 
-set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/external)
+set(EIGEN_INSTALL_DIR ${EXTERNAL_INSTALL_DIR}/eigen)
 
 #----------------------------------------------------------------------------------------------------------
 # Download and install GoogleTest ...
@@ -27,7 +27,7 @@ if (${CMAKE_VERSION} VERSION_LESS 3.2)
         URL http://bitbucket.org/eigen/eigen/get/3.3.3.zip
         # PREFIX ${CMAKE_CURRENT_BINARY_DIR}/eigen
         UPDATE_COMMAND ""
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EIGEN_INSTALL_DIR}
         )
 else()
     ExternalProject_Add(
@@ -35,8 +35,8 @@ else()
         URL http://bitbucket.org/eigen/eigen/get/3.3.3.zip
         # PREFIX ${CMAKE_CURRENT_BINARY_DIR}/eigen
         UPDATE_COMMAND ""
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
-        BUILD_BYPRODUCTS "${EXTERNAL_INSTALL_LOCATION}/include/eigen3"
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EIGEN_INSTALL_DIR}
+        BUILD_BYPRODUCTS "${EIGEN_INSTALL_DIR}/include/eigen3"
         )
 endif()
 
@@ -44,4 +44,4 @@ endif()
 
 ExternalProject_Get_Property(eigen source_dir binary_dir)
 
-set(EIGEN_INCLUDE_DIR "${EXTERNAL_INSTALL_LOCATION}/include/eigen3" PARENT_SCOPE)
+set(EIGEN_INCLUDE_DIR "${EIGEN_INSTALL_DIR}/include/eigen3" PARENT_SCOPE)

--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -19,9 +19,8 @@ include(ExternalProject)
 
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
-    SET(MKLDNN_GIT_REPO_URL https://github.com/01org/mkl-dnn)
-
-    set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/external)
+    set(MKLDNN_GIT_REPO_URL https://github.com/01org/mkl-dnn)
+    set(MKLDNN_INSTALL_DIR ${EXTERNAL_INSTALL_DIR}/mkldnn)
 
     # The 'BUILD_BYPRODUCTS' argument was introduced in CMake 3.2.
     if(${CMAKE_VERSION} VERSION_LESS 3.2)
@@ -30,7 +29,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             GIT_REPOSITORY ${MKLDNN_GIT_REPO_URL}
             UPDATE_COMMAND ""
             PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/third-party/patches/mkldnn-cmake-openmp.patch
-            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${MKLDNN_INSTALL_DIR}
             )
     else()
         ExternalProject_Add(
@@ -38,8 +37,8 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             GIT_REPOSITORY ${MKLDNN_GIT_REPO_URL}
             UPDATE_COMMAND ""
             PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/third-party/patches/mkldnn-cmake-openmp.patch
-            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
-            BUILD_BYPRODUCTS "${EXTERNAL_INSTALL_LOCATION}/include/mkldnn.hpp"
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${MKLDNN_INSTALL_DIR}
+            BUILD_BYPRODUCTS "${MKLDNN_INSTALL_DIR}/include/mkldnn.hpp"
             )
     endif()
 
@@ -54,7 +53,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         )
 
 
-    set(MKLDNN_INCLUDE_DIR "${EXTERNAL_INSTALL_LOCATION}/include" PARENT_SCOPE)
-    set(MKLDNN_LIB_DIR "${EXTERNAL_INSTALL_LOCATION}/lib" PARENT_SCOPE)
+    set(MKLDNN_INCLUDE_DIR "${MKLDNN_INSTALL_DIR}/include" PARENT_SCOPE)
+    set(MKLDNN_LIB_DIR "${MKLDNN_INSTALL_DIR}/lib" PARENT_SCOPE)
 
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,11 +96,37 @@ set(CMAKE_INSTALL_PREFIX "$ENV{HOME}/ngraph_dist" CACHE PATH "Install directory"
 message (STATUS "Installation directory: ${CMAKE_INSTALL_PREFIX}")
 message (STATUS "To Override use: cmake -DCMAKE_INSTALL_PREFIX=/foo -P cmake_install.cmake")
 
-install(TARGETS ngraph DESTINATION ${CMAKE_INSTALL_PREFIX})
+# Destinations
+set(CMAKE_INSTALL_LIB "${CMAKE_INSTALL_PREFIX}/lib")
+set(CMAKE_INSTALL_INCLUDE "${CMAKE_INSTALL_PREFIX}/include")
+
+# NGraph
+install(TARGETS ngraph DESTINATION ${CMAKE_INSTALL_LIB})  # libngraph.so
 install(DIRECTORY
-    ${CMAKE_CURRENT_SOURCE_DIR}/ngraph
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION "${CMAKE_INSTALL_INCLUDE}"
     FILES_MATCHING PATTERN "*.hpp"
+)
+
+# External
+# Requirements:
+# - In NGraph, there are multiple include paths set for different external projects.
+# - However, we want one single include path for external projects from the TF bridge side, while
+#   making sure that the `#include` files can still be resolved.
+# - Therefore, when `make install`, the include directory will be "flattened" for each external
+#   projects respectively.
+
+install(DIRECTORY
+    ${EIGEN_INCLUDE_DIR}/
+    DESTINATION "${CMAKE_INSTALL_INCLUDE}"
+)
+install(DIRECTORY
+    ${MKLDNN_INCLUDE_DIR}/
+    DESTINATION "${CMAKE_INSTALL_INCLUDE}"
+)
+install(DIRECTORY
+    ${MKLDNN_LIB_DIR}/
+    DESTINATION "${CMAKE_INSTALL_LIB}"
 )
 
 add_dependencies(ngraph eigen)


### PR DESCRIPTION
1. Standarize external project installation directory:
```
${EXTERNAL_INSTALL_DIR}
├── eigen               <-- ${EIGEN_INSTALL_DIR}
│   ├── include
│   │   └── eigen3      <-- ${EIGEN_INCLUDE_DIR}
│   │       ├── Eigen
│   ...
│
└── mkldnn              <-- ${MKLDNN_INSTALL_DIR}
    ├── include         <-- ${MKLDNN_INCLUDE_DIR}
    │   ├── mkldnn.h
    │   ...
    ├── lib             <-- ${MKLDNN_LIB_DIR}
    │   ├── libiomp5.so
    ...
```

2. Flattens headers / libs when using
```shell
make install
```
to enable include from TF side. This allows TF to have a single include path for ngraph's external projects.

3. Renamed `LOCATION` to `DIR`