### PR TITLE
Excluded MKL_DNN from include path for the Mac builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ cmake_minimum_required (VERSION 2.8)
 set(NGRAPH_INCLUDE_PATH
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
-
 # Suppress an OS X-specific warning.
 if (POLICY CMP0042)
     cmake_policy(SET CMP0042 OLD)

--- a/src/ngraph/CMakeLists.txt
+++ b/src/ngraph/CMakeLists.txt
@@ -65,18 +65,19 @@ endif()
 include_directories(
     "${NGRAPH_INCLUDE_PATH}"
     "${EIGEN_INCLUDE_DIR}"
-    "${MKLDNN_INCLUDE_DIR}"
     )
 
 add_library(ngraph SHARED ${SRC})
 target_include_directories(ngraph PUBLIC "${NGRAPH_INCLUDE_PATH}")
-
+    
 if (APPLE)
     set_property(TARGET ngraph PROPERTY PREFIX "lib")
     set_property(TARGET ngraph PROPERTY OUTPUT_NAME "ngraph.so")
     set_property(TARGET ngraph PROPERTY SUFFIX "")
+else()
+    include_directories("${MKLDNN_INCLUDE_DIR}")
 endif()
-
+    
 #-----------------------------------------------------------------------------------------------
 # Installation logic...
 #-----------------------------------------------------------------------------------------------


### PR DESCRIPTION
TESTNOW