### PR TITLE
Generate xUnit XML test results

### DIFF
--- a/contrib/docker/Makefile
+++ b/contrib/docker/Makefile
@@ -74,6 +74,7 @@ check_cpu: build_ngraph_cpp_cpu
 	docker run --rm --tty \
             ${VOLUME} \
 	    ${DOCKER_RUN_ENV} \
+            --env GTEST_OUTPUT="xml:${DOCKUSER_HOME}/ngraph-cpp-test/BUILD/unit-test-results.xml" \
             --env RUN_UID="$(shell id -u)" \
             --env RUN_CMD="set -e ; set -o pipefail ; cd ${DOCKUSER_HOME}/ngraph-cpp-test/BUILD; cmake -DCMAKE_CXX_COMPILER=clang++-3.9 -DCMAKE_C_COMPILER=clang-3.9 -DNGRAPH_BUILD_DOXYGEN_DOCS=ON -DNGRAPH_BUILD_SPHINX_DOCS=ON .. 2>&1 | tee cmake.log ; env VERBOSE=1 make ${PARALLEL} 2>&1 | tee make.log ; env VERBOSE=1 make check 2>&1 | tee make_check.log" \
             "ngraph_cpp_cpu:${BUILD_VERSION}" \


### PR DESCRIPTION
This is the first part of a multi-repo change to turn on capture of test results in the xUnit XML format that the Jenkins *Test Result Analyzer* plugin recognizes.  This part turns on XML test result generation for private-ngraph-cpp.

Detailed change: Add GTEST_OUTPUT environment variable definition, to generate an xml report from the unit-testing (written in Google Test).