### PR TITLE
operator overloading as a free function

### DIFF
--- a/src/ngraph/descriptor/tensor.cpp
+++ b/src/ngraph/descriptor/tensor.cpp
@@ -20,9 +20,9 @@ using namespace ngraph;
 using namespace ngraph::descriptor;
 
 Tensor::Tensor(const element::Type& element_type,
-        PrimaryTensorView*   primary_tensor_view,
-        const Node*          parent,
-        size_t               value_index)
+               PrimaryTensorView*   primary_tensor_view,
+               const Node*          parent,
+               size_t               value_index)
     : m_element_type(element_type)
     , m_primary_tensor_view(primary_tensor_view)
     , m_is_output{parent->is_output()}
@@ -59,7 +59,7 @@ size_t Tensor::get_pool_offset() const
     return m_pool_offset;
 }
 
-std::ostream& descriptor::operator<<(std::ostream& out, const Tensor& tensor)
+std::ostream& operator<<(std::ostream& out, const Tensor& tensor)
 {
     out << "Tensor(" << tensor.get_name() << ")";
     return out;

--- a/src/ngraph/descriptor/tensor.hpp
+++ b/src/ngraph/descriptor/tensor.hpp
@@ -59,8 +59,6 @@ public:
     void               set_pool_offset(size_t);
     size_t             get_pool_offset() const;
 
-    friend std::ostream& operator<<(std::ostream&, const Tensor&);
-
 protected:
     const element::Type& m_element_type;
     PrimaryTensorView*   m_primary_tensor_view;
@@ -72,3 +70,5 @@ protected:
     size_t               m_size;
     size_t               m_pool_offset;
 };
+
+std::ostream& operator<<(std::ostream&, const ngraph::descriptor::Tensor&);


### PR DESCRIPTION
- current master build fails in 16.04, is our CI 16.04?
- same issue as https://github.com/NervanaSystems/private-ngraph-cpp/pull/130/commits/036eafe05156f076287a08ab11e8839ed4dc0fcb
- ref: https://stackoverflow.com/questions/10744787/operator-must-take-exactly-one-argument/10744815#10744815
- tested to work with current TF