### PR TITLE
Changes from Christian to enable doxygen and sphinx

### DIFF
--- a/contrib/docker/Dockerfile.ngraph_cpp_cpu
+++ b/contrib/docker/Dockerfile.ngraph_cpp_cpu
@@ -6,7 +6,8 @@ RUN apt-get update && apt-get install -y \
         build-essential cmake \
         clang-3.9 clang-format-3.9 \
         git \
-        wget patch diffutils zlib1g-dev libtinfo-dev
+        wget patch diffutils zlib1g-dev libtinfo-dev \
+        doxygen sphinx-doc
 
 RUN apt-get clean autoclean && \
     apt-get autoremove -y

--- a/contrib/docker/Makefile
+++ b/contrib/docker/Makefile
@@ -75,7 +75,7 @@ check_cpu: build_ngraph_cpp_cpu
             ${VOLUME} \
 	    ${DOCKER_RUN_ENV} \
             --env RUN_UID="$(shell id -u)" \
-            --env RUN_CMD="set -e ; set -o pipefail ; cd ${DOCKUSER_HOME}/ngraph-cpp-test/BUILD; cmake -DCMAKE_CXX_COMPILER=clang++-3.9 -DCMAKE_C_COMPILER=clang-3.9 .. 2>&1 | tee cmake.log ; env VERBOSE=1 make ${PARALLEL} 2>&1 | tee make.log ; env VERBOSE=1 make check 2>&1 | tee make_check.log" \
+            --env RUN_CMD="set -e ; set -o pipefail ; cd ${DOCKUSER_HOME}/ngraph-cpp-test/BUILD; cmake -DCMAKE_CXX_COMPILER=clang++-3.9 -DCMAKE_C_COMPILER=clang-3.9 -DNGRAPH_BUILD_DOXYGEN_DOCS=ON -DNGRAPH_BUILD_SPHINX_DOCS=ON .. 2>&1 | tee cmake.log ; env VERBOSE=1 make ${PARALLEL} 2>&1 | tee make.log ; env VERBOSE=1 make check 2>&1 | tee make_check.log" \
             "ngraph_cpp_cpu:${BUILD_VERSION}" \
 	    sh -c "${DOCKUSER_HOME}/ngraph-cpp-test/contrib/docker/run_as_user.sh"
 


### PR DESCRIPTION
Simple modifications to add doxygen and sphinx-doc to the installed packages, plus set a couple cmake definitions which will be used later.

These changes have been tested three ways, and have passed all three:

1. Manually
2. In the private-ngraph-cpp-unittest job (http://cje.amr.corp.intel.com/aipg-algo/job/private-ngraph-cpp-unittest/282/artifact/private-ngraph-cpp/BUILD/cmake.log)
3. In the new ngraph-tensorflow-unittest job (http://cje.amr.corp.intel.com/aipg-algo/job/testing-ngraph-tensorflow-unittest/118/artifact/ngcpp_cmake.log)