### PR TITLE
new style that does not align declarations or assignments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,8 +6,8 @@ Standard: Cpp11
 
 AccessModifierOffset: -4
 
-AlignConsecutiveDeclarations: true
-AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: false
 AlignTrailingComments: true
 
 AllowShortBlocksOnASingleLine: true

--- a/src/ngraph/descriptor/buffer.hpp
+++ b/src/ngraph/descriptor/buffer.hpp
@@ -27,7 +27,6 @@ namespace ngraph
         {
         public:
             size_t size() const { return m_size; }
-
         protected:
             size_t m_size;
         };

--- a/src/ngraph/descriptor/buffer_pos.hpp
+++ b/src/ngraph/descriptor/buffer_pos.hpp
@@ -29,7 +29,6 @@ namespace ngraph
         {
         public:
             BufferPos() {}
-
             BufferPos(std::shared_ptr<Buffer> buffer, size_t offset, size_t size)
                 : m_buffer(buffer)
                 , m_offset(offset)
@@ -43,8 +42,8 @@ namespace ngraph
 
         protected:
             std::shared_ptr<Buffer> m_buffer;
-            size_t                  m_offset;
-            size_t                  m_size;
+            size_t m_offset;
+            size_t m_size;
         };
     }
 }

--- a/src/ngraph/descriptor/input.cpp
+++ b/src/ngraph/descriptor/input.cpp
@@ -18,8 +18,7 @@ using namespace std;
 using namespace ngraph;
 using namespace descriptor;
 
-Input::Input(
-    Node* node, size_t index, size_t argno, size_t arg_index, Output& output)
+Input::Input(Node* node, size_t index, size_t argno, size_t arg_index, Output& output)
     : m_node(node)
     , m_index(index)
     , m_argno(argno)

--- a/src/ngraph/descriptor/input.hpp
+++ b/src/ngraph/descriptor/input.hpp
@@ -37,26 +37,22 @@ namespace ngraph
             /// @param argno The position of the argument with this tensor
             /// @param arg_index The position of the tensor within the argument's tensors
             /// @param output The output that supplies a value for this input
-            Input(Node*   node,
-                  size_t  index,
-                  size_t  argno,
-                  size_t  arg_index,
-                  Output& output);
+            Input(Node* node, size_t index, size_t argno, size_t arg_index, Output& output);
 
             std::shared_ptr<Node> get_node();
-            size_t                get_argno() const { return m_argno; }
-            size_t                get_arg_index() const { return m_arg_index; }
-            size_t                get_index() const { return m_index; }
-            const Output&         get_output() const { return m_output; }
-            Output&               get_output() { return m_output; }
-            const Tensor&         get_tensor() const;
-            Tensor&               get_tensor();
+            size_t get_argno() const { return m_argno; }
+            size_t get_arg_index() const { return m_arg_index; }
+            size_t get_index() const { return m_index; }
+            const Output& get_output() const { return m_output; }
+            Output& get_output() { return m_output; }
+            const Tensor& get_tensor() const;
+            Tensor& get_tensor();
 
         protected:
-            Node*   m_node;      // The node we are an input for
-            size_t  m_index;     // Index into all input tensors
-            size_t  m_argno;     // Arg number for this input
-            size_t  m_arg_index; // Index into arg's tensors
+            Node* m_node;       // The node we are an input for
+            size_t m_index;     // Index into all input tensors
+            size_t m_argno;     // Arg number for this input
+            size_t m_arg_index; // Index into arg's tensors
             Output& m_output;
 
         private:

--- a/src/ngraph/descriptor/layout/dense_tensor_view_layout.cpp
+++ b/src/ngraph/descriptor/layout/dense_tensor_view_layout.cpp
@@ -24,10 +24,10 @@ using ngraph::TensorViewType;
 DenseTensorViewLayout::DenseTensorViewLayout(const TensorView& tensor_view)
     : TensorViewLayout(tensor_view)
 {
-    auto  tensor_view_type = tensor_view.get_tensor_view_type();
-    Shape shape            = tensor_view_type->get_shape();
-    m_size                 = ngraph::shape_size(shape);
-    m_strides              = ngraph::row_major_strides(shape);
+    auto tensor_view_type = tensor_view.get_tensor_view_type();
+    Shape shape = tensor_view_type->get_shape();
+    m_size = ngraph::shape_size(shape);
+    m_strides = ngraph::row_major_strides(shape);
 }
 
 size_t DenseTensorViewLayout::get_index_offset(const std::vector<size_t>& indices)

--- a/src/ngraph/descriptor/layout/dense_tensor_view_layout.hpp
+++ b/src/ngraph/descriptor/layout/dense_tensor_view_layout.hpp
@@ -41,8 +41,8 @@ namespace ngraph
 
             protected:
                 Strides m_strides;
-                size_t  m_offset;
-                size_t  m_size;
+                size_t m_offset;
+                size_t m_size;
             };
         }
     }

--- a/src/ngraph/descriptor/layout/tensor_view_layout.hpp
+++ b/src/ngraph/descriptor/layout/tensor_view_layout.hpp
@@ -40,7 +40,6 @@ namespace ngraph
 
             public:
                 virtual ~TensorViewLayout() {}
-
                 /// Extent of this view in buffer.
                 ///
                 /// When we support non-linear buffers, this will need to be something other than size_t.
@@ -53,11 +52,10 @@ namespace ngraph
 
                 /// Where this view is located in the buffer.
                 const BufferPos& get_buffer_pos() const { return m_buffer_pos; }
-                BufferPos&       get_buffer_pos() { return m_buffer_pos; }
-
+                BufferPos& get_buffer_pos() { return m_buffer_pos; }
             protected:
                 const ngraph::descriptor::TensorView& m_tensor_view;
-                BufferPos                             m_buffer_pos;
+                BufferPos m_buffer_pos;
             };
         }
     }

--- a/src/ngraph/descriptor/output.hpp
+++ b/src/ngraph/descriptor/output.hpp
@@ -37,19 +37,19 @@ namespace ngraph
             /// @param tensor_view The view of this tensor; where the value will be written
             Output(Node* node, size_t index, const std::shared_ptr<TensorView>& tensor_view);
 
-            std::shared_ptr<Node>       get_node() const;
-            size_t                      get_index() const { return m_index; }
+            std::shared_ptr<Node> get_node() const;
+            size_t get_index() const { return m_index; }
             std::shared_ptr<TensorView> get_tensor_view() const { return m_tensor_view; }
             void add_input(Input* input);
             const std::set<Input*>& get_inputs() const { return m_inputs; }
-            const Tensor&           get_tensor() const;
-            Tensor&                 get_tensor();
+            const Tensor& get_tensor() const;
+            Tensor& get_tensor();
 
         protected:
-            Node*                       m_node;
-            size_t                      m_index;
+            Node* m_node;
+            size_t m_index;
             std::shared_ptr<TensorView> m_tensor_view;
-            std::set<Input*>            m_inputs;
+            std::set<Input*> m_inputs;
         };
     }
 }

--- a/src/ngraph/descriptor/primary_tensor_view.cpp
+++ b/src/ngraph/descriptor/primary_tensor_view.cpp
@@ -18,9 +18,9 @@ using namespace ngraph;
 using namespace descriptor;
 
 PrimaryTensorView::PrimaryTensorView(const std::shared_ptr<const TensorViewType>& tensor_view_type,
-                                     const std::string&                           name,
-                                     bool                                         is_output,
-                                     bool                                         is_input)
+                                     const std::string& name,
+                                     bool is_output,
+                                     bool is_input)
     : TensorView(tensor_view_type)
     , m_tensor(tensor_view_type->get_element_type(), this, name, is_output, is_input)
 {

--- a/src/ngraph/descriptor/primary_tensor_view.hpp
+++ b/src/ngraph/descriptor/primary_tensor_view.hpp
@@ -41,12 +41,12 @@ namespace ngraph
             /// @param is_output The view can be read from the host at the end of a computation.
             /// @param is_input The view can be written from the host at the beginning of a computation.
             PrimaryTensorView(const std::shared_ptr<const TensorViewType>& tensor_view_type,
-                              const std::string&                           name,
-                              bool                                         is_output,
-                              bool                                         is_input);
+                              const std::string& name,
+                              bool is_output,
+                              bool is_input);
 
             virtual const Tensor& get_tensor() const override;
-            virtual Tensor&       get_tensor() override;
+            virtual Tensor& get_tensor() override;
 
         protected:
             Tensor m_tensor;

--- a/src/ngraph/descriptor/tensor.cpp
+++ b/src/ngraph/descriptor/tensor.cpp
@@ -20,10 +20,10 @@ using namespace ngraph;
 using namespace ngraph::descriptor;
 
 Tensor::Tensor(const element::Type& element_type,
-               PrimaryTensorView*   primary_tensor_view,
-               const std::string&   name,
-               bool                 is_output,
-               bool                 is_input)
+               PrimaryTensorView* primary_tensor_view,
+               const std::string& name,
+               bool is_output,
+               bool is_input)
     : m_element_type(element_type)
     , m_primary_tensor_view(primary_tensor_view)
     , m_is_output{is_output}

--- a/src/ngraph/descriptor/tensor.hpp
+++ b/src/ngraph/descriptor/tensor.hpp
@@ -44,34 +44,34 @@ private:
     Tensor& operator=(const Tensor&) = delete;
 
     Tensor(const element::Type& element_type,
-           PrimaryTensorView*   tensor_view,
-           const std::string&   name,
-           bool                 is_output,
-           bool                 is_input);
+           PrimaryTensorView* tensor_view,
+           const std::string& name,
+           bool is_output,
+           bool is_input);
 
     std::string get_next_view_name();
 
 public:
-    bool               is_output() const { return m_is_output; }
-    bool               is_input() const { return m_is_input; }
-    bool               is_persistent() const { return m_is_persistent; }
+    bool is_output() const { return m_is_output; }
+    bool is_input() const { return m_is_input; }
+    bool is_persistent() const { return m_is_persistent; }
     const std::string& get_name() const { return m_name; }
-    size_t             size() const;
-    void               set_pool_offset(size_t);
-    size_t             get_pool_offset() const;
+    size_t size() const;
+    void set_pool_offset(size_t);
+    size_t get_pool_offset() const;
 
     static std::string make_tensor_name(const Node* node, size_t value_index);
 
 protected:
     const element::Type& m_element_type;
-    PrimaryTensorView*   m_primary_tensor_view;
-    bool                 m_is_output;
-    bool                 m_is_input;
-    bool                 m_is_persistent;
-    std::string          m_name;
-    size_t               m_next_view_id;
-    size_t               m_size;
-    size_t               m_pool_offset;
+    PrimaryTensorView* m_primary_tensor_view;
+    bool m_is_output;
+    bool m_is_input;
+    bool m_is_persistent;
+    std::string m_name;
+    size_t m_next_view_id;
+    size_t m_size;
+    size_t m_pool_offset;
 };
 
 std::ostream& operator<<(std::ostream&, const ngraph::descriptor::Tensor&);

--- a/src/ngraph/descriptor/tensor_view.hpp
+++ b/src/ngraph/descriptor/tensor_view.hpp
@@ -49,7 +49,7 @@ namespace ngraph
         public:
             virtual ~TensorView() {}
             virtual const Tensor& get_tensor() const = 0;
-            virtual Tensor&       get_tensor()       = 0;
+            virtual Tensor& get_tensor() = 0;
 
             virtual std::shared_ptr<const ValueType> get_value_type() const override
             {
@@ -57,7 +57,6 @@ namespace ngraph
             }
 
             const std::string& get_name() const { return m_name; }
-
             std::shared_ptr<const TensorViewType> get_tensor_view_type() const
             {
                 return m_tensor_view_type;
@@ -81,9 +80,9 @@ namespace ngraph
             }
 
         protected:
-            std::shared_ptr<const TensorViewType>     m_tensor_view_type;
+            std::shared_ptr<const TensorViewType> m_tensor_view_type;
             std::shared_ptr<layout::TensorViewLayout> m_tensor_view_layout;
-            std::string                               m_name;
+            std::string m_name;
         };
 
         using TensorViewPtrs = std::vector<std::shared_ptr<TensorView>>;

--- a/src/ngraph/descriptor/tuple.cpp
+++ b/src/ngraph/descriptor/tuple.cpp
@@ -33,7 +33,7 @@ Tuple::Tuple(const std::vector<std::shared_ptr<ngraph::descriptor::Value>>& elem
 }
 
 void Tuple::collect_tensor_views(std::vector<std::shared_ptr<TensorView>>& views,
-                                 const std::shared_ptr<Value>&             value) const
+                                 const std::shared_ptr<Value>& value) const
 {
     for (auto element : m_elements)
     {

--- a/src/ngraph/descriptor/tuple.hpp
+++ b/src/ngraph/descriptor/tuple.hpp
@@ -31,7 +31,7 @@ namespace ngraph
             Tuple(const std::vector<std::shared_ptr<ngraph::descriptor::Value>>& elements);
 
             const std::shared_ptr<ngraph::TupleType> get_tuple_type() const;
-            std::shared_ptr<ngraph::TupleType>       get_tuple_type();
+            std::shared_ptr<ngraph::TupleType> get_tuple_type();
 
             virtual std::shared_ptr<const ValueType> get_value_type() const override
             {
@@ -42,7 +42,7 @@ namespace ngraph
                                               const std::shared_ptr<Value>& value) const override;
 
         protected:
-            std::shared_ptr<ngraph::TupleType>                      m_tuple_type;
+            std::shared_ptr<ngraph::TupleType> m_tuple_type;
             std::vector<std::shared_ptr<ngraph::descriptor::Value>> m_elements;
         };
     }

--- a/src/ngraph/descriptor/value.hpp
+++ b/src/ngraph/descriptor/value.hpp
@@ -29,7 +29,7 @@ namespace ngraph
         {
         public:
             virtual ~Value() {}
-            virtual std::shared_ptr<const ngraph::ValueType> get_value_type() const      = 0;
+            virtual std::shared_ptr<const ngraph::ValueType> get_value_type() const = 0;
 
             /// @brief helper for collecting all the tensor views in a sequence of values
             ///

--- a/src/ngraph/function.cpp
+++ b/src/ngraph/function.cpp
@@ -19,7 +19,7 @@
 using namespace std;
 using namespace ngraph;
 
-Function::Function(const std::shared_ptr<Node>&                       result,
+Function::Function(const std::shared_ptr<Node>& result,
                    const std::vector<std::shared_ptr<op::Parameter>>& parameters)
     : m_result(result)
     , m_parameters(parameters)

--- a/src/ngraph/function.hpp
+++ b/src/ngraph/function.hpp
@@ -16,8 +16,8 @@
 
 #include <initializer_list>
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "ngraph/descriptor/tensor_view.hpp"
 #include "ngraph/node.hpp"
@@ -32,18 +32,18 @@ namespace ngraph
     class Function
     {
     public:
-        Function(const std::shared_ptr<Node>&                       result,
+        Function(const std::shared_ptr<Node>& result,
                  const std::vector<std::shared_ptr<op::Parameter>>& parameters);
 
-        std::shared_ptr<Node>                             get_result() { return m_result; }
+        std::shared_ptr<Node> get_result() { return m_result; }
         const std::vector<std::shared_ptr<op::Parameter>> get_parameters() const
         {
             return m_parameters;
         }
         std::string get_name() const { return m_name; }
     protected:
-        std::shared_ptr<Node>                               m_result;
+        std::shared_ptr<Node> m_result;
         std::vector<std::shared_ptr<ngraph::op::Parameter>> m_parameters;
-        std::string                                         m_name;
+        std::string m_name;
     };
 }

--- a/src/ngraph/log.cpp
+++ b/src/ngraph/log.cpp
@@ -30,12 +30,12 @@ namespace nervana
     class thread_starter;
 }
 
-string                    nervana::logger::log_path;
-deque<string>             nervana::logger::queue;
-static mutex              queue_mutex;
+string nervana::logger::log_path;
+deque<string> nervana::logger::queue;
+static mutex queue_mutex;
 static condition_variable queue_condition;
 static unique_ptr<thread> queue_thread;
-static bool               active = false;
+static bool active = false;
 
 class nervana::thread_starter
 {
@@ -53,7 +53,7 @@ void nervana::logger::set_log_path(const string& path)
 
 void nervana::logger::start()
 {
-    active       = true;
+    active = true;
     queue_thread = unique_ptr<thread>(new thread(&thread_entry, nullptr));
 }
 
@@ -103,8 +103,8 @@ nervana::log_helper::log_helper(LOG_TYPE type, const char* file, int line, const
     }
 
     std::time_t tt = chrono::system_clock::to_time_t(chrono::system_clock::now());
-    auto        tm = std::gmtime(&tt);
-    char        buffer[256];
+    auto tm = std::gmtime(&tt);
+    char buffer[256];
     //    strftime(buffer,sizeof(buffer), "%d/%b/%Y:%H:%M:%S %z", tm);
     //    strftime(buffer,sizeof(buffer), "%Y-%m-%d %H:%M:%S UTC", tm);
     strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%Sz", tm);

--- a/src/ngraph/log.hpp
+++ b/src/ngraph/log.hpp
@@ -36,10 +36,10 @@ namespace nervana
             return i < _size ? _string[i] : throw std::out_of_range("");
         }
         constexpr const char* get_ptr(size_t offset) const { return &_string[offset]; }
-        constexpr size_t                     size() const { return _size; }
+        constexpr size_t size() const { return _size; }
     private:
         const char* _string;
-        size_t      _size;
+        size_t _size;
     };
 
     constexpr const char* find_last(conststring s, size_t offset, char ch)
@@ -84,23 +84,23 @@ namespace nervana
         static void log_item(const std::string& s);
         static void process_event(const std::string& s);
         static void thread_entry(void* param);
-        static std::string             log_path;
+        static std::string log_path;
         static std::deque<std::string> queue;
     };
 
-#define NGRAPH_ERR                                                                                     \
+#define NGRAPH_ERR                                                                                 \
     nervana::log_helper(nervana::LOG_TYPE::_LOG_TYPE_ERROR,                                        \
                         nervana::get_file_name(__FILE__),                                          \
                         __LINE__,                                                                  \
                         __PRETTY_FUNCTION__)                                                       \
         .stream()
-#define NGRAPH_WARN                                                                                    \
+#define NGRAPH_WARN                                                                                \
     nervana::log_helper(nervana::LOG_TYPE::_LOG_TYPE_WARNING,                                      \
                         nervana::get_file_name(__FILE__),                                          \
                         __LINE__,                                                                  \
                         __PRETTY_FUNCTION__)                                                       \
         .stream()
-#define NGRAPH_INFO                                                                                    \
+#define NGRAPH_INFO                                                                                \
     nervana::log_helper(nervana::LOG_TYPE::_LOG_TYPE_INFO,                                         \
                         nervana::get_file_name(__FILE__),                                          \
                         __LINE__,                                                                  \

--- a/src/ngraph/node.cpp
+++ b/src/ngraph/node.cpp
@@ -58,12 +58,16 @@ void Node::assign_tensors()
     size_t i = 0;
     for (auto tvt : tensor_view_types)
     {
-        auto tensor_view_descriptor = make_shared<descriptor::PrimaryTensorView>(tvt, ngraph::descriptor::Tensor::make_tensor_name(this, i), is_output(), is_parameter());
+        auto tensor_view_descriptor = make_shared<descriptor::PrimaryTensorView>(
+            tvt,
+            ngraph::descriptor::Tensor::make_tensor_name(this, i),
+            is_output(),
+            is_parameter());
         m_outputs.emplace_back(this, i, tensor_view_descriptor);
         i++;
     }
 
-    i            = 0;
+    i = 0;
     size_t argno = 0;
     for (auto arg : get_arguments())
     {

--- a/src/ngraph/node.hpp
+++ b/src/ngraph/node.hpp
@@ -64,10 +64,8 @@ namespace ngraph
         void assign_tensors();
 
         const Nodes& get_arguments() const { return m_arguments; }
-        void         clear_arguments() { m_arguments.clear(); }
-
+        void clear_arguments() { m_arguments.clear(); }
         const std::multiset<Node*>& users() const { return m_users; }
-
         virtual std::string get_node_id() const;
 
         /// Return true if this has the same implementing class as node. This
@@ -78,9 +76,8 @@ namespace ngraph
             return typeid(*this) == typeid(*node.get());
         }
 
-        std::shared_ptr<const ValueType>       get_value_type() { return m_value_type; }
+        std::shared_ptr<const ValueType> get_value_type() { return m_value_type; }
         const std::shared_ptr<const ValueType> get_value_type() const { return m_value_type; }
-
         void set_value_type(const element::Type& element_type, const Shape& shape)
         {
             m_value_type = std::make_shared<TensorViewType>(element_type, shape);
@@ -101,27 +98,26 @@ namespace ngraph
         bool is_output() const;
         void set_is_output();
 
-        size_t               get_instance_id() const { return m_instance_id; }
+        size_t get_instance_id() const { return m_instance_id; }
         friend std::ostream& operator<<(std::ostream&, const Node&);
 
-        std::vector<descriptor::Input>&        get_inputs() { return m_inputs; }
-        const std::vector<descriptor::Input>&  get_inputs() const { return m_inputs; }
-        std::vector<descriptor::Output>&       get_outputs() { return m_outputs; }
+        std::vector<descriptor::Input>& get_inputs() { return m_inputs; }
+        const std::vector<descriptor::Input>& get_inputs() const { return m_inputs; }
+        std::vector<descriptor::Output>& get_outputs() { return m_outputs; }
         const std::vector<descriptor::Output>& get_outputs() const { return m_outputs; }
-
         std::unordered_set<descriptor::Tensor*> liveness_live_list;
         std::unordered_set<descriptor::Tensor*> liveness_new_list;
         std::unordered_set<descriptor::Tensor*> liveness_free_list;
 
     protected:
-        Nodes                            m_arguments;
+        Nodes m_arguments;
         std::shared_ptr<const ValueType> m_value_type;
-        std::multiset<Node*>             m_users;
-        std::string                      m_name;
-        size_t                           m_instance_id;
-        static size_t                    m_next_instance_id;
-        std::vector<descriptor::Input>   m_inputs;
-        std::vector<descriptor::Output>  m_outputs;
-        bool                             m_is_output;
+        std::multiset<Node*> m_users;
+        std::string m_name;
+        size_t m_instance_id;
+        static size_t m_next_instance_id;
+        std::vector<descriptor::Input> m_inputs;
+        std::vector<descriptor::Output> m_outputs;
+        bool m_is_output;
     };
 }

--- a/src/ngraph/ops/binary_elementwise_arithmetic.cpp
+++ b/src/ngraph/ops/binary_elementwise_arithmetic.cpp
@@ -19,8 +19,7 @@ using namespace ngraph;
 using namespace ngraph::op;
 
 const element::Type& BinaryElementwiseArithmetic::propagate_element_types(
-                         const element::Type& arg0_element_type,
-                         const element::Type& arg1_element_type) const
+    const element::Type& arg0_element_type, const element::Type& arg1_element_type) const
 {
     if (arg0_element_type != arg1_element_type)
     {

--- a/src/ngraph/ops/binary_elementwise_builtin.cpp
+++ b/src/ngraph/ops/binary_elementwise_builtin.cpp
@@ -14,8 +14,8 @@
 
 #include <memory>
 
-#include "ngraph/ngraph.hpp"
 #include "ngraph/log.hpp"
+#include "ngraph/ngraph.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -41,11 +41,9 @@ void BinaryElementwiseBuiltin::propagate_types()
         throw ngraph_error("Arguments must have the same tensor view shape");
     }
 
-    const element::Type& result_element_type =
-        propagate_element_types(arg0_tensor_type->get_element_type(),
-                                arg1_tensor_type->get_element_type());
+    const element::Type& result_element_type = propagate_element_types(
+        arg0_tensor_type->get_element_type(), arg1_tensor_type->get_element_type());
 
-    set_value_type_checked(make_shared<TensorViewType>(result_element_type,
-                                                       arg0_tensor_type->get_shape()));
+    set_value_type_checked(
+        make_shared<TensorViewType>(result_element_type, arg0_tensor_type->get_shape()));
 }
-

--- a/src/ngraph/ops/binary_elementwise_comparison.cpp
+++ b/src/ngraph/ops/binary_elementwise_comparison.cpp
@@ -19,8 +19,7 @@ using namespace ngraph;
 using namespace ngraph::op;
 
 const element::Type& BinaryElementwiseComparison::propagate_element_types(
-                         const element::Type& arg0_element_type,
-                         const element::Type& arg1_element_type) const
+    const element::Type& arg0_element_type, const element::Type& arg1_element_type) const
 {
     if (arg0_element_type != arg1_element_type)
     {

--- a/src/ngraph/ops/broadcast.cpp
+++ b/src/ngraph/ops/broadcast.cpp
@@ -19,7 +19,8 @@ using namespace ngraph::op;
 
 void Broadcast::propagate_types()
 {
-    if (m_arguments.size() != 1){
+    if (m_arguments.size() != 1)
+    {
         throw ngraph_error("Wrong number of arguments.");
     }
 
@@ -42,5 +43,6 @@ void Broadcast::propagate_types()
     {
         throw ngraph_error("Broadcast arg, shape, and axes are incompatible");
     }
-    set_value_type_checked(make_shared<TensorViewType>(arg_tensor_view_type->get_element_type(), m_shape));
+    set_value_type_checked(
+        make_shared<TensorViewType>(arg_tensor_view_type->get_element_type(), m_shape));
 }

--- a/src/ngraph/ops/broadcast.hpp
+++ b/src/ngraph/ops/broadcast.hpp
@@ -28,8 +28,8 @@ namespace ngraph
             ///  the remaining axes in shape must be the same as the shape of arg.
             ///
             Broadcast(const std::shared_ptr<Node>& arg,
-                      const Shape&                 shape,
-                      const AxisSet&               broadcast_axes)
+                      const Shape& shape,
+                      const AxisSet& broadcast_axes)
                 : IndexBuiltin(arg)
                 , m_shape(shape)
                 , m_broadcast_axes(broadcast_axes)
@@ -37,10 +37,10 @@ namespace ngraph
             }
 
             virtual std::string description() const override { return "Broadcast"; }
-            virtual void        propagate_types() override;
+            virtual void propagate_types() override;
 
         protected:
-            Shape   m_shape;
+            Shape m_shape;
             AxisSet m_broadcast_axes;
         };
     }

--- a/src/ngraph/ops/concatenate.cpp
+++ b/src/ngraph/ops/concatenate.cpp
@@ -47,7 +47,7 @@ void Concat::propagate_types()
     size_t concatenation_axis_length = arg0_shape.at(m_concatenation_axis);
     auto& arg0_element_type = arg0_tensor_view_type->get_element_type();
 
-    for(auto i = 1; i < m_arguments.size(); i++)
+    for (auto i = 1; i < m_arguments.size(); i++)
     {
         auto argi_type = m_arguments.at(i)->get_value_type();
         if (nullptr == argi_type)
@@ -72,11 +72,12 @@ void Concat::propagate_types()
             throw ngraph_error("Argument element types do not match");
         }
 
-        for(auto j = 0; j < argi_shape.size(); j++)
+        for (auto j = 0; j < argi_shape.size(); j++)
         {
             if (j != m_concatenation_axis && arg0_shape.at(j) != argi_shape.at(j))
             {
-                throw ngraph_error("Arguments to concat do not have same dimension on a non-concatenation axis");
+                throw ngraph_error(
+                    "Arguments to concat do not have same dimension on a non-concatenation axis");
             }
             else if (j == m_concatenation_axis)
             {

--- a/src/ngraph/ops/concatenate.hpp
+++ b/src/ngraph/ops/concatenate.hpp
@@ -30,17 +30,16 @@ namespace ngraph
             ///
             /// Example: n0 has shape {2,4,2}, and n1 has shape {2,5,2}. Then the output of
             ///          Concat(Nodes{n0,n1},1) will have shape {2,9,2}.
-            Concat(const Nodes& args,size_t concatenation_axis)
+            Concat(const Nodes& args, size_t concatenation_axis)
                 : Builtin(args)
                 , m_concatenation_axis(concatenation_axis)
             {
             }
 
             virtual std::string description() const override { return "Concatenate"; }
-            virtual void        propagate_types() override;
+            virtual void propagate_types() override;
 
             size_t get_concatenation_axis() const { return m_concatenation_axis; }
-
         protected:
             const size_t m_concatenation_axis;
         };

--- a/src/ngraph/ops/constant.cpp
+++ b/src/ngraph/ops/constant.cpp
@@ -16,7 +16,10 @@
 
 using namespace ngraph::op;
 
-void ScalarConstantBase::propagate_types() {}
+void ScalarConstantBase::propagate_types()
+{
+}
 
-void TensorConstantBase::propagate_types() {}
-
+void TensorConstantBase::propagate_types()
+{
+}

--- a/src/ngraph/ops/constant.hpp
+++ b/src/ngraph/ops/constant.hpp
@@ -16,8 +16,8 @@
 
 #include <sstream>
 
-#include "ngraph/types/element_type.hpp"
 #include "ngraph/runtime/utils.hpp"
+#include "ngraph/types/element_type.hpp"
 
 namespace ngraph
 {
@@ -60,22 +60,18 @@ namespace ngraph
                 return ss.str();
             }
 
-            type get_value() const
-            {
-                return m_value;
-            }
-
+            type get_value() const { return m_value; }
         protected:
             typename T::type m_value;
         };
 
         using Float32ScalarConstant = ScalarConstant<element::Float32>;
-        using Int8ScalarConstant    = ScalarConstant<element::Int8>;
-        using Int32ScalarConstant   = ScalarConstant<element::Int32>;
-        using Int64ScalarConstant   = ScalarConstant<element::Int64>;
-        using UInt8ScalarConstant   = ScalarConstant<element::UInt8>;
-        using UInt32ScalarConstant  = ScalarConstant<element::UInt32>;
-        using UInt64ScalarConstant  = ScalarConstant<element::UInt64>;
+        using Int8ScalarConstant = ScalarConstant<element::Int8>;
+        using Int32ScalarConstant = ScalarConstant<element::Int32>;
+        using Int64ScalarConstant = ScalarConstant<element::Int64>;
+        using UInt8ScalarConstant = ScalarConstant<element::UInt8>;
+        using UInt32ScalarConstant = ScalarConstant<element::UInt32>;
+        using UInt64ScalarConstant = ScalarConstant<element::UInt64>;
 
         // Defines methods to all constant tensors
         class TensorConstantBase : public Node
@@ -113,18 +109,21 @@ namespace ngraph
                 return ss.str();
             }
 
-            typename std::shared_ptr<ngraph::runtime::ParameterizedTensorView<T>> get_value() const { return m_value; }
+            typename std::shared_ptr<ngraph::runtime::ParameterizedTensorView<T>> get_value() const
+            {
+                return m_value;
+            }
 
         protected:
             std::shared_ptr<ngraph::runtime::ParameterizedTensorView<T>> m_value;
         };
 
         using Float32TensorConstant = TensorConstant<element::Float32>;
-        using Int8TensorConstant    = TensorConstant<element::Int8>;
-        using Int32TensorConstant   = TensorConstant<element::Int32>;
-        using Int64TensorConstant   = TensorConstant<element::Int64>;
-        using UInt8TensorConstant   = TensorConstant<element::UInt8>;
-        using UInt32TensorConstant  = TensorConstant<element::UInt32>;
-        using UInt64TensorConstant  = TensorConstant<element::UInt64>;
+        using Int8TensorConstant = TensorConstant<element::Int8>;
+        using Int32TensorConstant = TensorConstant<element::Int32>;
+        using Int64TensorConstant = TensorConstant<element::Int64>;
+        using UInt8TensorConstant = TensorConstant<element::UInt8>;
+        using UInt32TensorConstant = TensorConstant<element::UInt32>;
+        using UInt64TensorConstant = TensorConstant<element::UInt64>;
     }
 }

--- a/src/ngraph/ops/convert.hpp
+++ b/src/ngraph/ops/convert.hpp
@@ -28,7 +28,7 @@ namespace ngraph
             }
 
             virtual std::string description() const override { return "Convert"; }
-            virtual void        propagate_types() override;
+            virtual void propagate_types() override;
 
         protected:
             const ngraph::element::Type& m_element_type;

--- a/src/ngraph/ops/dot.cpp
+++ b/src/ngraph/ops/dot.cpp
@@ -34,11 +34,11 @@ void Dot::propagate_types()
         throw ngraph_error("Arguments to dot must have the same element type");
     }
 
-    vector<size_t> arg0_shape     = arg0_tensor_type->get_shape();
-    vector<size_t> arg1_shape     = arg1_tensor_type->get_shape();
-    size_t         arg0_reduction = arg0_shape.size() - 1;
-    size_t         arg1_reduction;
-    const bool     is_scalar_mult = arg0_shape.size() == 0 || arg1_shape.size() == 0;
+    vector<size_t> arg0_shape = arg0_tensor_type->get_shape();
+    vector<size_t> arg1_shape = arg1_tensor_type->get_shape();
+    size_t arg0_reduction = arg0_shape.size() - 1;
+    size_t arg1_reduction;
+    const bool is_scalar_mult = arg0_shape.size() == 0 || arg1_shape.size() == 0;
 
     if (arg1_shape.size() > 1)
     {
@@ -56,22 +56,23 @@ void Dot::propagate_types()
     vector<size_t> result_shape;
     result_shape.reserve(arg0_shape.size() + arg1_shape.size() - (is_scalar_mult ? 0 : 2));
 
-    for(auto i = 0; i < arg0_shape.size(); i++)
+    for (auto i = 0; i < arg0_shape.size(); i++)
     {
-        if(is_scalar_mult || i != arg0_reduction)
+        if (is_scalar_mult || i != arg0_reduction)
         {
             result_shape.push_back(arg0_shape[i]);
         }
     }
 
-    for(auto i = 0; i < arg1_shape.size(); i++)
+    for (auto i = 0; i < arg1_shape.size(); i++)
     {
-        if(is_scalar_mult || i != arg1_reduction)
+        if (is_scalar_mult || i != arg1_reduction)
         {
             result_shape.push_back(arg1_shape[i]);
         }
     }
 
-    auto result_type = make_shared<TensorViewType>(arg0_tensor_type->get_element_type(), result_shape);
+    auto result_type =
+        make_shared<TensorViewType>(arg0_tensor_type->get_element_type(), result_shape);
     set_value_type_checked(result_type);
 }

--- a/src/ngraph/ops/dot.hpp
+++ b/src/ngraph/ops/dot.hpp
@@ -46,7 +46,7 @@ namespace ngraph
             }
 
             virtual std::string description() const override { return "Dot"; }
-            virtual void        propagate_types() override;
+            virtual void propagate_types() override;
         };
     }
 }

--- a/src/ngraph/ops/get_tuple_element.cpp
+++ b/src/ngraph/ops/get_tuple_element.cpp
@@ -33,7 +33,8 @@ void GetTupleElement::propagate_types()
         throw ngraph_error("Argument must be a tuple view");
     }
 
-    if (m_n >= arg0_tuple_type->get_element_types().size()){
+    if (m_n >= arg0_tuple_type->get_element_types().size())
+    {
         throw ngraph_error("Indexing tuple beyond its size");
     }
 

--- a/src/ngraph/ops/get_tuple_element.hpp
+++ b/src/ngraph/ops/get_tuple_element.hpp
@@ -31,11 +31,9 @@ namespace ngraph
             {
             }
 
-            virtual void        propagate_types() override;
+            virtual void propagate_types() override;
             virtual std::string description() const override { return "GetTupleElement"; }
-
             size_t get_n() const { return m_n; }
-
         protected:
             size_t m_n;
         };

--- a/src/ngraph/ops/op.hpp
+++ b/src/ngraph/ops/op.hpp
@@ -30,7 +30,6 @@ namespace ngraph
         class FunctionCall : public Node
         {
             virtual std::string description() const override { return "FunctionCall"; }
-
         protected:
             std::shared_ptr<Node> m_function;
         };
@@ -41,7 +40,6 @@ namespace ngraph
         {
         public:
             virtual std::string description() const override { return "Builtin"; }
-
         protected:
             Builtin(const std::vector<std::shared_ptr<Node>>& args)
                 : Node(args)
@@ -83,8 +81,8 @@ namespace ngraph
                 : Builtin(Nodes{arg})
             {
             }
-            virtual const element::Type& propagate_element_types(
-                const element::Type& arg_element_type) const = 0;
+            virtual const element::Type&
+                propagate_element_types(const element::Type& arg_element_type) const = 0;
 
         public:
             virtual void propagate_types() override;
@@ -97,8 +95,8 @@ namespace ngraph
                 : UnaryElementwiseBuiltin({arg})
             {
             }
-            virtual const element::Type& propagate_element_types(
-                const element::Type& arg_element_type) const final override;
+            virtual const element::Type&
+                propagate_element_types(const element::Type& arg_element_type) const final override;
         };
 
         /// Op(X, Y)[I] = op(X[I], Y[I])
@@ -110,9 +108,9 @@ namespace ngraph
                 : Builtin(Nodes{arg0, arg1})
             {
             }
-            virtual const element::Type& propagate_element_types(
-                                            const element::Type& arg0_element_type,
-                                            const element::Type& arg1_element_type) const = 0;
+            virtual const element::Type&
+                propagate_element_types(const element::Type& arg0_element_type,
+                                        const element::Type& arg1_element_type) const = 0;
 
         public:
             virtual void propagate_types() override;
@@ -121,34 +119,39 @@ namespace ngraph
         class BinaryElementwiseComparison : public BinaryElementwiseBuiltin
         {
         public:
-            BinaryElementwiseComparison(
-                const std::shared_ptr<Node>& arg0, const std::shared_ptr<Node>& arg1)
+            BinaryElementwiseComparison(const std::shared_ptr<Node>& arg0,
+                                        const std::shared_ptr<Node>& arg1)
                 : BinaryElementwiseBuiltin(arg0, arg1)
             {
             }
 
-            virtual std::string description() const override { return "BinaryElementwiseComparison"; }
+            virtual std::string description() const override
+            {
+                return "BinaryElementwiseComparison";
+            }
             //virtual void propagate_types() override;
-            virtual const element::Type& propagate_element_types(
-                                             const element::Type& arg0_element_type,
-                                             const element::Type& arg1_element_type) const override;
+            virtual const element::Type&
+                propagate_element_types(const element::Type& arg0_element_type,
+                                        const element::Type& arg1_element_type) const override;
         };
 
         class BinaryElementwiseArithmetic : public BinaryElementwiseBuiltin
         {
         public:
-            BinaryElementwiseArithmetic(
-                const std::shared_ptr<Node>& arg0, const std::shared_ptr<Node>& arg1)
+            BinaryElementwiseArithmetic(const std::shared_ptr<Node>& arg0,
+                                        const std::shared_ptr<Node>& arg1)
                 : BinaryElementwiseBuiltin(arg0, arg1)
             {
             }
 
-            virtual std::string description() const override { return "BinaryElementwiseArithmetic"; }
+            virtual std::string description() const override
+            {
+                return "BinaryElementwiseArithmetic";
+            }
             //virtual void propagate_types() override;
             virtual const element::Type& propagate_element_types(
-                                           const element::Type& arg0_element_type,
-                                           const element::Type& arg1_element_type)
-                const final override;
+                const element::Type& arg0_element_type,
+                const element::Type& arg1_element_type) const final override;
         };
     }
 }

--- a/src/ngraph/ops/parameter.cpp
+++ b/src/ngraph/ops/parameter.cpp
@@ -38,7 +38,9 @@ void Parameter::assign_function(Function* function, size_t index)
         throw ngraph_error("Re-assigning function to a parameter.");
     }
     m_function = function;
-    m_index    = index;
+    m_index = index;
 }
 
-void Parameter::propagate_types() {}
+void Parameter::propagate_types()
+{
+}

--- a/src/ngraph/ops/parameter.hpp
+++ b/src/ngraph/ops/parameter.hpp
@@ -37,15 +37,15 @@ namespace ngraph
             void assign_function(Function* function, size_t index);
 
         public:
-            Parameter(const std::shared_ptr<ValueType>& value_type=nullptr);
+            Parameter(const std::shared_ptr<ValueType>& value_type = nullptr);
             Parameter(const ngraph::element::Type& element_type, const Shape& shape);
 
-            std::string         description() const override { return "Parameter"; }
-            virtual void        propagate_types() override;
+            std::string description() const override { return "Parameter"; }
+            virtual void propagate_types() override;
 
         protected:
             Function* m_function;
-            size_t    m_index;
+            size_t m_index;
         };
     }
 }

--- a/src/ngraph/ops/select.cpp
+++ b/src/ngraph/ops/select.cpp
@@ -14,8 +14,8 @@
 
 #include <memory>
 
-#include "ngraph/ngraph.hpp"
 #include "ngraph/log.hpp"
+#include "ngraph/ngraph.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -42,8 +42,8 @@ void Select::propagate_types()
     {
         throw ngraph_error("Argument 0 for arithmetic operators must have boolean element type");
     }
-    if (arg0_tensor_type->get_shape() != arg1_tensor_type->get_shape()
-     || arg0_tensor_type->get_shape() != arg2_tensor_type->get_shape())
+    if (arg0_tensor_type->get_shape() != arg1_tensor_type->get_shape() ||
+        arg0_tensor_type->get_shape() != arg2_tensor_type->get_shape())
     {
         throw ngraph_error("Arguments must have the same tensor view shape");
     }
@@ -54,4 +54,3 @@ void Select::propagate_types()
 
     set_value_type_checked(arg1_tensor_type);
 }
-

--- a/src/ngraph/ops/select.hpp
+++ b/src/ngraph/ops/select.hpp
@@ -24,7 +24,7 @@ namespace ngraph
             Select(const std::shared_ptr<Node>& arg0,
                    const std::shared_ptr<Node>& arg1,
                    const std::shared_ptr<Node>& arg2)
-	      : Builtin(Nodes{arg0, arg1, arg2})
+                : Builtin(Nodes{arg0, arg1, arg2})
             {
             }
             virtual std::string description() const override { return "Select"; }

--- a/src/ngraph/ops/tuple.hpp
+++ b/src/ngraph/ops/tuple.hpp
@@ -27,7 +27,7 @@ namespace ngraph
             }
 
             virtual std::string description() const override { return "Tuple"; }
-            virtual void        propagate_types() override;
+            virtual void propagate_types() override;
         };
     }
 }

--- a/src/ngraph/ops/unary_elementwise_arithmetic.cpp
+++ b/src/ngraph/ops/unary_elementwise_arithmetic.cpp
@@ -20,8 +20,8 @@ using namespace std;
 using namespace ngraph;
 using namespace ngraph::op;
 
-const element::Type& UnaryElementwiseArithmetic::propagate_element_types(
-                         const element::Type& arg_element_type) const
+const element::Type&
+    UnaryElementwiseArithmetic::propagate_element_types(const element::Type& arg_element_type) const
 {
     if (arg_element_type == element::Bool::element_type())
     {

--- a/src/ngraph/ops/unary_elementwise_builtin.cpp
+++ b/src/ngraph/ops/unary_elementwise_builtin.cpp
@@ -37,6 +37,6 @@ void UnaryElementwiseBuiltin::propagate_types()
     const element::Type& result_element_type =
         propagate_element_types(arg_tensor_type->get_element_type());
 
-    set_value_type_checked(make_shared<TensorViewType>(result_element_type,
-                                                       arg_tensor_type->get_shape()));
+    set_value_type_checked(
+        make_shared<TensorViewType>(result_element_type, arg_tensor_type->get_shape()));
 }

--- a/src/ngraph/pass/assign_tensors.cpp
+++ b/src/ngraph/pass/assign_tensors.cpp
@@ -19,8 +19,8 @@
 
 #include "ngraph/log.hpp"
 #include "ngraph/ngraph.hpp"
-#include "ngraph/pass/propagate_types.hpp"
 #include "ngraph/pass/manager.hpp"
+#include "ngraph/pass/propagate_types.hpp"
 
 using namespace std;
 using namespace ngraph;

--- a/src/ngraph/pass/dump_sorted.cpp
+++ b/src/ngraph/pass/dump_sorted.cpp
@@ -14,8 +14,8 @@
 
 #include <fstream>
 
-#include "ngraph/pass/dump_sorted.hpp"
 #include "ngraph/ngraph.hpp"
+#include "ngraph/pass/dump_sorted.hpp"
 #include "ngraph/util.hpp"
 
 using namespace std;
@@ -50,7 +50,6 @@ bool pass::DumpSorted::run_on_call_list(list<Node*>& nodes)
             }
             out << join(outputs);
             out << "\n";
-
 
             for (const Tensor* tensor : node->liveness_live_list)
             {

--- a/src/ngraph/pass/dump_sorted.hpp
+++ b/src/ngraph/pass/dump_sorted.hpp
@@ -35,5 +35,5 @@ public:
     virtual bool run_on_call_list(std::list<Node*>&) override;
 
 private:
-    const std::string   m_output_file;
+    const std::string m_output_file;
 };

--- a/src/ngraph/pass/liveness.cpp
+++ b/src/ngraph/pass/liveness.cpp
@@ -21,7 +21,6 @@
 #include "ngraph/pass/assign_tensors.hpp"
 #include "ngraph/pass/liveness.hpp"
 #include "ngraph/util.hpp"
-#include "ngraph/log.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -31,7 +30,7 @@ bool pass::Liveness::run_on_call_list(list<Node*>& ops)
 {
     unordered_set<Tensor*> currently_live;
 
-    for(auto it=ops.rbegin(); it!=ops.rend(); it++)
+    for (auto it = ops.rbegin(); it != ops.rend(); it++)
     {
         Node* node = *it;
         node->liveness_live_list.clear();
@@ -143,13 +142,10 @@ void pass::Liveness::check_dependencies(
 
 bool pass::Liveness::is_temporary(const Tensor& tensor)
 {
-    return
-        tensor.is_persistent() == false
-        && tensor.is_input() == false
-        && tensor.is_output() == false
-        ;
-        // && tensor.is_constant() == false
-        // && tensor.is_compile_only() == false;
+    return tensor.is_persistent() == false && tensor.is_input() == false &&
+           tensor.is_output() == false;
+    // && tensor.is_constant() == false
+    // && tensor.is_compile_only() == false;
 }
 
 void pass::Liveness::validate_liveness(const list<Node*>& ops)
@@ -170,4 +166,3 @@ void pass::Liveness::validate_liveness(const list<Node*>& ops)
         dead_tensors.insert(node->liveness_free_list.begin(), node->liveness_free_list.end());
     }
 }
-

--- a/src/ngraph/pass/liveness.hpp
+++ b/src/ngraph/pass/liveness.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include "ngraph/pass/call_pass.hpp"
 #include "ngraph/descriptor/tensor.hpp"
+#include "ngraph/pass/call_pass.hpp"
 
 namespace ngraph
 {

--- a/src/ngraph/pass/manager.cpp
+++ b/src/ngraph/pass/manager.cpp
@@ -15,10 +15,10 @@
 #include <iostream>
 #include <memory>
 
-#include "ngraph/log.hpp"
-#include "ngraph/pass/manager.hpp"
-#include "ngraph/node.hpp"
 #include "ngraph/function.hpp"
+#include "ngraph/log.hpp"
+#include "ngraph/node.hpp"
+#include "ngraph/pass/manager.hpp"
 
 using namespace std;
 using namespace ngraph;

--- a/src/ngraph/pass/manager.hpp
+++ b/src/ngraph/pass/manager.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <vector>
-#include <memory>
 #include <list>
+#include <memory>
+#include <vector>
 
 #include "ngraph/pass/call_pass.hpp"
 #include "ngraph/pass/tree_pass.hpp"
@@ -37,17 +37,17 @@ class ngraph::pass::ManagerState
 {
 public:
     Function* get_function();
-    void      set_function(Function*);
+    void set_function(Function*);
 
     size_t get_temporary_pool_size();
-    void   set_temporary_pool_size(size_t);
+    void set_temporary_pool_size(size_t);
 
     std::list<Node*>& get_call_graph();
     const std::list<Node*>& get_call_graph() const;
 
 private:
-    Function*        m_function = nullptr;
-    size_t           m_temporary_pool_size = 0;
+    Function* m_function = nullptr;
+    size_t m_temporary_pool_size = 0;
     std::list<Node*> m_call_graph;
 };
 
@@ -59,7 +59,7 @@ public:
 
     void initialize_default_passes();
 
-    template<typename T, class... Args>
+    template <typename T, class... Args>
     void register_pass(Args... args)
     {
         static_assert(std::is_base_of<pass::Base, T>::value, "pass not derived from pass base");
@@ -86,5 +86,5 @@ private:
 
     std::vector<std::shared_ptr<TreeBase>> m_tree_passes;
     std::vector<std::shared_ptr<CallBase>> m_call_passes;
-    ManagerState                           m_state;
+    ManagerState m_state;
 };

--- a/src/ngraph/pass/memory_layout.cpp
+++ b/src/ngraph/pass/memory_layout.cpp
@@ -16,11 +16,11 @@
 #include <sstream>
 
 #include "ngraph/log.hpp"
+#include "ngraph/log.hpp"
 #include "ngraph/ngraph.hpp"
 #include "ngraph/pass/liveness.hpp"
 #include "ngraph/pass/manager.hpp"
 #include "ngraph/pass/memory_layout.hpp"
-#include "ngraph/log.hpp"
 #include "ngraph/util.hpp"
 
 using namespace std;
@@ -69,7 +69,6 @@ pass::MemoryManager::node::node(size_t size, block_state state)
     : m_size{size}
     , m_state{state}
 {
-
 }
 
 pass::MemoryManager::MemoryManager(size_t alignment)
@@ -84,14 +83,10 @@ pass::MemoryManager::MemoryManager(size_t alignment)
 size_t pass::MemoryManager::allocate(size_t size)
 {
     size_t rc;
-    switch(m_scheme)
+    switch (m_scheme)
     {
-    case allocation_scheme::FIRST_FIT:
-        rc = first_fit(size);
-        break;
-    case allocation_scheme::BEST_FIT:
-        rc = best_fit(size);
-        break;
+    case allocation_scheme::FIRST_FIT: rc = first_fit(size); break;
+    case allocation_scheme::BEST_FIT: rc = best_fit(size); break;
     }
     return rc;
 }
@@ -103,7 +98,7 @@ size_t pass::MemoryManager::best_fit(size_t size)
     size_t min_delta = numeric_limits<size_t>::max();
     auto best_fit = m_node_list.end();
     size_t best_offset = offset;
-    for (auto it=m_node_list.begin(); it != m_node_list.end(); ++it)
+    for (auto it = m_node_list.begin(); it != m_node_list.end(); ++it)
     {
         if (it->m_state == block_state::FREE && it->m_size >= size)
         {
@@ -143,7 +138,7 @@ size_t pass::MemoryManager::first_fit(size_t size)
     size = align(size, m_alignment);
     size_t offset = 0;
     bool found = false;
-    for (auto it=m_node_list.begin(); it != m_node_list.end(); ++it)
+    for (auto it = m_node_list.begin(); it != m_node_list.end(); ++it)
     {
         if (it->m_state == block_state::FREE && it->m_size >= size)
         {
@@ -176,7 +171,7 @@ void pass::MemoryManager::free(size_t offset)
 {
     size_t search_offset = 0;
     bool found = false;
-    for (auto it=m_node_list.begin(); it != m_node_list.end(); ++it)
+    for (auto it = m_node_list.begin(); it != m_node_list.end(); ++it)
     {
         if (offset == search_offset)
         {

--- a/src/ngraph/pass/memory_layout.hpp
+++ b/src/ngraph/pass/memory_layout.hpp
@@ -62,12 +62,11 @@ public:
         node(size_t size, block_state state);
 
         bool is_free() const { return m_state == block_state::FREE; }
-
-        size_t          m_size;
-        block_state     m_state;
+        size_t m_size;
+        block_state m_state;
     };
 
-    MemoryManager(size_t alignment=1);
+    MemoryManager(size_t alignment = 1);
     // memory_manager& alignment(size_t a);
 
     size_t allocate(size_t size);
@@ -81,17 +80,14 @@ public:
     std::list<node>::iterator end() { return m_node_list.end(); }
     std::list<node>::const_iterator begin() const { return m_node_list.cbegin(); }
     std::list<node>::const_iterator end() const { return m_node_list.cend(); }
-
     const std::list<node>& get_node_list() const { return m_node_list; }
-
     size_t max_allocated() const { return m_max_allocated; }
-
 private:
     size_t first_fit(size_t size);
     size_t best_fit(size_t size);
 
-    std::list<node>     m_node_list;
-    size_t              m_alignment;
-    allocation_scheme   m_scheme;
-    size_t              m_max_allocated;
+    std::list<node> m_node_list;
+    size_t m_alignment;
+    allocation_scheme m_scheme;
+    size_t m_max_allocated;
 };

--- a/src/ngraph/pass/memory_visualize.cpp
+++ b/src/ngraph/pass/memory_visualize.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // ----------------------------------------------------------------------------
 
-#include <fstream>
-#include <unordered_set>
-#include <unordered_map>
 #include <algorithm>
+#include <fstream>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "memory_visualize.hpp"
 #include "ngraph/descriptor/tensor.hpp"
@@ -154,8 +154,7 @@ void pass::MemoryVisualize::draw_tensor_weight(ostream& file, const list<Node*>&
             }
             i++;
         }
-        sort(tensor_set.begin(), tensor_set.end(), [](const Tensor* t1, const Tensor* t2)
-        {
+        sort(tensor_set.begin(), tensor_set.end(), [](const Tensor* t1, const Tensor* t2) {
             return t1->size() < t2->size();
         });
         for (const Tensor* tensor : tensor_set)
@@ -206,12 +205,16 @@ void pass::MemoryVisualize::draw_histogram(ostream& file, const list<Node*>& nod
         y += line_spacing;
         size_t x1 = offset;
         size_t x2 = ((usage / memory_footprint) * scale) + offset;
-        file << "<text x=\"" << 0 << "\" y=\"" << y + text_offset << "\" fill=\"" << "black" << "\">" << node->get_node_id() << "</text>\n";
-        file << "<line x1=\"" << x1 << "\" y1=\"" << y << "\" x2=\"" << x2 << "\" y2=\"" << y << "\"";
+        file << "<text x=\"" << 0 << "\" y=\"" << y + text_offset << "\" fill=\""
+             << "black"
+             << "\">" << node->get_node_id() << "</text>\n";
+        file << "<line x1=\"" << x1 << "\" y1=\"" << y << "\" x2=\"" << x2 << "\" y2=\"" << y
+             << "\"";
         file << " style=\"stroke:forestgreen;stroke-width:" << stroke_width << "\" />\n";
         x1 = x2;
         x2 = ((footprint / memory_footprint) * scale) + offset;
-        file << "<line x1=\"" << x1 << "\" y1=\"" << y << "\" x2=\"" << x2 << "\" y2=\"" << y << "\"";
+        file << "<line x1=\"" << x1 << "\" y1=\"" << y << "\" x2=\"" << x2 << "\" y2=\"" << y
+             << "\"";
         file << " style=\"stroke:firebrick;stroke-width:" << stroke_width << "\" />\n";
     }
     file << "</svg>\n";

--- a/src/ngraph/pass/memory_visualize.hpp
+++ b/src/ngraph/pass/memory_visualize.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
+#include <iostream>
 #include <limits>
 #include <list>
-#include <iostream>
 
 #include "ngraph/pass/call_pass.hpp"
 
@@ -47,6 +47,6 @@ private:
     static size_t memory_usage(const Node*);
     static size_t memory_footprint(const Node*);
     static size_t memory_footprint(const std::list<Node*>&);
-    
+
     const std::string m_filename;
 };

--- a/src/ngraph/pass/pass.hpp
+++ b/src/ngraph/pass/pass.hpp
@@ -27,6 +27,7 @@ namespace ngraph
 class ngraph::pass::Base
 {
     friend class Manager;
+
 public:
 protected:
     ManagerState& get_state();

--- a/src/ngraph/pass/visualize_tree.cpp
+++ b/src/ngraph/pass/visualize_tree.cpp
@@ -14,8 +14,8 @@
 
 #include <fstream>
 
-#include "ngraph/pass/visualize_tree.hpp"
 #include "ngraph/node.hpp"
+#include "ngraph/pass/visualize_tree.hpp"
 #include "ngraph/util.hpp"
 
 using namespace ngraph;
@@ -24,8 +24,7 @@ using namespace std;
 bool pass::VisualizeTree::run_on_tree(std::shared_ptr<Node> base_node)
 {
     // map<size_t, list<node_ptr>> dependent_nodes;
-    traverse_nodes(base_node, [&](Node* node)
-    {
+    traverse_nodes(base_node, [&](Node* node) {
         for (auto arg : node->get_arguments())
         {
             m_ss << add_attributes(arg.get());
@@ -73,7 +72,7 @@ std::string pass::VisualizeTree::get_attributes(const Node* node)
 void pass::VisualizeTree::render() const
 {
 #if GRAPHVIZ_FOUND
-    auto     tmp_file = m_name + ".tmp";
+    auto tmp_file = m_name + ".tmp";
     ofstream out(tmp_file);
     if (out)
     {
@@ -84,7 +83,7 @@ void pass::VisualizeTree::render() const
 
         stringstream ss;
         ss << "dot -Tpng " << tmp_file << " -o " << m_name;
-        auto cmd    = ss.str();
+        auto cmd = ss.str();
         auto stream = popen(cmd.c_str(), "r");
         pclose(stream);
 

--- a/src/ngraph/pass/visualize_tree.hpp
+++ b/src/ngraph/pass/visualize_tree.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
+#include <set>
 #include <sstream>
 #include <string>
-#include <set>
 
 #include "ngraph/pass/tree_pass.hpp"
 
@@ -40,7 +40,7 @@ private:
     std::string get_attributes(const Node* node);
     void render() const;
 
-    std::stringstream     m_ss;
-    std::string           m_name;
+    std::stringstream m_ss;
+    std::string m_name;
     std::set<const Node*> m_nodes_with_attributes;
 };

--- a/src/ngraph/runtime/call_frame.cpp
+++ b/src/ngraph/runtime/call_frame.cpp
@@ -20,10 +20,10 @@ using namespace std;
 using namespace ngraph;
 using namespace ngraph::runtime;
 
-CallFrame::CallFrame(size_t                                             n_inputs,
-                     size_t                                             n_outputs,
-                     const TensorViewPtrs&                              temps,
-                     size_t                                             initial_pc,
+CallFrame::CallFrame(size_t n_inputs,
+                     size_t n_outputs,
+                     const TensorViewPtrs& temps,
+                     size_t initial_pc,
                      const shared_ptr<vector<shared_ptr<Instruction>>>& instructions)
 
     : m_n_inputs(n_inputs)
@@ -42,10 +42,10 @@ void CallFrame::tensor_call(
     copy(inputs.begin(), inputs.end(), m_tensor_views.begin());
     copy(outputs.begin(), outputs.end(), m_tensor_views.begin() + m_n_inputs);
     m_next_pc = m_initial_pc;
-    m_return  = false;
+    m_return = false;
     while (!m_return)
     {
-        m_pc      = m_next_pc;
+        m_pc = m_next_pc;
         m_next_pc = m_pc + 1;
         m_instructions->at(m_pc)->execute(*this);
     }

--- a/src/ngraph/runtime/call_frame.hpp
+++ b/src/ngraph/runtime/call_frame.hpp
@@ -32,10 +32,10 @@ namespace ngraph
         {
         public:
             CallFrame(
-                size_t                                                            n_inputs,
-                size_t                                                            n_outputs,
-                const TensorViewPtrs&                                             temps,
-                size_t                                                            initial_pc,
+                size_t n_inputs,
+                size_t n_outputs,
+                const TensorViewPtrs& temps,
+                size_t initial_pc,
                 const std::shared_ptr<std::vector<std::shared_ptr<Instruction>>>& instructions);
 
             /// @brief Invoke the function with values matching the signature of the function.
@@ -48,9 +48,7 @@ namespace ngraph
             void tensor_call(const TensorViewPtrs& inputs, const TensorViewPtrs& outpus);
 
             void set_return() { m_return = true; }
-
             std::shared_ptr<TensorView> get_tensor_view(size_t i) { return m_tensor_views[i]; }
-
             template <typename ET>
             ParameterizedTensorView<ET>* get_parameterized_tensor_view(size_t i)
             {
@@ -58,14 +56,14 @@ namespace ngraph
             }
 
         protected:
-            size_t                                                     m_n_inputs;
-            size_t                                                     m_n_outputs;
-            TensorViewPtrs                                             m_tensor_views;
-            size_t                                                     m_initial_pc;
+            size_t m_n_inputs;
+            size_t m_n_outputs;
+            TensorViewPtrs m_tensor_views;
+            size_t m_initial_pc;
             std::shared_ptr<std::vector<std::shared_ptr<Instruction>>> m_instructions;
-            size_t                                                     m_pc;
-            size_t                                                     m_next_pc;
-            bool                                                       m_return;
+            size_t m_pc;
+            size_t m_next_pc;
+            bool m_return;
         };
     }
 }

--- a/src/ngraph/runtime/eigen/abs.hpp
+++ b/src/ngraph/runtime/eigen/abs.hpp
@@ -43,9 +43,8 @@ namespace ngraph
 
                 virtual void execute(CallFrame& call_frame) const override
                 {
-                    runtime::eigen::abs(
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg),
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                    runtime::eigen::abs(call_frame.get_parameterized_tensor_view<ET>(m_arg),
+                                        call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/add.hpp
+++ b/src/ngraph/runtime/eigen/add.hpp
@@ -44,10 +44,9 @@ namespace ngraph
 
                 virtual void execute(CallFrame& call_frame) const override
                 {
-                    runtime::eigen::add(
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg0),
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg1),
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                    runtime::eigen::add(call_frame.get_parameterized_tensor_view<ET>(m_arg0),
+                                        call_frame.get_parameterized_tensor_view<ET>(m_arg1),
+                                        call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/concat_matrix.hpp
+++ b/src/ngraph/runtime/eigen/concat_matrix.hpp
@@ -33,28 +33,26 @@ namespace ngraph
                 auto mat_out = get_map_matrix_2d(&*out);
                 auto& out_shape = out->get_shape();
 
-                assert (out_shape.size() == 2);
-                assert (axis == 0 || axis == 1);
+                assert(out_shape.size() == 2);
+                assert(axis == 0 || axis == 1);
 
                 size_t concat_pos = 0;
 
-                for(T arg : args)
+                for (T arg : args)
                 {
                     auto mat_arg = get_map_matrix_2d(&*arg);
                     auto& arg_shape = arg->get_shape();
 
-                    assert (arg_shape.size() == 2);
+                    assert(arg_shape.size() == 2);
 
                     if (axis == 0)
                     {
-                        mat_out.block(concat_pos,0,arg_shape.at(0),arg_shape.at(1))
-                          << mat_arg;
+                        mat_out.block(concat_pos, 0, arg_shape.at(0), arg_shape.at(1)) << mat_arg;
                         concat_pos += arg_shape.at(0);
                     }
                     else
                     {
-                        mat_out.block(0,concat_pos,arg_shape.at(0),arg_shape.at(1))
-                          << mat_arg;
+                        mat_out.block(0, concat_pos, arg_shape.at(0), arg_shape.at(1)) << mat_arg;
                         concat_pos += arg_shape.at(1);
                     }
                 }
@@ -74,14 +72,12 @@ namespace ngraph
                 virtual void execute(CallFrame& call_frame) const override
                 {
                     std::vector<ParameterizedTensorView<ET>*> ptvs;
-                    for(size_t arg : m_args)
+                    for (size_t arg : m_args)
                     {
                         ptvs.push_back(call_frame.get_parameterized_tensor_view<ET>(arg));
                     }
                     runtime::eigen::concat_matrix(
-                        ptvs,
-                        call_frame.get_parameterized_tensor_view<ET>(m_out),
-                        m_axis);
+                        ptvs, call_frame.get_parameterized_tensor_view<ET>(m_out), m_axis);
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/concat_vector.hpp
+++ b/src/ngraph/runtime/eigen/concat_vector.hpp
@@ -33,18 +33,18 @@ namespace ngraph
                 auto vec_out = get_map_matrix(&*out);
                 auto& out_shape = out->get_shape();
 
-                assert (out_shape.size() == 1);
+                assert(out_shape.size() == 1);
 
                 size_t concat_pos = 0;
 
-                for(T arg : args)
+                for (T arg : args)
                 {
                     auto vec_arg = get_map_matrix(&*arg);
                     auto& arg_shape = arg->get_shape();
 
-                    assert (arg_shape.size() == 1);
+                    assert(arg_shape.size() == 1);
 
-                    vec_out.segment(concat_pos,arg_shape.at(0)) << vec_arg;
+                    vec_out.segment(concat_pos, arg_shape.at(0)) << vec_arg;
                     concat_pos += arg_shape.at(0);
                 }
             }
@@ -62,13 +62,12 @@ namespace ngraph
                 virtual void execute(CallFrame& call_frame) const override
                 {
                     std::vector<ParameterizedTensorView<ET>*> ptvs;
-                    for(size_t arg : m_args)
+                    for (size_t arg : m_args)
                     {
                         ptvs.push_back(call_frame.get_parameterized_tensor_view<ET>(arg));
                     }
                     runtime::eigen::concat_vector(
-                        ptvs,
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                        ptvs, call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/constant.hpp
+++ b/src/ngraph/runtime/eigen/constant.hpp
@@ -25,7 +25,7 @@ namespace ngraph
     {
         namespace eigen
         {
-            template <typename ET,typename T>
+            template <typename ET, typename T>
             void assign_constant(const std::vector<ET>& value, T out)
             {
                 out->get_vector() = value;
@@ -44,8 +44,7 @@ namespace ngraph
                 virtual void execute(CallFrame& call_frame) const override
                 {
                     runtime::eigen::assign_constant(
-                        m_value,
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                        m_value, call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/divide.hpp
+++ b/src/ngraph/runtime/eigen/divide.hpp
@@ -44,10 +44,9 @@ namespace ngraph
 
                 virtual void execute(CallFrame& call_frame) const override
                 {
-                    runtime::eigen::divide(
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg0),
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg1),
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                    runtime::eigen::divide(call_frame.get_parameterized_tensor_view<ET>(m_arg0),
+                                           call_frame.get_parameterized_tensor_view<ET>(m_arg1),
+                                           call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/dot.hpp
+++ b/src/ngraph/runtime/eigen/dot.hpp
@@ -44,10 +44,9 @@ namespace ngraph
 
                 virtual void execute(CallFrame& call_frame) const override
                 {
-                    runtime::eigen::dot(
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg0),
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg1),
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                    runtime::eigen::dot(call_frame.get_parameterized_tensor_view<ET>(m_arg0),
+                                        call_frame.get_parameterized_tensor_view<ET>(m_arg1),
+                                        call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/equal.hpp
+++ b/src/ngraph/runtime/eigen/equal.hpp
@@ -25,11 +25,11 @@ namespace ngraph
     {
         namespace eigen
         {
-            template <typename TI,typename TO>
+            template <typename TI, typename TO>
             void equal(TI arg0, TI arg1, TO out)
             {
                 auto result_as_float = get_map_array(&*arg0) == get_map_array(&*arg1);
-                auto result_as_char  = result_as_float.template cast<char>();
+                auto result_as_char = result_as_float.template cast<char>();
                 set_map_array(&*out, result_as_char);
             }
 

--- a/src/ngraph/runtime/eigen/less_than.hpp
+++ b/src/ngraph/runtime/eigen/less_than.hpp
@@ -25,11 +25,11 @@ namespace ngraph
     {
         namespace eigen
         {
-            template <typename TI,typename TO>
+            template <typename TI, typename TO>
             void less_than(TI arg0, TI arg1, TO out)
             {
                 auto result_as_float = get_map_array(&*arg0) < get_map_array(&*arg1);
-                auto result_as_char  = result_as_float.template cast<char>();
+                auto result_as_char = result_as_float.template cast<char>();
                 set_map_array(&*out, result_as_char);
             }
 

--- a/src/ngraph/runtime/eigen/log.hpp
+++ b/src/ngraph/runtime/eigen/log.hpp
@@ -43,9 +43,8 @@ namespace ngraph
 
                 virtual void execute(CallFrame& call_frame) const override
                 {
-                    runtime::eigen::log(
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg),
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                    runtime::eigen::log(call_frame.get_parameterized_tensor_view<ET>(m_arg),
+                                        call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/matrix_mult.hpp
+++ b/src/ngraph/runtime/eigen/matrix_mult.hpp
@@ -28,7 +28,7 @@ namespace ngraph
             template <typename T>
             void matrix_mult(T arg0, T arg1, T out)
             {
-                set_map_matrix_2d(&*out,get_map_matrix_2d(&*arg0) * get_map_matrix_2d(&*arg1));
+                set_map_matrix_2d(&*out, get_map_matrix_2d(&*arg0) * get_map_matrix_2d(&*arg1));
             }
 
             template <typename ET>

--- a/src/ngraph/runtime/eigen/matrix_vector_product.hpp
+++ b/src/ngraph/runtime/eigen/matrix_vector_product.hpp
@@ -28,7 +28,7 @@ namespace ngraph
             template <typename T>
             void matrix_vector_product(T arg0, T arg1, T out)
             {
-                set_map_matrix(&*out,get_map_matrix_2d(&*arg0) * get_map_matrix(&*arg1));
+                set_map_matrix(&*out, get_map_matrix_2d(&*arg0) * get_map_matrix(&*arg1));
             }
 
             template <typename ET>

--- a/src/ngraph/runtime/eigen/maximum.hpp
+++ b/src/ngraph/runtime/eigen/maximum.hpp
@@ -44,10 +44,9 @@ namespace ngraph
 
                 virtual void execute(CallFrame& call_frame) const override
                 {
-                    runtime::eigen::maximum(
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg0),
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg1),
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                    runtime::eigen::maximum(call_frame.get_parameterized_tensor_view<ET>(m_arg0),
+                                            call_frame.get_parameterized_tensor_view<ET>(m_arg1),
+                                            call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/multiply.hpp
+++ b/src/ngraph/runtime/eigen/multiply.hpp
@@ -43,10 +43,9 @@ namespace ngraph
 
                 virtual void execute(CallFrame& call_frame) const override
                 {
-                    runtime::eigen::multiply(
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg0),
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg1),
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                    runtime::eigen::multiply(call_frame.get_parameterized_tensor_view<ET>(m_arg0),
+                                             call_frame.get_parameterized_tensor_view<ET>(m_arg1),
+                                             call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/negate.hpp
+++ b/src/ngraph/runtime/eigen/negate.hpp
@@ -43,9 +43,8 @@ namespace ngraph
 
                 virtual void execute(CallFrame& call_frame) const override
                 {
-                    runtime::eigen::negate(
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg),
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                    runtime::eigen::negate(call_frame.get_parameterized_tensor_view<ET>(m_arg),
+                                           call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/not_equal.hpp
+++ b/src/ngraph/runtime/eigen/not_equal.hpp
@@ -25,11 +25,11 @@ namespace ngraph
     {
         namespace eigen
         {
-            template <typename TI,typename TO>
+            template <typename TI, typename TO>
             void not_equal(TI arg0, TI arg1, TO out)
             {
                 auto result_as_float = get_map_array(&*arg0) != get_map_array(&*arg1);
-                auto result_as_char  = result_as_float.template cast<char>();
+                auto result_as_char = result_as_float.template cast<char>();
                 set_map_array(&*out, result_as_char);
             }
 

--- a/src/ngraph/runtime/eigen/return.hpp
+++ b/src/ngraph/runtime/eigen/return.hpp
@@ -27,7 +27,6 @@ namespace ngraph
             {
             public:
                 ReturnInstruction() {}
-
                 virtual void execute(CallFrame& call_frame) const override
                 {
                     call_frame.set_return();

--- a/src/ngraph/runtime/eigen/scalar_tensor_product.hpp
+++ b/src/ngraph/runtime/eigen/scalar_tensor_product.hpp
@@ -28,7 +28,7 @@ namespace ngraph
             template <typename T>
             void scalar_tensor_product(T arg0, T arg1, T out)
             {
-                set_map_matrix(&*out,(&*arg0)->get_vector()[0] * get_map_matrix(&*arg1));
+                set_map_matrix(&*out, (&*arg0)->get_vector()[0] * get_map_matrix(&*arg1));
             }
 
             template <typename ET>

--- a/src/ngraph/runtime/eigen/select.hpp
+++ b/src/ngraph/runtime/eigen/select.hpp
@@ -25,10 +25,12 @@ namespace ngraph
     {
         namespace eigen
         {
-            template <typename TA,typename TB>
+            template <typename TA, typename TB>
             void select(TA arg0, TB arg1, TB arg2, TB out)
             {
-                set_map_array(&*out, get_map_array(&*arg0).select(get_map_array(&*arg1),get_map_array(&*arg2)));
+                set_map_array(
+                    &*out,
+                    get_map_array(&*arg0).select(get_map_array(&*arg1), get_map_array(&*arg2)));
             }
 
             template <typename ET>

--- a/src/ngraph/runtime/eigen/subtract.hpp
+++ b/src/ngraph/runtime/eigen/subtract.hpp
@@ -44,10 +44,9 @@ namespace ngraph
 
                 virtual void execute(CallFrame& call_frame) const override
                 {
-                    runtime::eigen::subtract(
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg0),
-                        call_frame.get_parameterized_tensor_view<ET>(m_arg1),
-                        call_frame.get_parameterized_tensor_view<ET>(m_out));
+                    runtime::eigen::subtract(call_frame.get_parameterized_tensor_view<ET>(m_arg0),
+                                             call_frame.get_parameterized_tensor_view<ET>(m_arg1),
+                                             call_frame.get_parameterized_tensor_view<ET>(m_out));
                 }
 
             protected:

--- a/src/ngraph/runtime/eigen/utils.hpp
+++ b/src/ngraph/runtime/eigen/utils.hpp
@@ -63,9 +63,10 @@ namespace ngraph
                 auto& s = t->get_shape();
                 auto s_rest = std::vector<size_t>(s.begin() + 1, s.end());
                 Eigen::Map<Eigen::Array<typename T::value_type,
-                                        Eigen::Dynamic, Eigen::Dynamic,
-                                        Eigen::RowMajor>>(
-                    &v[0], s[0], ngraph::shape_size(s_rest)) = u;
+                                        Eigen::Dynamic,
+                                        Eigen::Dynamic,
+                                        Eigen::RowMajor>>(&v[0], s[0], ngraph::shape_size(s_rest)) =
+                    u;
             }
 
             template <typename T, typename U>
@@ -75,9 +76,10 @@ namespace ngraph
                 auto& s = t->get_shape();
                 auto s_rest = std::vector<size_t>(s.begin() + 1, s.end());
                 Eigen::Map<Eigen::Array<typename T::value_type,
-                                        Eigen::Dynamic, Eigen::Dynamic,
-                                        Eigen::RowMajor>>(
-                    &v[0], s[0], ngraph::shape_size(s_rest)) = u;
+                                        Eigen::Dynamic,
+                                        Eigen::Dynamic,
+                                        Eigen::RowMajor>>(&v[0], s[0], ngraph::shape_size(s_rest)) =
+                    u;
             }
 
             template <typename T, typename U>
@@ -87,7 +89,8 @@ namespace ngraph
                 auto& s = t->get_shape();
                 auto s_rest = std::vector<size_t>(s.begin() + 1, s.end());
                 Eigen::Map<Eigen::Matrix<typename T::value_type,
-                                         Eigen::Dynamic, Eigen::Dynamic,
+                                         Eigen::Dynamic,
+                                         Eigen::Dynamic,
                                          Eigen::RowMajor>>(
                     &v[0], s[0], ngraph::shape_size(s_rest)) = u;
             }
@@ -99,7 +102,8 @@ namespace ngraph
                 auto& s = t->get_shape();
                 auto s_rest = std::vector<size_t>(s.begin() + 1, s.end());
                 Eigen::Map<Eigen::Matrix<typename T::value_type,
-                                         Eigen::Dynamic, Eigen::Dynamic,
+                                         Eigen::Dynamic,
+                                         Eigen::Dynamic,
                                          Eigen::RowMajor>>(
                     &v[0], s[0], ngraph::shape_size(s_rest)) = u;
             }
@@ -114,7 +118,8 @@ namespace ngraph
             }
 
             template <typename T>
-            Eigen::Map<Eigen::Array<typename T::value_type, Eigen::Dynamic, 1>> get_map_array(T* arg)
+            Eigen::Map<Eigen::Array<typename T::value_type, Eigen::Dynamic, 1>>
+                get_map_array(T* arg)
             {
                 auto& v = arg->get_vector();
                 return Eigen::Map<Eigen::Array<typename T::value_type, Eigen::Dynamic, 1>>(
@@ -131,7 +136,8 @@ namespace ngraph
             }
 
             template <typename T>
-            Eigen::Map<Eigen::Matrix<typename T::value_type, Eigen::Dynamic, 1>> get_map_matrix(T* arg)
+            Eigen::Map<Eigen::Matrix<typename T::value_type, Eigen::Dynamic, 1>>
+                get_map_matrix(T* arg)
             {
                 auto& v = arg->get_vector();
                 return Eigen::Map<Eigen::Matrix<typename T::value_type, Eigen::Dynamic, 1>>(
@@ -139,51 +145,65 @@ namespace ngraph
             }
 
             template <typename T>
-            Eigen::Map<Eigen::Array<typename T::value_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
+            Eigen::Map<
+                Eigen::
+                    Array<typename T::value_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
                 get_map_array_2d(std::shared_ptr<T>& arg)
             {
                 auto& v = arg->get_vector();
                 auto& s = arg->get_shape();
                 auto s_rest = std::vector<size_t>(s.begin() + 1, s.end());
                 return Eigen::Map<Eigen::Array<typename T::value_type,
-                                               Eigen::Dynamic, Eigen::Dynamic,
+                                               Eigen::Dynamic,
+                                               Eigen::Dynamic,
                                                Eigen::RowMajor>>(
                     &v[0], s[0], ngraph::shape_size(s_rest));
             }
 
             template <typename T>
-            Eigen::Map<Eigen::Array<typename T::value_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> get_map_array_2d(T* arg)
+            Eigen::Map<
+                Eigen::
+                    Array<typename T::value_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
+                get_map_array_2d(T* arg)
             {
                 auto& v = arg->get_vector();
                 auto& s = arg->get_shape();
                 auto s_rest = std::vector<size_t>(s.begin() + 1, s.end());
                 return Eigen::Map<Eigen::Array<typename T::value_type,
-                                               Eigen::Dynamic, Eigen::Dynamic,
+                                               Eigen::Dynamic,
+                                               Eigen::Dynamic,
                                                Eigen::RowMajor>>(
                     &v[0], s[0], ngraph::shape_size(s_rest));
             }
 
             template <typename T>
-            Eigen::Map<Eigen::Matrix<typename T::value_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
+            Eigen::Map<
+                Eigen::
+                    Matrix<typename T::value_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
                 get_map_array_2d(std::shared_ptr<T>& arg)
             {
                 auto& v = arg->get_vector();
                 auto& s = arg->get_shape();
                 auto s_rest = std::vector<size_t>(s.begin() + 1, s.end());
                 return Eigen::Map<Eigen::Matrix<typename T::value_type,
-                                                Eigen::Dynamic, Eigen::Dynamic,
+                                                Eigen::Dynamic,
+                                                Eigen::Dynamic,
                                                 Eigen::RowMajor>>(
                     &v[0], s[0], ngraph::shape_size(s_rest));
             }
 
             template <typename T>
-            Eigen::Map<Eigen::Matrix<typename T::value_type,Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> get_map_matrix_2d(T* arg)
+            Eigen::Map<
+                Eigen::
+                    Matrix<typename T::value_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
+                get_map_matrix_2d(T* arg)
             {
                 auto& v = arg->get_vector();
                 auto& s = arg->get_shape();
                 auto s_rest = std::vector<size_t>(s.begin() + 1, s.end());
                 return Eigen::Map<Eigen::Matrix<typename T::value_type,
-                                                Eigen::Dynamic, Eigen::Dynamic,
+                                                Eigen::Dynamic,
+                                                Eigen::Dynamic,
                                                 Eigen::RowMajor>>(
                     &v[0], s[0], ngraph::shape_size(s_rest));
             }

--- a/src/ngraph/runtime/external_function.hpp
+++ b/src/ngraph/runtime/external_function.hpp
@@ -31,11 +31,11 @@ namespace ngraph
                                                   ExternalFunction*,
                                                   const std::vector<size_t>& inputs,
                                                   const std::vector<size_t>& outputs)>;
-            using OpMap      = std::unordered_map<std::type_index, OpFunction>;
+            using OpMap = std::unordered_map<std::type_index, OpFunction>;
 
         public:
             ExternalFunction(const std::shared_ptr<ngraph::Function>& function,
-                             bool                                     release_function = true);
+                             bool release_function = true);
             std::shared_ptr<ngraph::runtime::CallFrame> make_call_frame();
             std::shared_ptr<std::vector<std::shared_ptr<ngraph::runtime::Instruction>>>
                 get_instructions()
@@ -45,17 +45,16 @@ namespace ngraph
 
             // Release original function's resources
             void release_function() { m_function = nullptr; }
-
         protected:
             void compile();
 
             std::shared_ptr<ngraph::Function> m_function;
-            bool                              m_release_function;
-            bool                              m_is_compiled;
-            size_t                            m_n_inputs;
-            size_t                            m_n_outputs;
+            bool m_release_function;
+            bool m_is_compiled;
+            size_t m_n_inputs;
+            size_t m_n_outputs;
             std::shared_ptr<std::vector<std::shared_ptr<ngraph::runtime::Instruction>>>
-                                               m_instructions;
+                m_instructions;
             ngraph::descriptor::TensorViewPtrs m_temp_views;
 
             static OpMap& get_op_map();

--- a/src/ngraph/runtime/instruction.hpp
+++ b/src/ngraph/runtime/instruction.hpp
@@ -24,7 +24,7 @@ namespace ngraph
         class Instruction
         {
         public:
-            virtual ~Instruction(){}
+            virtual ~Instruction() {}
             virtual void execute(CallFrame& call_frame) const = 0;
         };
     }

--- a/src/ngraph/runtime/parameterized_tensor_view.hpp
+++ b/src/ngraph/runtime/parameterized_tensor_view.hpp
@@ -49,7 +49,7 @@ namespace ngraph
                 const std::shared_ptr<ngraph::descriptor::TensorView>& descriptor);
 
             using element_type = ET;
-            using value_type   = typename ET::type;
+            using value_type = typename ET::type;
             using storage_type = std::vector<value_type>;
 
             template <typename T>
@@ -61,7 +61,6 @@ namespace ngraph
 
             // For getting the data out
             storage_type& get_vector() { return m_vector; }
-
         protected:
             storage_type m_vector;
         };

--- a/src/ngraph/runtime/tensor_view.hpp
+++ b/src/ngraph/runtime/tensor_view.hpp
@@ -39,9 +39,7 @@ namespace ngraph
 
         public:
             TensorView() {}
-
             virtual ~TensorView() {}
-
             template <typename ET>
             ParameterizedTensorView<ET>* get_parameterized_tensor_view()
             {
@@ -65,7 +63,6 @@ namespace ngraph
             }
 
             const Shape& get_shape() { return m_descriptor->get_tensor_view_type()->get_shape(); }
-
         protected:
             std::shared_ptr<ngraph::descriptor::TensorView> m_descriptor;
         };

--- a/src/ngraph/runtime/tuple.cpp
+++ b/src/ngraph/runtime/tuple.cpp
@@ -33,7 +33,7 @@ Tuple::Tuple(const std::vector<std::shared_ptr<ngraph::runtime::Value>>& element
 }
 
 void Tuple::collect_tensor_views(std::vector<std::shared_ptr<TensorView>>& views,
-                                 const std::shared_ptr<Value>&        value) const
+                                 const std::shared_ptr<Value>& value) const
 {
     for (auto element : m_elements)
     {

--- a/src/ngraph/runtime/tuple.hpp
+++ b/src/ngraph/runtime/tuple.hpp
@@ -40,12 +40,11 @@ namespace ngraph
                 return m_descriptor;
             }
 
-            virtual void
-                collect_tensor_views(std::vector<std::shared_ptr<TensorView>>& views,
-                                     const std::shared_ptr<Value>& value) const override;
+            virtual void collect_tensor_views(std::vector<std::shared_ptr<TensorView>>& views,
+                                              const std::shared_ptr<Value>& value) const override;
 
         protected:
-            std::vector<std::shared_ptr<Value>>        m_elements;
+            std::vector<std::shared_ptr<Value>> m_elements;
             std::shared_ptr<ngraph::descriptor::Tuple> m_descriptor;
         };
     }

--- a/src/ngraph/runtime/value.hpp
+++ b/src/ngraph/runtime/value.hpp
@@ -24,17 +24,16 @@ namespace ngraph
     namespace runtime
     {
         class TensorView;
-        
+
         /// @brief A first-class runtime value.
         class Value
         {
         public:
             virtual ~Value() {}
-
             /// @brief The compile-time descriptor for this value.
-            virtual std::shared_ptr<ngraph::descriptor::Value> get_descriptor() const         = 0;
+            virtual std::shared_ptr<ngraph::descriptor::Value> get_descriptor() const = 0;
 
-                        /// @brief helper for collecting all the tensor views in a sequence of values
+            /// @brief helper for collecting all the tensor views in a sequence of values
             ///
             /// @param views The vector of tensor views being collected.
             /// @param value A shared pointer for this.

--- a/src/ngraph/shape.cpp
+++ b/src/ngraph/shape.cpp
@@ -33,7 +33,7 @@ size_t ngraph::shape_size(const Shape& shape)
 Strides ngraph::row_major_strides(const Shape& shape)
 {
     Strides strides;
-    size_t  s = 1;
+    size_t s = 1;
     for (auto d = shape.rbegin(); d != shape.rend(); d++)
     {
         strides.push_back(s);

--- a/src/ngraph/types/element_type.cpp
+++ b/src/ngraph/types/element_type.cpp
@@ -16,16 +16,16 @@
 #include <cmath>
 #include <iostream>
 
-#include "ngraph/types/element_type.hpp"
 #include "ngraph/log.hpp"
+#include "ngraph/types/element_type.hpp"
 
 using namespace ngraph;
 
 std::map<std::string, ngraph::element::Type> ngraph::element::Type::m_element_list;
 
-ngraph::element::Type::Type(size_t             bitwidth,
-                            bool               is_float,
-                            bool               is_signed,
+ngraph::element::Type::Type(size_t bitwidth,
+                            bool is_float,
+                            bool is_signed,
                             const std::string& cname)
     : m_bitwidth{bitwidth}
     , m_is_float{is_float}

--- a/src/ngraph/types/element_type.hpp
+++ b/src/ngraph/types/element_type.hpp
@@ -37,23 +37,23 @@ namespace ngraph
             Type(size_t bitwidth, bool is_float, bool is_signed, const std::string& cname);
 
             const std::string& c_type_string() const;
-            size_t             size() const;
-            size_t             hash() const
+            size_t size() const;
+            size_t hash() const
             {
                 std::hash<std::string> h;
                 return h(m_cname);
             }
 
-            bool                 operator==(const Type& other) const;
-            bool                 operator!=(const Type& other) const { return !(*this == other); }
+            bool operator==(const Type& other) const;
+            bool operator!=(const Type& other) const { return !(*this == other); }
             friend std::ostream& operator<<(std::ostream&, const Type&);
 
         private:
             static std::map<std::string, Type> m_element_list;
-            size_t                             m_bitwidth;
-            bool                               m_is_float;
-            bool                               m_is_signed;
-            const std::string                  m_cname;
+            size_t m_bitwidth;
+            bool m_is_float;
+            bool m_is_signed;
+            const std::string m_cname;
         };
 
         std::ostream& operator<<(std::ostream& out, const ngraph::element::Type& obj);

--- a/src/ngraph/types/type.cpp
+++ b/src/ngraph/types/type.cpp
@@ -14,8 +14,8 @@
 
 #include <memory>
 
-#include "ngraph/ngraph.hpp"
 #include "ngraph/log.hpp"
+#include "ngraph/ngraph.hpp"
 #include "ngraph/util.hpp"
 
 using namespace std;
@@ -39,7 +39,8 @@ bool TensorViewType::operator==(const ValueType& that) const
     return true;
 }
 
-void TensorViewType::collect_tensor_views(std::vector<std::shared_ptr<const TensorViewType>>& views) const
+void TensorViewType::collect_tensor_views(
+    std::vector<std::shared_ptr<const TensorViewType>>& views) const
 {
     views.push_back(shared_from_this());
 }
@@ -54,9 +55,10 @@ bool TupleType::operator==(const ValueType& that) const
     return that_tvt->get_element_types() == get_element_types();
 }
 
-void TupleType::collect_tensor_views(std::vector<std::shared_ptr<const TensorViewType>>& views) const
+void TupleType::collect_tensor_views(
+    std::vector<std::shared_ptr<const TensorViewType>>& views) const
 {
-    for(auto elt : m_element_types)
+    for (auto elt : m_element_types)
     {
         elt->collect_tensor_views(views);
     }
@@ -70,7 +72,7 @@ std::ostream& ngraph::operator<<(std::ostream& out, const ValueType& obj)
 
 std::ostream& ngraph::operator<<(std::ostream& out, const TensorViewType& obj)
 {
-    out << "TensorViewType(" << obj.m_element_type << ", {" << join(obj.m_shape)  << "})";
+    out << "TensorViewType(" << obj.m_element_type << ", {" << join(obj.m_shape) << "})";
     return out;
 }
 

--- a/src/ngraph/types/type.hpp
+++ b/src/ngraph/types/type.hpp
@@ -17,8 +17,8 @@
 #include <memory>
 #include <vector>
 
-#include "ngraph/types/element_type.hpp"
 #include "ngraph/shape.hpp"
+#include "ngraph/types/element_type.hpp"
 
 namespace ngraph
 {
@@ -35,12 +35,10 @@ namespace ngraph
 
     protected:
         ValueType() {}
-
     public:
         virtual ~ValueType() {}
         virtual bool operator==(const ValueType& that) const = 0;
-        bool         operator!=(const ValueType& that) const { return !(*this == that); }
-
+        bool operator!=(const ValueType& that) const { return !(*this == that); }
         /// Add tensor views in depth-first order.
         virtual void collect_tensor_views(
             std::vector<std::shared_ptr<const TensorViewType>>& views) const = 0;
@@ -61,8 +59,7 @@ namespace ngraph
         }
 
         const element::Type& get_element_type() const { return m_element_type; }
-        const Shape&         get_shape() const { return m_shape; }
-
+        const Shape& get_shape() const { return m_shape; }
         virtual bool operator==(const ValueType& that) const override;
         virtual void collect_tensor_views(
             std::vector<std::shared_ptr<const TensorViewType>>& views) const override;
@@ -71,7 +68,7 @@ namespace ngraph
 
     protected:
         const element::Type& m_element_type;
-        Shape                m_shape;
+        Shape m_shape;
     };
 
     /// Describes a tuple of values; a vector of types
@@ -80,7 +77,6 @@ namespace ngraph
     public:
         /// Construct empty tuple and add value types later.
         TupleType() {}
-
         /// @param element_types A vector of types for the tuple elements
         TupleType(const std::vector<std::shared_ptr<const ValueType>>& element_types)
             : m_element_types(element_types)
@@ -91,7 +87,10 @@ namespace ngraph
         {
             return m_element_types;
         }
-        std::vector<std::shared_ptr<const ValueType>> set_element_types() { return m_element_types; }
+        std::vector<std::shared_ptr<const ValueType>> set_element_types()
+        {
+            return m_element_types;
+        }
 
         virtual bool operator==(const ValueType& that) const override;
         virtual void collect_tensor_views(

--- a/src/ngraph/util.cpp
+++ b/src/ngraph/util.cpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // ----------------------------------------------------------------------------
 
-#include <iomanip>
-#include <map>
 #include <deque>
 #include <forward_list>
+#include <iomanip>
+#include <map>
 #include <unordered_set>
 
-#include "ngraph/util.hpp"
-#include "ngraph/node.hpp"
 #include "ngraph/log.hpp"
+#include "ngraph/node.hpp"
+#include "ngraph/util.hpp"
 
 using namespace std;
 
@@ -28,10 +28,10 @@ map<string, ngraph::stopwatch*> ngraph::stopwatch_statistics;
 
 void ngraph::dump(ostream& out, const void* _data, size_t _size)
 {
-    auto           flags = out.flags();
-    const uint8_t* data  = reinterpret_cast<const uint8_t*>(_data);
-    size_t            len   = _size;
-    size_t            index = 0;
+    auto flags = out.flags();
+    const uint8_t* data = reinterpret_cast<const uint8_t*>(_data);
+    size_t len = _size;
+    size_t index = 0;
     while (index < len)
     {
         out << std::hex << std::setw(8) << std::setfill('0') << index;
@@ -99,9 +99,9 @@ string ngraph::trim(const string& s)
 
 vector<string> ngraph::split(const string& src, char delimiter, bool do_trim)
 {
-    size_t         pos;
-    string         token;
-    size_t         start = 0;
+    size_t pos;
+    string token;
+    size_t start = 0;
     vector<string> rc;
     while ((pos = src.find(delimiter, start)) != std::string::npos)
     {
@@ -135,8 +135,7 @@ size_t ngraph::hash_combine(const std::vector<size_t>& list)
     return seed;
 }
 
-void ngraph::traverse_nodes(const std::shared_ptr<ngraph::Node>& p,
-                            std::function<void(Node*)>           f)
+void ngraph::traverse_nodes(const std::shared_ptr<ngraph::Node>& p, std::function<void(Node*)> f)
 {
     std::unordered_set<Node*> instances_seen;
     deque<Node*> stack;
@@ -151,7 +150,10 @@ void ngraph::traverse_nodes(const std::shared_ptr<ngraph::Node>& p,
             f(n);
         }
         stack.pop_front();
-        for (auto arg : n->get_arguments()) { stack.push_front(arg.get()); }
+        for (auto arg : n->get_arguments())
+        {
+            stack.push_front(arg.get());
+        }
     }
 }
 
@@ -159,10 +161,7 @@ void ngraph::free_nodes(shared_ptr<Node> p)
 {
     std::deque<Node*> sorted_list;
 
-    traverse_nodes(p, [&](Node* n)
-    {
-        sorted_list.push_front(n);
-    });
+    traverse_nodes(p, [&](Node* n) { sorted_list.push_front(n); });
 
     for (Node* n : sorted_list)
     {

--- a/src/ngraph/util.hpp
+++ b/src/ngraph/util.hpp
@@ -18,10 +18,10 @@
 #include <chrono>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <memory>
 
 namespace ngraph
 {
@@ -114,7 +114,7 @@ namespace ngraph
             if (m_active == false)
             {
                 m_total_count++;
-                m_active     = true;
+                m_active = true;
                 m_start_time = m_clock.now();
             }
         }
@@ -124,7 +124,7 @@ namespace ngraph
             if (m_active == true)
             {
                 auto end_time = m_clock.now();
-                m_last_time   = end_time - m_start_time;
+                m_last_time = end_time - m_start_time;
                 m_total_time += m_last_time;
                 m_active = false;
             }
@@ -151,14 +151,14 @@ namespace ngraph
         size_t get_total_microseconds() const { return get_total_nanoseconds() / 1e3; }
         size_t get_total_nanoseconds() const { return m_total_time.count(); }
     private:
-        std::chrono::high_resolution_clock                          m_clock;
+        std::chrono::high_resolution_clock m_clock;
         std::chrono::time_point<std::chrono::high_resolution_clock> m_start_time;
-        bool                                                        m_active = false;
-        std::chrono::nanoseconds                                    m_total_time =
+        bool m_active = false;
+        std::chrono::nanoseconds m_total_time =
             std::chrono::high_resolution_clock::duration::zero();
         std::chrono::nanoseconds m_last_time;
-        size_t                   m_total_count = 0;
-        std::string              m_name;
+        size_t m_total_count = 0;
+        std::string m_name;
     };
 
     template <class InputIt, class BinaryOp>

--- a/src/ngraph/uuid.hpp
+++ b/src/ngraph/uuid.hpp
@@ -32,17 +32,17 @@ class ngraph::uuid_type
 public:
     uuid_type()
     {
-        m_data[0]  = random_generator();
-        m_data[1]  = random_generator();
+        m_data[0] = random_generator();
+        m_data[1] = random_generator();
         uint8_t* p = (uint8_t*)m_data;
-        p[6]       = (p[6] & 0x0F) | 0x40;
-        p[8]       = (p[8] & 0x3F) | 0x80;
+        p[6] = (p[6] & 0x0F) | 0x40;
+        p[8] = (p[8] & 0x3F) | 0x80;
     }
 
     std::string to_string() const
     {
         std::stringstream ss;
-        uint8_t*          p = (uint8_t*)m_data;
+        uint8_t* p = (uint8_t*)m_data;
         for (int i = 0; i < 4; i++)
             ss << std::hex << std::setw(2) << std::setfill('0') << (int)*p++;
         ss << "-";

--- a/src/ngraph/visualize.cpp
+++ b/src/ngraph/visualize.cpp
@@ -17,8 +17,8 @@
 #include <list>
 
 #include "ngraph/node.hpp"
-#include "ngraph/visualize.hpp"
 #include "ngraph/util.hpp"
+#include "ngraph/visualize.hpp"
 
 using namespace ngraph;
 using namespace std;
@@ -70,7 +70,7 @@ std::string Visualize::get_attributes(const Node* node)
 void Visualize::save_dot(const string& path) const
 {
 #if GRAPHVIZ_FOUND
-    auto     tmp_file = path + ".tmp";
+    auto tmp_file = path + ".tmp";
     ofstream out(tmp_file);
     if (out)
     {
@@ -81,7 +81,7 @@ void Visualize::save_dot(const string& path) const
 
         stringstream ss;
         ss << "dot -Tpng " << tmp_file << " -o " << path;
-        auto cmd    = ss.str();
+        auto cmd = ss.str();
         auto stream = popen(cmd.c_str(), "r");
         pclose(stream);
 

--- a/src/ngraph/visualize.hpp
+++ b/src/ngraph/visualize.hpp
@@ -39,7 +39,7 @@ private:
     std::string add_attributes(const Node* node);
     std::string get_attributes(const Node* node);
 
-    std::stringstream     m_ss;
-    std::string           m_name;
+    std::stringstream m_ss;
+    std::string m_name;
     std::set<const Node*> m_nodes_with_attributes;
 };

--- a/test/build_graph.cpp
+++ b/test/build_graph.cpp
@@ -23,13 +23,13 @@ using namespace ngraph;
 TEST(build_graph, build_simple)
 {
     // Function with 4 parameters
-    auto arg0        = make_shared<op::Parameter>(element::Float32::element_type(), Shape{7, 3});
-    auto arg1        = make_shared<op::Parameter>(element::Float32::element_type(), Shape{3});
-    auto arg2        = make_shared<op::Parameter>(element::Float32::element_type(), Shape{32, 7});
-    auto arg3        = make_shared<op::Parameter>(element::Float32::element_type(), Shape{32, 7});
+    auto arg0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{7, 3});
+    auto arg1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{3});
+    auto arg2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{32, 7});
+    auto arg3 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{32, 7});
     auto broadcast_1 = make_shared<op::Broadcast>(arg3, Shape{10, 32, 7}, AxisSet{0});
-    auto b1          = make_shared<op::Broadcast>(arg3, Shape{10, 32, 7}, AxisSet{0});
-    auto dot         = make_shared<op::Dot>(arg2, arg0);
+    auto b1 = make_shared<op::Broadcast>(arg3, Shape{10, 32, 7}, AxisSet{0});
+    auto dot = make_shared<op::Dot>(arg2, arg0);
     ASSERT_EQ(dot->get_arguments()[0], arg2);
     ASSERT_EQ(dot->get_arguments()[1], arg0);
 
@@ -66,7 +66,7 @@ TEST(build_graph, node_comparison)
     auto dot = make_shared<op::Dot>(arg0, arg1);
     auto add = make_shared<op::Add>(dot, arg2);
 
-    auto parg        = make_shared<op::Parameter>(element::Float32::element_type(), Shape{});
+    auto parg = make_shared<op::Parameter>(element::Float32::element_type(), Shape{});
     auto pattern_dot = make_shared<op::Dot>(parg, parg);
     ASSERT_TRUE(pattern_dot->is_same_op_type(dot));
     // TODO This passes because typeid is not behaving as documented.
@@ -78,7 +78,7 @@ TEST(build_graph, literal)
 {
     // float scalar from a float
     //auto float0 = FloatScalarConstant::make(3.0);
-    auto float0            = make_shared<op::Float32ScalarConstant>(3.0);
+    auto float0 = make_shared<op::Float32ScalarConstant>(3.0);
     auto float_scalar_type = make_shared<TensorViewType>(element::Float32::element_type(), Shape{});
     ASSERT_EQ(float0->get_value(), 3.0);
     ASSERT_EQ(*float0->get_value_type(), *float_scalar_type);
@@ -91,7 +91,7 @@ TEST(build_graph, literal)
     ASSERT_EQ(float1->get_value(), 3);
     ASSERT_EQ(*float1->get_value_type(), *float_scalar_type);
 
-    auto int32_0           = make_shared<op::Int32ScalarConstant>(3.0);
+    auto int32_0 = make_shared<op::Int32ScalarConstant>(3.0);
     auto int32_scalar_type = make_shared<TensorViewType>(element::Int32::element_type(), Shape{});
     ASSERT_EQ(int32_0->get_value(), 3);
     ASSERT_EQ(*int32_0->get_value_type(), *int32_scalar_type);
@@ -181,4 +181,6 @@ TEST(build_graph, set_value_type_checked)
 }
 
 // Check argument inverses
-TEST(build_graph, arg_inverse) {}
+TEST(build_graph, arg_inverse)
+{
+}

--- a/test/execute.cpp
+++ b/test/execute.cpp
@@ -22,21 +22,21 @@ using namespace ngraph;
 TEST(execute, test_abc)
 {
     auto shape = Shape{2, 2};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto C     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>((A + B) * C, op::Parameters{A, B, C});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto C = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>((A + B) * C, op::Parameters{A, B, C});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{1, 2, 3, 4};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{5, 6, 7, 8};
-    auto c      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *c          = vector<float>{9, 10, 11, 12};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{1, 2, 3, 4};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{5, 6, 7, 8};
+    auto c = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *c = vector<float>{9, 10, 11, 12};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({a, b, c}, {result});
@@ -65,27 +65,27 @@ TEST(execute, test_abc_tuple)
     auto f = make_shared<Function>(make_shared<op::Tuple>(Nodes{(A + B) * C}), op::Parameters{ABC});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a            = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a                = vector<float>{1, 2, 3, 4};
-    auto b            = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b                = vector<float>{5, 6, 7, 8};
-    auto c            = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *c                = vector<float>{9, 10, 11, 12};
-    auto abc          = ngraph::runtime::make_tuple({a, b, c});
-    auto bac          = ngraph::runtime::make_tuple({b, a, c});
-    auto acb          = ngraph::runtime::make_tuple({a, c, b});
-    auto result       = ngraph::runtime::make_tensor<element::Float32>(shape);
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{1, 2, 3, 4};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{5, 6, 7, 8};
+    auto c = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *c = vector<float>{9, 10, 11, 12};
+    auto abc = ngraph::runtime::make_tuple({a, b, c});
+    auto bac = ngraph::runtime::make_tuple({b, a, c});
+    auto acb = ngraph::runtime::make_tuple({a, c, b});
+    auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
     auto result_tuple = ngraph::runtime::make_tuple({result});
 
     (*cf)({abc}, {result_tuple});
     ASSERT_EQ((vector<float>{54, 80, 110, 144}), result->get_vector());
-    
+
     (*cf)({bac}, {result_tuple});
     ASSERT_EQ((vector<float>{54, 80, 110, 144}), result->get_vector());
-    
+
     (*cf)({acb}, {result_tuple});
     ASSERT_EQ((vector<float>{50, 72, 98, 128}), result->get_vector());
 }
@@ -93,135 +93,122 @@ TEST(execute, test_abc_tuple)
 TEST(execute, test_abs)
 {
     auto shape = Shape{2, 2};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Abs>(A), op::Parameters{A});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Abs>(A), op::Parameters{A});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{1, -2, 0, -4.8f};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{1, -2, 0, -4.8f};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({a}, {result});
     ASSERT_EQ((vector<float>{1, 2, 0, 4.8f}), result->get_vector());
 }
 
-
-
 TEST(execute, test_concat_matrix_colwise)
 {
     auto shape_a = Shape{2, 2};
-    auto A       = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
     auto shape_b = Shape{2, 3};
-    auto B       = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
     auto shape_c = Shape{2, 3};
-    auto C       = make_shared<op::Parameter>(element::Float32::element_type(), shape_c);
+    auto C = make_shared<op::Parameter>(element::Float32::element_type(), shape_c);
     auto shape_r = Shape{2, 8};
-    auto f       = make_shared<Function>(make_shared<op::Concat>(Nodes{A,B,C},1), op::Parameters{A,B,C});
+    auto f =
+        make_shared<Function>(make_shared<op::Concat>(Nodes{A, B, C}, 1), op::Parameters{A, B, C});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape_a);
-    *a          = vector<float>{2,  4,
-                                8, 16};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape_b);
-    *b          = vector<float>{ 1, 2, 4,
-                                 8,16,32};
-    auto c      = ngraph::runtime::make_tensor<element::Float32>(shape_c);
-    *c          = vector<float>{ 2, 3, 5,
-                                 7,11,13};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape_a);
+    *a = vector<float>{2, 4, 8, 16};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape_b);
+    *b = vector<float>{1, 2, 4, 8, 16, 32};
+    auto c = ngraph::runtime::make_tensor<element::Float32>(shape_c);
+    *c = vector<float>{2, 3, 5, 7, 11, 13};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape_r);
 
-    (*cf)({a,b,c}, {result});
-    ASSERT_EQ((vector<float>{ 2,  4, 1,  2, 4, 2,  3,  5,
-                              8, 16, 8, 16,32, 7, 11, 13}), result->get_vector());
+    (*cf)({a, b, c}, {result});
+    ASSERT_EQ((vector<float>{2, 4, 1, 2, 4, 2, 3, 5, 8, 16, 8, 16, 32, 7, 11, 13}),
+              result->get_vector());
 }
 
 TEST(execute, test_concat_matrix_rowwise)
 {
     auto shape_a = Shape{2, 2};
-    auto A       = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
     auto shape_b = Shape{3, 2};
-    auto B       = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
     auto shape_c = Shape{3, 2};
-    auto C       = make_shared<op::Parameter>(element::Float32::element_type(), shape_c);
+    auto C = make_shared<op::Parameter>(element::Float32::element_type(), shape_c);
     auto shape_r = Shape{8, 2};
-    auto f       = make_shared<Function>(make_shared<op::Concat>(Nodes{A,B,C},0), op::Parameters{A,B,C});
+    auto f =
+        make_shared<Function>(make_shared<op::Concat>(Nodes{A, B, C}, 0), op::Parameters{A, B, C});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape_a);
-    *a          = vector<float>{2,  4,
-                                8, 16};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape_b);
-    *b          = vector<float>{ 1, 2,
-                                 4, 8,
-                                16,32};
-    auto c      = ngraph::runtime::make_tensor<element::Float32>(shape_c);
-    *c          = vector<float>{ 2, 3,
-                                 5, 7,
-                                11,13};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape_a);
+    *a = vector<float>{2, 4, 8, 16};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape_b);
+    *b = vector<float>{1, 2, 4, 8, 16, 32};
+    auto c = ngraph::runtime::make_tensor<element::Float32>(shape_c);
+    *c = vector<float>{2, 3, 5, 7, 11, 13};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape_r);
 
-    (*cf)({a,b,c}, {result});
-    ASSERT_EQ((vector<float>{ 2,  4,
-                              8, 16,
-                              1,  2,
-                              4,  8,
-                             16, 32,
-                              2,  3,
-                              5,  7,
-                             11, 13}), result->get_vector());
+    (*cf)({a, b, c}, {result});
+    ASSERT_EQ((vector<float>{2, 4, 8, 16, 1, 2, 4, 8, 16, 32, 2, 3, 5, 7, 11, 13}),
+              result->get_vector());
 }
 
 TEST(execute, test_concat_vector)
 {
     auto shape_a = Shape{4};
-    auto A       = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
     auto shape_b = Shape{6};
-    auto B       = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
     auto shape_c = Shape{2};
-    auto C       = make_shared<op::Parameter>(element::Float32::element_type(), shape_c);
+    auto C = make_shared<op::Parameter>(element::Float32::element_type(), shape_c);
     auto shape_r = Shape{12};
-    auto f       = make_shared<Function>(make_shared<op::Concat>(Nodes{A,B,C},0), op::Parameters{A,B,C});
+    auto f =
+        make_shared<Function>(make_shared<op::Concat>(Nodes{A, B, C}, 0), op::Parameters{A, B, C});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape_a);
-    *a          = vector<float>{2,4,8,16};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape_b);
-    *b          = vector<float>{1,2,4,8,16,32};
-    auto c      = ngraph::runtime::make_tensor<element::Float32>(shape_c);
-    *c          = vector<float>{18,19};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape_a);
+    *a = vector<float>{2, 4, 8, 16};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape_b);
+    *b = vector<float>{1, 2, 4, 8, 16, 32};
+    auto c = ngraph::runtime::make_tensor<element::Float32>(shape_c);
+    *c = vector<float>{18, 19};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape_r);
 
-    (*cf)({a,b,c}, {result});
-    ASSERT_EQ((vector<float>{2,4,8,16,1,2,4,8,16,32,18,19}), result->get_vector());
+    (*cf)({a, b, c}, {result});
+    ASSERT_EQ((vector<float>{2, 4, 8, 16, 1, 2, 4, 8, 16, 32, 18, 19}), result->get_vector());
 }
 
 TEST(execute, test_divide)
 {
     auto shape = Shape{2, 2};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Divide>(A, B), op::Parameters{A, B});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Divide>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{2, 4, 8, 16};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{1, 2, 4, 8};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{2, 4, 8, 16};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{1, 2, 4, 8};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({a, b}, {result});
@@ -231,18 +218,18 @@ TEST(execute, test_divide)
 TEST(execute, test_equal)
 {
     auto shape = Shape{2, 2, 2};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Equal>(A, B), op::Parameters{A, B});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Equal>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{1, 8, -8, 17, -0.5, 0, 1, 1};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{1, 8, 4, 8, 0, 0, 1, 1.5};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{1, 8, -8, 17, -0.5, 0, 1, 1};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{1, 8, 4, 8, 0, 0, 1, 1.5};
     auto result = ngraph::runtime::make_tensor<element::Bool>(shape);
 
     (*cf)({a, b}, {result});
@@ -251,66 +238,63 @@ TEST(execute, test_equal)
 
 TEST(execute, test_dot1d)
 {
-    auto shape   = Shape{4};
-    auto A       = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B       = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto shape = Shape{4};
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
     auto shape_r = Shape{1};
-    auto f       = make_shared<Function>(make_shared<op::Dot>(A,B), op::Parameters{A,B});
+    auto f = make_shared<Function>(make_shared<op::Dot>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{2, 4, 8, 16};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{1, 2, 4, 8};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{2, 4, 8, 16};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{1, 2, 4, 8};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape_r);
 
-    (*cf)({a,b}, {result});
+    (*cf)({a, b}, {result});
     ASSERT_EQ((vector<float>{170}), result->get_vector());
 }
 
 TEST(execute, test_dot2d)
 {
-    auto shape   = Shape{2,2};
-    auto A       = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B       = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto shape_r = Shape{2,2};
-    auto f       = make_shared<Function>(make_shared<op::Dot>(A,B), op::Parameters{A,B});
+    auto shape = Shape{2, 2};
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto shape_r = Shape{2, 2};
+    auto f = make_shared<Function>(make_shared<op::Dot>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{1, 2,
-                                3, 4};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{5, 6,
-                                7, 8};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{1, 2, 3, 4};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{5, 6, 7, 8};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape_r);
 
-    (*cf)({a,b}, {result});
-    ASSERT_EQ((vector<float>{19,22,
-                             43,50}), result->get_vector());
+    (*cf)({a, b}, {result});
+    ASSERT_EQ((vector<float>{19, 22, 43, 50}), result->get_vector());
 }
 
 TEST(execute, test_lessthan)
 {
     auto shape = Shape{2, 2, 2};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Less>(A, B), op::Parameters{A, B});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Less>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{1, 8, -8, 17, -0.5, 0.5, 2, 1};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{1, 2, 4, 8, 0, 0, 1, 1.5};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{1, 8, -8, 17, -0.5, 0.5, 2, 1};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{1, 2, 4, 8, 0, 0, 1, 1.5};
     auto result = ngraph::runtime::make_tensor<element::Bool>(shape);
 
     (*cf)({a, b}, {result});
@@ -320,15 +304,15 @@ TEST(execute, test_lessthan)
 TEST(execute, test_log)
 {
     auto shape = Shape{2, 2, 2};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Log>(A), op::Parameters{A});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Log>(A), op::Parameters{A});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
     auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a     = vector<float>{expf(1), expf(2), expf(3), expf(4), expf(5), expf(6), expf(7), expf(8)};
+    *a = vector<float>{expf(1), expf(2), expf(3), expf(4), expf(5), expf(6), expf(7), expf(8)};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({a}, {result});
@@ -338,18 +322,18 @@ TEST(execute, test_log)
 TEST(execute, test_maximum)
 {
     auto shape = Shape{2, 2, 2};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Maximum>(A, B), op::Parameters{A, B});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Maximum>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{1, 8, -8, 17, -0.5, 0.5, 2, 1};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{1, 2, 4, 8, 0, 0, 1, 1.5};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{1, 8, -8, 17, -0.5, 0.5, 2, 1};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{1, 2, 4, 8, 0, 0, 1, 1.5};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({a, b}, {result});
@@ -359,15 +343,15 @@ TEST(execute, test_maximum)
 TEST(execute, test_negative)
 {
     auto shape = Shape{2, 3};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Negative>(A), op::Parameters{A});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Negative>(A), op::Parameters{A});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{1, -2, 0, -4.8f, 8.6f, -8.6f};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{1, -2, 0, -4.8f, 8.6f, -8.6f};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({a}, {result});
@@ -377,18 +361,18 @@ TEST(execute, test_negative)
 TEST(execute, test_notequal)
 {
     auto shape = Shape{2, 2, 2};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::NotEqual>(A, B), op::Parameters{A, B});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::NotEqual>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{1, 8, -8, 17, -0.5, 0, 1, 1};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{1, 8, 4, 8, 0, 0, 1, 1.5};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{1, 8, -8, 17, -0.5, 0, 1, 1};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{1, 8, 4, 8, 0, 0, 1, 1.5};
     auto result = ngraph::runtime::make_tensor<element::Bool>(shape);
 
     (*cf)({a, b}, {result});
@@ -398,112 +382,109 @@ TEST(execute, test_notequal)
 TEST(execute, test_scalar_tensor_arg0)
 {
     auto shape_a = Shape{};
-    auto shape_b = Shape{2,2,2};
-    auto A       = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
-    auto B       = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
-    auto f       = make_shared<Function>(make_shared<op::Dot>(A,B), op::Parameters{A,B});
+    auto shape_b = Shape{2, 2, 2};
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
+    auto f = make_shared<Function>(make_shared<op::Dot>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape_a);
-    *a          = vector<float>{6};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape_b);
-    *b          = vector<float>{1, 2, 3, 4, 5, 6, 7, 8};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape_a);
+    *a = vector<float>{6};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape_b);
+    *b = vector<float>{1, 2, 3, 4, 5, 6, 7, 8};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape_b);
 
-    (*cf)({a,b}, {result});
+    (*cf)({a, b}, {result});
     ASSERT_EQ((vector<float>{6, 12, 18, 24, 30, 36, 42, 48}), result->get_vector());
 }
 
 TEST(execute, test_scalar_tensor_arg1)
 {
-    auto shape_a = Shape{2,2,2};
+    auto shape_a = Shape{2, 2, 2};
     auto shape_b = Shape{};
-    auto A       = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
-    auto B       = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
-    auto f       = make_shared<Function>(make_shared<op::Dot>(A,B), op::Parameters{A,B});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
+    auto f = make_shared<Function>(make_shared<op::Dot>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape_a);
-    *a          = vector<float>{1, 2, 3, 4, 5, 6, 7, 8};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape_b);
-    *b          = vector<float>{6};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape_a);
+    *a = vector<float>{1, 2, 3, 4, 5, 6, 7, 8};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape_b);
+    *b = vector<float>{6};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape_a);
 
-    (*cf)({a,b}, {result});
+    (*cf)({a, b}, {result});
     ASSERT_EQ((vector<float>{6, 12, 18, 24, 30, 36, 42, 48}), result->get_vector());
 }
 
 TEST(execute, test_scalar_scalar)
 {
     auto shape = Shape{};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Dot>(A,B), op::Parameters{A,B});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Dot>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{8};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{6};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{8};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{6};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
-    (*cf)({a,b}, {result});
+    (*cf)({a, b}, {result});
     ASSERT_EQ((vector<float>{48}), result->get_vector());
 }
 
 TEST(execute, test_matrix_vector)
 {
-    auto shape_a = Shape{4,4};
+    auto shape_a = Shape{4, 4};
     auto shape_b = Shape{4};
-    auto A       = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
-    auto B       = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
-    auto f       = make_shared<Function>(make_shared<op::Dot>(A,B), op::Parameters{A,B});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape_a);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape_b);
+    auto f = make_shared<Function>(make_shared<op::Dot>(A, B), op::Parameters{A, B});
     auto shape_r = Shape{4};
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape_a);
-    *a          = vector<float>{ 1, 2, 3, 4,
-                                 5, 6, 7, 8,
-                                 9,10,11,12,
-                                13,14,15,16};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape_b);
-    *b          = vector<float>{17,18,19,20};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape_a);
+    *a = vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape_b);
+    *b = vector<float>{17, 18, 19, 20};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape_r);
 
-    (*cf)({a,b}, {result});
-    ASSERT_EQ((vector<float>{190,486,782,1078}), result->get_vector());
+    (*cf)({a, b}, {result});
+    ASSERT_EQ((vector<float>{190, 486, 782, 1078}), result->get_vector());
 }
 
 TEST(execute, test_select)
 {
     auto shape = Shape{2, 2, 2};
-    auto A     = make_shared<op::Parameter>(element::Bool::element_type(), shape);
-    auto B     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto C     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Select>(A, B, C), op::Parameters{A, B, C});
+    auto A = make_shared<op::Parameter>(element::Bool::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto C = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Select>(A, B, C), op::Parameters{A, B, C});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Bool>(shape);
-    *a          = vector<char>{0, 1, 1, 0, 0, 1, 0, 1};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{1, 2, 3, 4, 5, 6, 7, 8};
-    auto c      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *c          = vector<float>{11, 12, 13, 14, 15, 16, 17, 18};
+    auto a = ngraph::runtime::make_tensor<element::Bool>(shape);
+    *a = vector<char>{0, 1, 1, 0, 0, 1, 0, 1};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{1, 2, 3, 4, 5, 6, 7, 8};
+    auto c = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *c = vector<float>{11, 12, 13, 14, 15, 16, 17, 18};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({a, b, c}, {result});
@@ -513,18 +494,18 @@ TEST(execute, test_select)
 TEST(execute, test_subtract)
 {
     auto shape = Shape{2, 2};
-    auto A     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto B     = make_shared<op::Parameter>(element::Float32::element_type(), shape);
-    auto f     = make_shared<Function>(make_shared<op::Subtract>(A, B), op::Parameters{A, B});
+    auto A = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto B = make_shared<op::Parameter>(element::Float32::element_type(), shape);
+    auto f = make_shared<Function>(make_shared<op::Subtract>(A, B), op::Parameters{A, B});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
-    auto a      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *a          = vector<float>{2, 4, 8, 16};
-    auto b      = ngraph::runtime::make_tensor<element::Float32>(shape);
-    *b          = vector<float>{1, 2, 4, 8};
+    auto a = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *a = vector<float>{2, 4, 8, 16};
+    auto b = ngraph::runtime::make_tensor<element::Float32>(shape);
+    *b = vector<float>{1, 2, 4, 8};
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({a, b}, {result});
@@ -534,11 +515,11 @@ TEST(execute, test_subtract)
 TEST(execute, test_scalar_constant)
 {
     auto shape = Shape{};
-    auto A     = make_shared<op::ScalarConstant<element::Float32>>(-3.0f);
-    auto f     = make_shared<Function>(A, op::Parameters{});
+    auto A = make_shared<op::ScalarConstant<element::Float32>>(-3.0f);
+    auto f = make_shared<Function>(A, op::Parameters{});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
@@ -549,34 +530,34 @@ TEST(execute, test_scalar_constant)
 
 TEST(execute, test_tensor_constant)
 {
-    auto shape = Shape{2,2,2};
-    auto A     = make_shared<op::TensorConstant<element::Float32>>(shape);
-    A->get_value()->get_vector() = {1,2,3,4,5,6,7,8};
-    auto f     = make_shared<Function>(A, op::Parameters{});
+    auto shape = Shape{2, 2, 2};
+    auto A = make_shared<op::TensorConstant<element::Float32>>(shape);
+    A->get_value()->get_vector() = {1, 2, 3, 4, 5, 6, 7, 8};
+    auto f = make_shared<Function>(A, op::Parameters{});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({}, {result});
-    ASSERT_EQ((vector<float>{1,2,3,4,5,6,7,8}), result->get_vector());
+    ASSERT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8}), result->get_vector());
 }
 
 TEST(execute, test_tensor_constant_with_op)
 {
-    auto shape = Shape{2,2,2};
-    auto A     = make_shared<op::TensorConstant<element::Float32>>(shape);
-    A->get_value()->get_vector() = {-1,2,3,-4,5,-6,-7,8};
-    auto f     = make_shared<Function>(make_shared<op::Abs>(A), op::Parameters{});
+    auto shape = Shape{2, 2, 2};
+    auto A = make_shared<op::TensorConstant<element::Float32>>(shape);
+    A->get_value()->get_vector() = {-1, 2, 3, -4, 5, -6, -7, 8};
+    auto f = make_shared<Function>(make_shared<op::Abs>(A), op::Parameters{});
 
     auto external = make_shared<ngraph::runtime::ExternalFunction>(f);
-    auto cf       = external->make_call_frame();
+    auto cf = external->make_call_frame();
 
     // Create some tensors for input/output
     auto result = ngraph::runtime::make_tensor<element::Float32>(shape);
 
     (*cf)({}, {result});
-    ASSERT_EQ((vector<float>{1,2,3,4,5,6,7,8}), result->get_vector());
+    ASSERT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8}), result->get_vector());
 }

--- a/test/input_output_assign.cpp
+++ b/test/input_output_assign.cpp
@@ -66,7 +66,7 @@ TEST(input_output, simple_output)
     auto tv_tp_0 = make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4});
     auto param_0 = make_shared<op::Parameter>(tv_tp_0);
     auto param_1 = make_shared<op::Parameter>(tv_tp_0);
-    auto add     = make_shared<op::Add>(param_0, param_1);
+    auto add = make_shared<op::Add>(param_0, param_1);
 
     // Sort the ops
     vector<shared_ptr<Node>> nodes;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -22,7 +22,7 @@ using namespace std;
 
 int main(int argc, char** argv)
 {
-    const char*   exclude = "--gtest_filter=-benchmark.*";
+    const char* exclude = "--gtest_filter=-benchmark.*";
     vector<char*> argv_vector;
     argv_vector.push_back(argv[0]);
     argv_vector.push_back((char*)exclude);

--- a/test/mkldnn.cpp
+++ b/test/mkldnn.cpp
@@ -13,19 +13,18 @@
 // ----------------------------------------------------------------------------
 
 #include <iostream>
-#include <vector>
 #include <mkldnn.hpp>
+#include <vector>
 
 #include "gtest/gtest.h"
 
-static int tensor_volume(const mkldnn::memory::dims &t)
+static int tensor_volume(const mkldnn::memory::dims& t)
 {
     int x = 1;
     for (const auto i : t)
         x *= i;
     return x;
 }
-
 
 TEST(mkldnn, engine)
 {
@@ -34,41 +33,55 @@ TEST(mkldnn, engine)
 #pragma GCC diagnostic ignored "-Wgnu-statement-expression"
 
     EXPECT_NO_THROW(({
-    auto cpu_engine = engine(engine::cpu, 0);
+        auto cpu_engine = engine(engine::cpu, 0);
 
-    const int mb = 2;
-    const int groups = 2;
-    memory::dims input_tz = {mb, 256, 13, 13};
-    memory::dims weights_tz = {groups, 384/groups, 256/groups, 3, 3};
-    memory::dims bias_tz = {384};
-    memory::dims strides = {1, 1};
-    memory::dims padding = {0, 0};
-    memory::dims output_tz = {mb, 384,
-        (input_tz[2] + 2*padding[0] - weights_tz[3])/strides[0] + 1,
-        (input_tz[3] + 2*padding[1] - weights_tz[4])/strides[1] + 1,
-    };
+        const int mb = 2;
+        const int groups = 2;
+        memory::dims input_tz = {mb, 256, 13, 13};
+        memory::dims weights_tz = {groups, 384 / groups, 256 / groups, 3, 3};
+        memory::dims bias_tz = {384};
+        memory::dims strides = {1, 1};
+        memory::dims padding = {0, 0};
+        memory::dims output_tz = {
+            mb,
+            384,
+            (input_tz[2] + 2 * padding[0] - weights_tz[3]) / strides[0] + 1,
+            (input_tz[3] + 2 * padding[1] - weights_tz[4]) / strides[1] + 1,
+        };
 
-    std::vector<float> input(tensor_volume(input_tz), .0f);
-    std::vector<float> weights(tensor_volume(weights_tz), .0f);
-    std::vector<float> bias(tensor_volume(bias_tz), .0f);
-    std::vector<float> output(tensor_volume(output_tz), .0f);
+        std::vector<float> input(tensor_volume(input_tz), .0f);
+        std::vector<float> weights(tensor_volume(weights_tz), .0f);
+        std::vector<float> bias(tensor_volume(bias_tz), .0f);
+        std::vector<float> output(tensor_volume(output_tz), .0f);
 
-    auto c3_src_desc = memory::desc({input_tz}, memory::data_type::f32, memory::format::nchw);
-    auto c3_weights_desc = memory::desc({weights_tz}, memory::data_type::f32, memory::format::goihw);
-    auto c3_bias_desc = memory::desc({bias_tz}, memory::data_type::f32, memory::format::x);
-    auto c3_dst_desc = memory::desc({output_tz}, memory::data_type::f32, memory::format::nchw);
+        auto c3_src_desc = memory::desc({input_tz}, memory::data_type::f32, memory::format::nchw);
+        auto c3_weights_desc =
+            memory::desc({weights_tz}, memory::data_type::f32, memory::format::goihw);
+        auto c3_bias_desc = memory::desc({bias_tz}, memory::data_type::f32, memory::format::x);
+        auto c3_dst_desc = memory::desc({output_tz}, memory::data_type::f32, memory::format::nchw);
 
-    auto c3_src = memory({c3_src_desc, cpu_engine}, input.data());
-    auto c3_weights = memory({c3_weights_desc, cpu_engine}, weights.data());
-    auto c3_bias = memory({c3_bias_desc, cpu_engine}, bias.data());
-    auto c3_dst = memory({c3_dst_desc, cpu_engine}, output.data());
+        auto c3_src = memory({c3_src_desc, cpu_engine}, input.data());
+        auto c3_weights = memory({c3_weights_desc, cpu_engine}, weights.data());
+        auto c3_bias = memory({c3_bias_desc, cpu_engine}, bias.data());
+        auto c3_dst = memory({c3_dst_desc, cpu_engine}, output.data());
 
-    auto c3 = convolution_forward(convolution_forward::primitive_desc(convolution_forward::desc(prop_kind::forward,
-                                                                                                algorithm::convolution_direct,
-                                                                                                c3_src_desc, c3_weights_desc, c3_bias_desc, c3_dst_desc,
-                                                                                                strides, padding, padding, padding_kind::zero),
-                                                                      cpu_engine), c3_src, c3_weights, c3_bias, c3_dst);
+        auto c3 = convolution_forward(convolution_forward::primitive_desc(
+                                          convolution_forward::desc(prop_kind::forward,
+                                                                    algorithm::convolution_direct,
+                                                                    c3_src_desc,
+                                                                    c3_weights_desc,
+                                                                    c3_bias_desc,
+                                                                    c3_dst_desc,
+                                                                    strides,
+                                                                    padding,
+                                                                    padding,
+                                                                    padding_kind::zero),
+                                          cpu_engine),
+                                      c3_src,
+                                      c3_weights,
+                                      c3_bias,
+                                      c3_dst);
 
-    stream(stream::kind::eager).submit({c3}).wait();
+        stream(stream::kind::eager).submit({c3}).wait();
     }));
 }

--- a/test/pass_liveness.cpp
+++ b/test/pass_liveness.cpp
@@ -19,16 +19,16 @@
 
 #include "gtest/gtest.h"
 
-#include "ngraph/pass/liveness.hpp"
+#include "ngraph/log.hpp"
+#include "ngraph/ngraph.hpp"
 #include "ngraph/pass/assign_tensors.hpp"
+#include "ngraph/pass/dump_sorted.hpp"
+#include "ngraph/pass/liveness.hpp"
+#include "ngraph/pass/liveness.hpp"
 #include "ngraph/pass/manager.hpp"
 #include "ngraph/pass/propagate_types.hpp"
 #include "ngraph/pass/topological_sort.hpp"
-#include "ngraph/pass/liveness.hpp"
 #include "ngraph/pass/visualize_tree.hpp"
-#include "ngraph/pass/dump_sorted.hpp"
-#include "ngraph/ngraph.hpp"
-#include "ngraph/log.hpp"
 
 #include "test_tools.hpp"
 
@@ -49,7 +49,7 @@ TEST(pass, liveness)
     pass_manager.register_pass<pass::Liveness>();
     pass_manager.register_pass<pass::DumpSorted>(dump_file);
 
-    shared_ptr<Function>   func      = make_test_graph();
+    shared_ptr<Function> func = make_test_graph();
     pass_manager.run_passes(func.get());
     auto sorted = pass_manager.get_call_graph();
 
@@ -80,8 +80,6 @@ TEST(pass, liveness)
 
     // auto exc = ex.executor(seq_stuff);
     // return exc;
-
-
 
     // lg = LivenessGraph(exc.exop.ops)
     // lg.layout_memory()

--- a/test/pass_manager.cpp
+++ b/test/pass_manager.cpp
@@ -37,7 +37,7 @@ TEST(pass_manager, add)
     pass_manager.register_pass<pass::PropagateTypes>();
     pass_manager.register_pass<pass::AssignTensors>();
 
-    auto   graph      = make_test_graph();
+    auto graph = make_test_graph();
     size_t node_count = get_node_count(graph->get_result());
     pass_manager.run_passes(graph.get());
     auto sorted = pass_manager.get_call_graph();

--- a/test/pass_memory_layout.cpp
+++ b/test/pass_memory_layout.cpp
@@ -20,15 +20,15 @@
 #include "gtest/gtest.h"
 
 #include "ngraph/ngraph.hpp"
-#include "ngraph/pass/liveness.hpp"
 #include "ngraph/pass/assign_tensors.hpp"
+#include "ngraph/pass/dump_sorted.hpp"
+#include "ngraph/pass/liveness.hpp"
+#include "ngraph/pass/liveness.hpp"
 #include "ngraph/pass/manager.hpp"
+#include "ngraph/pass/memory_layout.hpp"
 #include "ngraph/pass/propagate_types.hpp"
 #include "ngraph/pass/topological_sort.hpp"
-#include "ngraph/pass/liveness.hpp"
 #include "ngraph/pass/visualize_tree.hpp"
-#include "ngraph/pass/dump_sorted.hpp"
-#include "ngraph/pass/memory_layout.hpp"
 #include "test_tools.hpp"
 
 using namespace ngraph;

--- a/test/runtime.cpp
+++ b/test/runtime.cpp
@@ -30,22 +30,22 @@ namespace ngeigen = ngraph::runtime::eigen;
 
 TEST(runtime, test_add)
 {
-    auto x          = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto x = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
     x->get_vector() = {1, 2, 3, 4};
-    auto y          = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto y = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
     y->get_vector() = {5, 6, 7, 8};
-    auto z          = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto z = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
     ngraph::runtime::eigen::add(x, y, z);
     ASSERT_EQ((vector<float>{6, 8, 10, 12}), z->get_vector());
 }
 
 TEST(runtime, test_multiply)
 {
-    auto x          = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto x = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
     x->get_vector() = {1, 2, 3, 4};
-    auto y          = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto y = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
     y->get_vector() = {5, 6, 7, 8};
-    auto z          = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto z = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
     ngraph::runtime::eigen::multiply(x, y, z);
     ASSERT_EQ((vector<float>{5, 12, 21, 32}), z->get_vector());
 }
@@ -71,13 +71,13 @@ TEST(runtime, test_add_multiply)
         3, 1, {ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2})}, 0, instructions};
 
     // Create some tensors for input/output
-    auto a          = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto a = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
     a->get_vector() = {1, 2, 3, 4};
-    auto b          = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto b = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
     b->get_vector() = {5, 6, 7, 8};
-    auto c          = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto c = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
     c->get_vector() = {9, 10, 11, 12};
-    auto result     = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
+    auto result = ngraph::runtime::make_tensor<element::Float32>(Shape{2, 2});
 
     cf({a, b, c}, {result});
     ASSERT_EQ((vector<float>{54, 80, 110, 144}), result->get_vector());

--- a/test/tensor.cpp
+++ b/test/tensor.cpp
@@ -13,19 +13,19 @@
 // ----------------------------------------------------------------------------
 
 #include <memory>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <memory>
 
 #include "gtest/gtest.h"
+#include "ngraph/function.hpp"
 #include "ngraph/ngraph.hpp"
 #include "ngraph/pass/assign_tensors.hpp"
+#include "ngraph/pass/liveness.hpp"
 #include "ngraph/pass/manager.hpp"
 #include "ngraph/pass/propagate_types.hpp"
-#include "ngraph/pass/liveness.hpp"
 #include "ngraph/pass/topological_sort.hpp"
-#include "ngraph/function.hpp"
 #include "test_tools.hpp"
 
 using namespace std;
@@ -43,8 +43,8 @@ TEST(tensor, size)
 
     {
         auto arg0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3});
-        auto add  = make_shared<op::Add>(arg0, arg0);
-        auto f0   = make_shared<Function>(add, op::Parameters{arg0});
+        auto add = make_shared<op::Add>(arg0, arg0);
+        auto f0 = make_shared<Function>(add, op::Parameters{arg0});
 
         pass_manager.run_passes(f0);
 
@@ -56,8 +56,8 @@ TEST(tensor, size)
 
     {
         auto arg0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{});
-        auto add  = make_shared<op::Add>(arg0, arg0);
-        auto f0   = make_shared<Function>(add, op::Parameters{arg0});
+        auto add = make_shared<op::Add>(arg0, arg0);
+        auto f0 = make_shared<Function>(add, op::Parameters{arg0});
 
         pass_manager.run_passes(f0);
 
@@ -69,8 +69,8 @@ TEST(tensor, size)
 
     {
         auto arg0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{1});
-        auto add  = make_shared<op::Add>(arg0, arg0);
-        auto f0   = make_shared<Function>(add, op::Parameters{arg0});
+        auto add = make_shared<op::Add>(arg0, arg0);
+        auto f0 = make_shared<Function>(add, op::Parameters{arg0});
 
         pass_manager.run_passes(f0);
 

--- a/test/test_tools.cpp
+++ b/test/test_tools.cpp
@@ -14,9 +14,9 @@
 
 #include <algorithm>
 
-#include "test_tools.hpp"
 #include "ngraph/ngraph.hpp"
 #include "ngraph/util.hpp"
+#include "test_tools.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -28,8 +28,8 @@ bool validate_list(const list<Node*>& nodes)
     bool rc = true;
     for (auto it = nodes.rbegin(); it != nodes.rend(); it++)
     {
-        auto          node_tmp         = *it;
-        auto          dependencies_tmp = node_tmp->get_arguments();
+        auto node_tmp = *it;
+        auto dependencies_tmp = node_tmp->get_arguments();
         vector<Node*> dependencies;
         for (shared_ptr<Node> n : dependencies_tmp)
         {
@@ -39,7 +39,7 @@ bool validate_list(const list<Node*>& nodes)
         for (; tmp != nodes.rend(); tmp++)
         {
             auto dep_tmp = *tmp;
-            auto found   = find(dependencies.begin(), dependencies.end(), dep_tmp);
+            auto found = find(dependencies.begin(), dependencies.end(), dep_tmp);
             if (found != dependencies.end())
             {
                 dependencies.erase(found);
@@ -79,9 +79,6 @@ shared_ptr<Function> make_test_graph()
 size_t get_node_count(std::shared_ptr<Node> n)
 {
     size_t node_count = 0;
-    traverse_nodes(n, [&](const Node* node) {
-        node_count++;
-    });
+    traverse_nodes(n, [&](const Node* node) { node_count++; });
     return node_count;
 }
-

--- a/test/topological_sort.cpp
+++ b/test/topological_sort.cpp
@@ -19,12 +19,12 @@
 
 #include "gtest/gtest.h"
 
+#include "ngraph/log.hpp"
 #include "ngraph/ngraph.hpp"
 #include "ngraph/pass/manager.hpp"
 #include "ngraph/pass/topological_sort.hpp"
-#include "ngraph/visualize.hpp"
 #include "ngraph/util.hpp"
-#include "ngraph/log.hpp"
+#include "ngraph/visualize.hpp"
 #include "test_tools.hpp"
 
 using namespace std;
@@ -103,7 +103,7 @@ TEST(benchmark, topological_sort)
     shared_ptr<Node> result;
     vector<shared_ptr<op::Parameter>> args;
     result = make_shared<op::Parameter>(element::Float32::element_type(), Shape{1});
-    for (int i=0; i<1000000; i++)
+    for (int i = 0; i < 1000000; i++)
     {
         auto in_1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{1});
         auto in_2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{1});
@@ -122,9 +122,7 @@ TEST(benchmark, topological_sort)
     NGRAPH_INFO << "topological sort took " << timer.get_milliseconds() << "ms";
 
     size_t node_count = 0;
-    traverse_nodes(result, [&](const Node* node) {
-        node_count++;
-    });
+    traverse_nodes(result, [&](const Node* node) { node_count++; });
 
     NGRAPH_INFO << "node count " << node_count;
 

--- a/test/type_prop.cpp
+++ b/test/type_prop.cpp
@@ -32,7 +32,7 @@ TEST(type_prop, broadcast_deduce)
 {
     // Deduce type
     auto param = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 4});
-    auto bc    = make_shared<op::Broadcast>(param, Shape{2, 3, 4}, AxisSet{1});
+    auto bc = make_shared<op::Broadcast>(param, Shape{2, 3, 4}, AxisSet{1});
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
     ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{2, 3, 4}));
@@ -42,7 +42,7 @@ TEST(type_prop, broadcast_deduce_correct)
 {
     // Check deduced type against correctly specified type
     auto param = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 4});
-    auto bc    = make_shared<op::Broadcast>(param, Shape{2, 3, 4}, AxisSet{1});
+    auto bc = make_shared<op::Broadcast>(param, Shape{2, 3, 4}, AxisSet{1});
     bc->set_value_type(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 3, 4}));
     bc->propagate_types();
@@ -54,7 +54,7 @@ TEST(type_prop, broadcast_deduce_incorrect)
 {
     // Check deduced type against incorrectly specified type
     auto param = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 4});
-    auto bc    = make_shared<op::Broadcast>(param, Shape{2, 4, 3}, AxisSet{1});
+    auto bc = make_shared<op::Broadcast>(param, Shape{2, 4, 3}, AxisSet{1});
     bc->set_value_type(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 3, 4}));
     try
@@ -77,7 +77,7 @@ TEST(type_prop, broadcast_bad_arguments)
 {
     // Check for bad arguments
     auto param = make_shared<op::Parameter>(make_shared<TupleType>());
-    auto bc    = make_shared<op::Broadcast>(param, Shape{2, 4, 3}, AxisSet{1});
+    auto bc = make_shared<op::Broadcast>(param, Shape{2, 4, 3}, AxisSet{1});
     try
     {
         bc->propagate_types();
@@ -100,9 +100,9 @@ TEST(type_prop, concat_deduce)
     auto param0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3, 4});
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 7, 4});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 2, 4});
-    auto c      = make_shared<op::Concat>(Nodes{param0,param1,param2}, 1);
+    auto c = make_shared<op::Concat>(Nodes{param0, param1, param2}, 1);
     c->propagate_types();
-    auto c_vt   = c->get_value_type();
+    auto c_vt = c->get_value_type();
     ASSERT_EQ(*c_vt, TensorViewType(element::Float32::element_type(), Shape{2, 12, 4}));
 }
 
@@ -112,7 +112,7 @@ TEST(type_prop, concat_deduce_incorrect)
     auto param0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3, 4});
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 7, 4});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 2, 4});
-    auto c      = make_shared<op::Concat>(Nodes{param0,param1,param2}, 1);
+    auto c = make_shared<op::Concat>(Nodes{param0, param1, param2}, 1);
     c->set_value_type(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 14, 4}));
     try
@@ -135,8 +135,11 @@ TEST(type_prop, concat_deduce_wrong_rank)
 {
     auto param0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3, 4});
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 7, 4});
-    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 2,});
-    auto c      = make_shared<op::Concat>(Nodes{param0,param1,param2}, 1);
+    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(),
+                                             Shape{
+                                                 2, 2,
+                                             });
+    auto c = make_shared<op::Concat>(Nodes{param0, param1, param2}, 1);
     try
     {
         c->propagate_types();
@@ -158,7 +161,7 @@ TEST(type_prop, concat_deduce_wrong_shape)
     auto param0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3, 4});
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 7, 4});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 2, 5});
-    auto c      = make_shared<op::Concat>(Nodes{param0,param1,param2}, 1);
+    auto c = make_shared<op::Concat>(Nodes{param0, param1, param2}, 1);
     try
     {
         c->propagate_types();
@@ -167,7 +170,10 @@ TEST(type_prop, concat_deduce_wrong_shape)
     }
     catch (const ngraph_error& error)
     {
-        EXPECT_EQ(error.what(), std::string("Arguments to concat do not have same dimension on a non-concatenation axis"));
+        EXPECT_EQ(
+            error.what(),
+            std::string(
+                "Arguments to concat do not have same dimension on a non-concatenation axis"));
     }
     catch (...)
     {
@@ -180,7 +186,7 @@ TEST(type_prop, concat_deduce_axis_oob)
     auto param0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3, 4});
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 7, 4});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 2, 5});
-    auto c      = make_shared<op::Concat>(Nodes{param0,param1,param2}, 3);
+    auto c = make_shared<op::Concat>(Nodes{param0, param1, param2}, 3);
     try
     {
         c->propagate_types();
@@ -203,9 +209,9 @@ TEST(type_prop, concat_deduce_axis_barely_in_bounds)
     auto param0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3, 4});
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3, 8});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3, 12});
-    auto c      = make_shared<op::Concat>(Nodes{param0,param1,param2}, 2);
+    auto c = make_shared<op::Concat>(Nodes{param0, param1, param2}, 2);
     c->propagate_types();
-    auto c_vt   = c->get_value_type();
+    auto c_vt = c->get_value_type();
     ASSERT_EQ(*c_vt, TensorViewType(element::Float32::element_type(), Shape{2, 3, 24}));
 }
 
@@ -214,7 +220,7 @@ TEST(type_prop, concat_deduce_elem_type_mismatch)
     auto param0 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3, 4});
     auto param1 = make_shared<op::Parameter>(element::Int32::element_type(), Shape{2, 7, 4});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 2, 4});
-    auto c      = make_shared<op::Concat>(Nodes{param0,param1,param2}, 1);
+    auto c = make_shared<op::Concat>(Nodes{param0, param1, param2}, 1);
     try
     {
         c->propagate_types();
@@ -238,22 +244,22 @@ TEST(type_prop, dot_deduce_scalar_2d)
 {
     // Deduce type for scalar/matrix arguments
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{});
-    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4,5});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4, 5});
+    auto bc = make_shared<op::Dot>(param1, param2);
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
-    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{4,5}));
+    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{4, 5}));
 }
 
 TEST(type_prop, dot_deduce_2d_scalar)
 {
     // Deduce type for matrix/scalar arguments
-    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4,5});
+    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4, 5});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto bc = make_shared<op::Dot>(param1, param2);
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
-    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{4,5}));
+    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{4, 5}));
 }
 
 TEST(type_prop, dot_deduce_scalar_scalar)
@@ -261,7 +267,7 @@ TEST(type_prop, dot_deduce_scalar_scalar)
     // Deduce type for scalar/scalar arguments
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto bc = make_shared<op::Dot>(param1, param2);
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
     ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{}));
@@ -272,7 +278,7 @@ TEST(type_prop, dot_deduce_scalar_1d)
     // Deduce type for scalar/vector arguments
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{6});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto bc = make_shared<op::Dot>(param1, param2);
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
     ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{6}));
@@ -283,7 +289,7 @@ TEST(type_prop, dot_deduce_1d)
     // Deduce type for vector/vector arguments
     auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4});
     auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto bc = make_shared<op::Dot>(param1, param2);
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
     ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{}));
@@ -292,44 +298,44 @@ TEST(type_prop, dot_deduce_1d)
 TEST(type_prop, dot_deduce_2d)
 {
     // Deduce type for matrix/matrix arguments
-    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4,2});
-    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2,3});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4, 2});
+    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 3});
+    auto bc = make_shared<op::Dot>(param1, param2);
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
-    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{4,3}));
+    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{4, 3}));
 }
 
 TEST(type_prop, dot_deduce_different_rank)
 {
     // Deduce type for different-rank tensor arguments
-    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2,8,4,2});
-    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{1,2,3});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 8, 4, 2});
+    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{1, 2, 3});
+    auto bc = make_shared<op::Dot>(param1, param2);
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
-    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{2,8,4,1,3}));
+    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{2, 8, 4, 1, 3}));
 }
 
 TEST(type_prop, dot_deduce_different_rank_correct)
 {
     // Deduced type matches explicitly set type
-    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2,8,4,2});
-    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{1,2,3});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{2, 8, 4, 2});
+    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{1, 2, 3});
+    auto bc = make_shared<op::Dot>(param1, param2);
     bc->set_value_type(
-        make_shared<TensorViewType>(element::Float32::element_type(), Shape{2,8,4,1,3}));
+        make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 8, 4, 1, 3}));
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
-    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{2,8,4,1,3}));
+    ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{2, 8, 4, 1, 3}));
 }
 
 TEST(type_prop, dot_deduce_element_type_mismatch)
 {
     // Type deduction fails due to element type mismatch
-    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4,2});
-    auto param2 = make_shared<op::Parameter>(element::Int32::element_type(), Shape{2,5});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4, 2});
+    auto param2 = make_shared<op::Parameter>(element::Int32::element_type(), Shape{2, 5});
+    auto bc = make_shared<op::Dot>(param1, param2);
     try
     {
         bc->propagate_types();
@@ -349,9 +355,9 @@ TEST(type_prop, dot_deduce_element_type_mismatch)
 TEST(type_prop, dot_deduce_reduction_axes_size_mismatch)
 {
     // Type deduction fails due to reduction axes size mismatch
-    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4,2});
-    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{3,5});
-    auto bc     = make_shared<op::Dot>(param1, param2);
+    auto param1 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{4, 2});
+    auto param2 = make_shared<op::Parameter>(element::Float32::element_type(), Shape{3, 5});
+    auto bc = make_shared<op::Dot>(param1, param2);
     try
     {
         bc->propagate_types();
@@ -417,7 +423,8 @@ void test_binary_bad_arguments_view_element_types(const shared_ptr<Node>& node)
     }
     catch (const ngraph_error& error)
     {
-        EXPECT_EQ(error.what(), std::string("Arguments must have the same tensor view element type"));
+        EXPECT_EQ(error.what(),
+                  std::string("Arguments must have the same tensor view element type"));
     }
     catch (...)
     {
@@ -434,8 +441,8 @@ void test_binary_good_arguments(const shared_ptr<Node>& node)
 void test_binary(shared_ptr<Node>(f)(const shared_ptr<Node>& x, const shared_ptr<Node>& y))
 {
     // Check for bad arguments
-    auto tp0_param       = make_shared<op::Parameter>(make_shared<TupleType>());
-    auto tp1_param       = make_shared<op::Parameter>(make_shared<TupleType>());
+    auto tp0_param = make_shared<op::Parameter>(make_shared<TupleType>());
+    auto tp1_param = make_shared<op::Parameter>(make_shared<TupleType>());
     auto tv0_2_4_param_0 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
     auto tv0_2_4_param_1 = make_shared<op::Parameter>(
@@ -487,10 +494,10 @@ TEST(type_prop, comparison_good)
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
     auto tv0_2_4_param_1 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
-    auto eq = make_shared<op::Equal>(tv0_2_4_param_0,tv0_2_4_param_1);
+    auto eq = make_shared<op::Equal>(tv0_2_4_param_0, tv0_2_4_param_1);
     TensorViewType expected_type{element::Bool::element_type(), Shape{2, 4}};
     eq->propagate_types();
-    EXPECT_EQ(*eq->get_value_type(),expected_type);
+    EXPECT_EQ(*eq->get_value_type(), expected_type);
 }
 
 TEST(type_prop, binary_arithmetic_bad_argument_element_types)
@@ -499,7 +506,7 @@ TEST(type_prop, binary_arithmetic_bad_argument_element_types)
         make_shared<TensorViewType>(element::Bool::element_type(), Shape{2, 4}));
     auto tv0_2_4_param_1 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Bool::element_type(), Shape{2, 4}));
-    auto bc = make_shared<op::Add>(tv0_2_4_param_0,tv0_2_4_param_1);
+    auto bc = make_shared<op::Add>(tv0_2_4_param_0, tv0_2_4_param_1);
     try
     {
         bc->propagate_types();
@@ -508,7 +515,8 @@ TEST(type_prop, binary_arithmetic_bad_argument_element_types)
     }
     catch (const ngraph_error& error)
     {
-        EXPECT_EQ(error.what(), std::string("Operands for arithmetic operators must have numeric element type"));
+        EXPECT_EQ(error.what(),
+                  std::string("Operands for arithmetic operators must have numeric element type"));
     }
     catch (...)
     {
@@ -529,7 +537,8 @@ TEST(type_prop, unary_arithmetic_bad_argument_element_types)
     }
     catch (const ngraph_error& error)
     {
-        EXPECT_EQ(error.what(), std::string("Operands for arithmetic operators must have numeric element type"));
+        EXPECT_EQ(error.what(),
+                  std::string("Operands for arithmetic operators must have numeric element type"));
     }
     catch (...)
     {
@@ -545,7 +554,7 @@ TEST(type_prop, select_deduce)
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
     auto tv0_2_4_param_2 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
-    auto bc = make_shared<op::Select>(tv0_2_4_param_0,tv0_2_4_param_1,tv0_2_4_param_2);
+    auto bc = make_shared<op::Select>(tv0_2_4_param_0, tv0_2_4_param_1, tv0_2_4_param_2);
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
     ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{2, 4}));
@@ -559,9 +568,8 @@ TEST(type_prop, select_deduce_correct)
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
     auto tv0_2_4_param_2 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
-    auto bc = make_shared<op::Select>(tv0_2_4_param_0,tv0_2_4_param_1,tv0_2_4_param_2);
-    bc->set_value_type(
-        make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
+    auto bc = make_shared<op::Select>(tv0_2_4_param_0, tv0_2_4_param_1, tv0_2_4_param_2);
+    bc->set_value_type(make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
     bc->propagate_types();
     auto bc_vt = bc->get_value_type();
     ASSERT_EQ(*bc_vt, TensorViewType(element::Float32::element_type(), Shape{2, 4}));
@@ -575,7 +583,7 @@ TEST(type_prop, select_shape_mismatch_a)
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
     auto tv0_2_4_param_2 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
-    auto bc = make_shared<op::Select>(tv0_2_4_param_0,tv0_2_4_param_1,tv0_2_4_param_2);
+    auto bc = make_shared<op::Select>(tv0_2_4_param_0, tv0_2_4_param_1, tv0_2_4_param_2);
     try
     {
         bc->propagate_types();
@@ -600,7 +608,7 @@ TEST(type_prop, select_shape_mismatch_b)
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{3, 5}));
     auto tv0_2_4_param_2 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
-    auto bc = make_shared<op::Select>(tv0_2_4_param_0,tv0_2_4_param_1,tv0_2_4_param_2);
+    auto bc = make_shared<op::Select>(tv0_2_4_param_0, tv0_2_4_param_1, tv0_2_4_param_2);
     try
     {
         bc->propagate_types();
@@ -625,7 +633,7 @@ TEST(type_prop, select_shape_mismatch_c)
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
     auto tv0_2_4_param_2 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{3, 5}));
-    auto bc = make_shared<op::Select>(tv0_2_4_param_0,tv0_2_4_param_1,tv0_2_4_param_2);
+    auto bc = make_shared<op::Select>(tv0_2_4_param_0, tv0_2_4_param_1, tv0_2_4_param_2);
     try
     {
         bc->propagate_types();
@@ -650,7 +658,7 @@ TEST(type_prop, select_elem_mismatch_a)
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
     auto tv0_2_4_param_2 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
-    auto bc = make_shared<op::Select>(tv0_2_4_param_0,tv0_2_4_param_1,tv0_2_4_param_2);
+    auto bc = make_shared<op::Select>(tv0_2_4_param_0, tv0_2_4_param_1, tv0_2_4_param_2);
     try
     {
         bc->propagate_types();
@@ -659,7 +667,9 @@ TEST(type_prop, select_elem_mismatch_a)
     }
     catch (const ngraph_error& error)
     {
-        EXPECT_EQ(error.what(), std::string("Argument 0 for arithmetic operators must have boolean element type"));
+        EXPECT_EQ(
+            error.what(),
+            std::string("Argument 0 for arithmetic operators must have boolean element type"));
     }
     catch (...)
     {
@@ -675,7 +685,7 @@ TEST(type_prop, select_elem_mismatch_bc)
         make_shared<TensorViewType>(element::Float32::element_type(), Shape{2, 4}));
     auto tv0_2_4_param_2 = make_shared<op::Parameter>(
         make_shared<TensorViewType>(element::Int32::element_type(), Shape{2, 4}));
-    auto bc = make_shared<op::Select>(tv0_2_4_param_0,tv0_2_4_param_1,tv0_2_4_param_2);
+    auto bc = make_shared<op::Select>(tv0_2_4_param_0, tv0_2_4_param_1, tv0_2_4_param_2);
     try
     {
         bc->propagate_types();
@@ -684,11 +694,11 @@ TEST(type_prop, select_elem_mismatch_bc)
     }
     catch (const ngraph_error& error)
     {
-        EXPECT_EQ(error.what(), std::string("Arguments 1 and 2 must have the same tensor view type"));
+        EXPECT_EQ(error.what(),
+                  std::string("Arguments 1 and 2 must have the same tensor view type"));
     }
     catch (...)
     {
         FAIL() << "Deduced type check failed for unexpected reason";
     }
 }
-

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -27,7 +27,7 @@ TEST(util, split)
 {
     {
         string s1 = "this,is,a,test";
-        auto   r1 = split(s1, ',');
+        auto r1 = split(s1, ',');
         ASSERT_EQ(4, r1.size());
         EXPECT_STRCASEEQ("this", r1[0].c_str());
         EXPECT_STRCASEEQ("is", r1[1].c_str());
@@ -37,7 +37,7 @@ TEST(util, split)
 
     {
         string s1 = "this,is,a,test,";
-        auto   r1 = split(s1, ',');
+        auto r1 = split(s1, ',');
         ASSERT_EQ(5, r1.size());
         EXPECT_STRCASEEQ("this", r1[0].c_str());
         EXPECT_STRCASEEQ("is", r1[1].c_str());
@@ -48,7 +48,7 @@ TEST(util, split)
 
     {
         string s1 = ",this,is,a,test";
-        auto   r1 = split(s1, ',');
+        auto r1 = split(s1, ',');
         ASSERT_EQ(5, r1.size());
         EXPECT_STRCASEEQ("", r1[0].c_str());
         EXPECT_STRCASEEQ("this", r1[1].c_str());
@@ -59,7 +59,7 @@ TEST(util, split)
 
     {
         string s1 = "this,,is,a,test";
-        auto   r1 = split(s1, ',');
+        auto r1 = split(s1, ',');
         ASSERT_EQ(5, r1.size());
         EXPECT_STRCASEEQ("this", r1[0].c_str());
         EXPECT_STRCASEEQ("", r1[1].c_str());
@@ -70,14 +70,14 @@ TEST(util, split)
 
     {
         string s1 = "this";
-        auto   r1 = split(s1, ',');
+        auto r1 = split(s1, ',');
         ASSERT_EQ(1, r1.size());
         EXPECT_STRCASEEQ("this", r1[0].c_str());
     }
 
     {
         string s1 = "";
-        auto   r1 = split(s1, ',');
+        auto r1 = split(s1, ',');
         ASSERT_EQ(1, r1.size());
         EXPECT_STRCASEEQ("", r1[0].c_str());
     }
@@ -134,36 +134,38 @@ TEST(util, contains)
     EXPECT_FALSE(contains(v1, 8));
 }
 
-TEST(util, remove_from) {}
+TEST(util, remove_from)
+{
+}
 
 TEST(util, reduce)
 {
     {
         std::vector<size_t> x = {};
-        size_t              actual =
+        size_t actual =
             ngraph::reduce(x.begin(), x.end(), [](size_t a, size_t b) { return a + b; });
         EXPECT_EQ(actual, 0);
     }
     {
         std::vector<size_t> x = {10};
-        size_t              actual =
+        size_t actual =
             ngraph::reduce(x.begin(), x.end(), [](size_t a, size_t b) { return a + b; });
         EXPECT_EQ(actual, 10);
     }
     {
         std::vector<size_t> x = {1, 2, 3, 4, 5, 6};
-        size_t              actual =
+        size_t actual =
             ngraph::reduce(x.begin(), x.end(), [](size_t a, size_t b) { return a + b; });
         EXPECT_EQ(actual, 21);
     }
     {
-        std::vector<size_t> x      = {1, 2, 3, 4, 5, 6};
-        size_t              actual = ngraph::reduce(x.begin(), x.end(), ngraph::plus<size_t>);
+        std::vector<size_t> x = {1, 2, 3, 4, 5, 6};
+        size_t actual = ngraph::reduce(x.begin(), x.end(), ngraph::plus<size_t>);
         EXPECT_EQ(actual, 21);
     }
     {
-        std::vector<size_t> x      = {1, 2, 3, 4, 5, 6};
-        size_t              actual = ngraph::reduce(x.begin(), x.end(), ngraph::mul<size_t>);
+        std::vector<size_t> x = {1, 2, 3, 4, 5, 6};
+        size_t actual = ngraph::reduce(x.begin(), x.end(), ngraph::mul<size_t>);
         EXPECT_EQ(actual, 720);
     }
 }


### PR DESCRIPTION
In an attempt to reduce the amount of whitespace diffs in PRs I made a slight tweak to our .clang-format file. I think it looks fine and it should help. My whole goal here is the whitespace issue.