### PR TITLE
Fix to Dockerfile.ngraph_cpp_cpu

### DIFF
--- a/contrib/docker/Dockerfile.ngraph_cpp_cpu
+++ b/contrib/docker/Dockerfile.ngraph_cpp_cpu
@@ -2,22 +2,13 @@
 
 FROM ubuntu:16.04
 
-RUN apt-get update
+RUN apt-get update && apt-get install -y \
+        build-essential cmake \
+        clang-3.9 clang-format-3.9 \
+        git \
+        wget patch diffutils  
 
-RUN apt-get install -y build-essential cmake && \
-    apt-get clean autoclean && \
-    apt-get autoremove -y
-
-RUN apt-get install -y clang-3.9 clang-format-3.9 && \
-    apt-get clean autoclean && \
-    apt-get autoremove -y
-
-RUN apt-get install -y git && \
-    apt-get clean autoclean && \
-    apt-get autoremove -y
-
-RUN apt-get install -y wget patch diffutils && \
-    apt-get clean autoclean && \
+RUN apt-get clean autoclean && \
     apt-get autoremove -y
 
 # Add chown_files script to avoid 


### PR DESCRIPTION
In Dockerfile.ngraph_cpp_cpu, moved all `apt-get install` commands into same RUN line as `apt-get update`.  There is a subtle timebomb if `apt-get update` is performed in a separate RUN line, due to how docker layers work.  Because this timebomb occurs on a per node basis, it ends up being hard to debug.