### PR TITLE
Replace with sphinx-doc with python-sphinx

### DIFF
--- a/contrib/docker/Dockerfile.ngraph_cpp_cpu
+++ b/contrib/docker/Dockerfile.ngraph_cpp_cpu
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
         clang-3.9 clang-format-3.9 \
         git \
         wget patch diffutils zlib1g-dev libtinfo-dev \
-        doxygen sphinx-doc
+        doxygen python-sphinx
 
 RUN apt-get clean autoclean && \
     apt-get autoremove -y


### PR DESCRIPTION
Remove sphinx-doc package, add python-sphinx package

Tested three different ways, all passed:
1. Manual
2. private-ngraph-cpp CI Jenkins job (http://cje.amr.corp.intel.com/aipg-algo/job/testing-private-ngraph-cpp-unittest/34/artifact/private-ngraph-cpp/BUILD/cmake.log)
3. ngraph-tensorflow CI Jenkins job (http://cje.amr.corp.intel.com/aipg-algo/job/testing-private-ngraph-cpp-unittest/34/artifact/private-ngraph-cpp/BUILD/cmake.log)