### PR TITLE
Tweak code format script to ignore symlinked .cpp / .hpp files

### DIFF
--- a/maint/apply-code-format.sh
+++ b/maint/apply-code-format.sh
@@ -41,6 +41,9 @@ for ROOT_SUBDIR in src test; do
     fi
 
     echo "About to format C/C++ code in directory tree '$(pwd)/${ROOT_SUBDIR}' ..."
+    # Note that we restrict to "-type f" to exclude symlinks. Emacs sometimes
+    # creates dangling symlinks with .cpp/.hpp suffixes as a sort of locking
+    # mechanism, and this confuses clang-format.
     find "${ROOT_SUBDIR}" -type f -and \( -name '*.cpp' -or -name '*.hpp' \) | xargs "${CLANG_FORMAT_PROG}" -i -style=file
     echo "Done."
 done

--- a/maint/check-code-format.sh
+++ b/maint/check-code-format.sh
@@ -45,6 +45,9 @@ for ROOT_SUBDIR in src test; do
 
     echo "About to format C/C++ code in directory tree '$(pwd)/${ROOT_SUBDIR}' ..."
     declare SRC_FILE
+    # Note that we restrict to "-type f" to exclude symlinks. Emacs sometimes
+    # creates dangling symlinks with .cpp/.hpp suffixes as a sort of locking
+    # mechanism, and this confuses clang-format.
     for SRC_FILE in $(find "${ROOT_SUBDIR}" -type f -and \( -name '*.cpp' -or -name '*.hpp' \) ); do
         if "${CLANG_FORMAT_PROG}" -style=file -output-replacements-xml "${SRC_FILE}" | grep -c "<replacement " >/dev/null; then
             FAILED_FILES+=( "${SRC_FILE}" )


### PR DESCRIPTION
Emacs likes to add hidden symlinks with names like '.#myfile.cpp' that don't actually point to real files as a locking mechanism, which cause the format check/apply scripts to fail. This tweaks the format scripts to ignore files that are symlinks (adds a -type f predicate to the find commands), which gets around this issue.