### PR TITLE
delete Input and Output copy constructors

### DIFF
--- a/src/ngraph/descriptor/input.hpp
+++ b/src/ngraph/descriptor/input.hpp
@@ -60,9 +60,9 @@ namespace ngraph
             Output& m_output;
 
         private:
-            // Input(const Input&) = default;
-            // Input(Input&&) = default;
-            // Input& operator=(const Input&) = delete;
+            Input(const Input&) = delete;
+            Input(Input&&) = delete;
+            Input& operator=(const Input&) = delete;
         };
     }
 }

--- a/src/ngraph/descriptor/output.hpp
+++ b/src/ngraph/descriptor/output.hpp
@@ -27,11 +27,6 @@ namespace ngraph
         // Describes an output tensor of an op
         class Output
         {
-            // For some odd reason emplace_back is requiring a copy constructor
-            // it should not. See issue #111 for details
-            // Output(const Output&) = delete;
-            // Output& operator=(const Output&) = delete;
-
         public:
             /// @param node Node that owns this output.
             /// @param index Position of the output tensor in all output tensors
@@ -53,6 +48,11 @@ namespace ngraph
             size_t m_index;
             std::shared_ptr<TensorView> m_tensor_view;
             std::set<Input*> m_inputs;
+
+        private:
+            Output(const Output&) = delete;
+            Output(Output&&) = delete;
+            Output& operator=(const Output&) = delete;
         };
     }
 }

--- a/src/ngraph/node.hpp
+++ b/src/ngraph/node.hpp
@@ -99,10 +99,10 @@ namespace ngraph
         size_t get_instance_id() const { return m_instance_id; }
         friend std::ostream& operator<<(std::ostream&, const Node&);
 
-        std::vector<descriptor::Input>& get_inputs() { return m_inputs; }
-        const std::vector<descriptor::Input>& get_inputs() const { return m_inputs; }
-        std::vector<descriptor::Output>& get_outputs() { return m_outputs; }
-        const std::vector<descriptor::Output>& get_outputs() const { return m_outputs; }
+        std::deque<descriptor::Input>& get_inputs() { return m_inputs; }
+        const std::deque<descriptor::Input>& get_inputs() const { return m_inputs; }
+        std::deque<descriptor::Output>& get_outputs() { return m_outputs; }
+        const std::deque<descriptor::Output>& get_outputs() const { return m_outputs; }
         std::unordered_set<descriptor::Tensor*> liveness_live_list;
         std::unordered_set<descriptor::Tensor*> liveness_new_list;
         std::unordered_set<descriptor::Tensor*> liveness_free_list;
@@ -114,8 +114,8 @@ namespace ngraph
         std::string m_name;
         size_t m_instance_id;
         static size_t m_next_instance_id;
-        std::vector<descriptor::Input> m_inputs;
-        std::vector<descriptor::Output> m_outputs;
+        std::deque<descriptor::Input> m_inputs;
+        std::deque<descriptor::Output> m_outputs;
         bool m_is_output;
     };
 }

--- a/src/ngraph/pass/liveness.cpp
+++ b/src/ngraph/pass/liveness.cpp
@@ -39,7 +39,7 @@ bool pass::Liveness::run_on_call_graph(list<Node*>& ops)
         node->liveness_new_list.clear();
         node->liveness_free_list.clear();
         unordered_set<Tensor*> input_tensor_decls;
-        for (auto input_decl : node->get_inputs())
+        for (Input& input_decl : node->get_inputs())
         {
             Tensor& tensor = input_decl.get_tensor();
             if (is_temporary(tensor))
@@ -49,7 +49,7 @@ bool pass::Liveness::run_on_call_graph(list<Node*>& ops)
         }
 
         unordered_set<Tensor*> output_tensor_decls;
-        for (auto output_decl : node->get_outputs())
+        for (Output& output_decl : node->get_outputs())
         {
             Tensor& tensor = output_decl.get_tensor();
             if (is_temporary(tensor))

--- a/test/input_output_assign.cpp
+++ b/test/input_output_assign.cpp
@@ -31,7 +31,7 @@ TEST(input_output, param_tensor)
     ASSERT_EQ(param->get_outputs().size(), 1);
     for (size_t i = 0; i < param->get_outputs().size(); i++)
     {
-        auto output = param->get_outputs()[i];
+        auto& output = param->get_outputs()[i];
         ASSERT_EQ(i, output.get_index());
         ASSERT_EQ(param, output.get_node());
     }
@@ -52,7 +52,7 @@ TEST(input_output, param_tuple)
     ASSERT_EQ(param->get_outputs().size(), 2);
     for (size_t i = 0; i < param->get_outputs().size(); i++)
     {
-        auto output = param->get_outputs()[i];
+        auto& output = param->get_outputs()[i];
         ASSERT_EQ(i, output.get_index());
         ASSERT_EQ(param, output.get_node());
     }
@@ -87,11 +87,11 @@ TEST(input_output, simple_output)
     }
 
     // At this point, the add should have each input associated with the output of the appropriate parameter
-    auto inputs = add->get_inputs();
+    auto& inputs = add->get_inputs();
     ASSERT_EQ(2, inputs.size());
     for (size_t i = 0; i < inputs.size(); i++)
     {
-        auto input = inputs[i];
+        auto& input = inputs[i];
         ASSERT_EQ(i, input.get_index());
         ASSERT_EQ(i, input.get_argno());
         ASSERT_EQ(0, input.get_arg_index());

--- a/test/tensor.cpp
+++ b/test/tensor.cpp
@@ -49,7 +49,7 @@ TEST(tensor, size)
 
         pass_manager.run_passes(f0);
 
-        auto outputs = arg0->get_outputs();
+        auto& outputs = arg0->get_outputs();
         ASSERT_EQ(1, outputs.size());
         Tensor& output = outputs[0].get_tensor();
         EXPECT_EQ(2 * 3 * 4, output.size());
@@ -63,7 +63,7 @@ TEST(tensor, size)
 
         pass_manager.run_passes(f0);
 
-        auto outputs = arg0->get_outputs();
+        auto& outputs = arg0->get_outputs();
         ASSERT_EQ(1, outputs.size());
         Tensor& output = outputs[0].get_tensor();
         EXPECT_EQ(1 * 4, output.size());
@@ -77,7 +77,7 @@ TEST(tensor, size)
 
         pass_manager.run_passes(f0);
 
-        auto outputs = arg0->get_outputs();
+        auto& outputs = arg0->get_outputs();
         ASSERT_EQ(1, outputs.size());
         Tensor& output = outputs[0].get_tensor();
         EXPECT_EQ(1 * 4, output.size());


### PR DESCRIPTION
Add I did was change the Input/Output storage from vector to deque, then I could delete the copy constructors for Input/Output. Some of the unit tests were copying Input/Output so I had to fix them.