### PR TITLE
Avoid std::deque<Input> before Input type is complete

### DIFF
--- a/src/ngraph/descriptor/output.hpp
+++ b/src/ngraph/descriptor/output.hpp
@@ -23,7 +23,10 @@
 namespace ngraph
 {
     // The forward declaration of Node is needed here because Node has a deque of
-    // Outputs, which does not work on all platforms.
+    // Outputs, and Output is an incomplete type at this point. STL containers of
+    // incomplete type have undefined behavior according to the C++11 standard, and
+    // in practice including node.hpp here was causing compilation errors on some
+    // systems (namely macOS).
     class Node;
 
     namespace descriptor


### PR DESCRIPTION
With the `deque` change, including `node.hpp` inside `output.hpp` causes `deque<descriptor::Input>` to be used before `Input` is complete, which macOS does not seem to like because something down in the header file gutty-works tries to take a `sizeof(Input)`. (Apparently STL containers on incomplete types technically are not allowed, even though Ubuntu will let you get away with it in this instance.) Changing to forward declarations for ~`Input` and~ `Node` avoids the error.