### PR TITLE
fix bug with Convert autodiff

### DIFF
--- a/src/ngraph/ops/convert.cpp
+++ b/src/ngraph/ops/convert.cpp
@@ -34,5 +34,5 @@ void ngraph::op::Convert::generate_adjoints(autodiff::Adjoints& adjoints,
 {
     auto x = m_arguments[0];
 
-    adjoints.add_delta(x, std::make_shared<op::Convert>(delta, m_element_type));
+    adjoints.add_delta(x, std::make_shared<op::Convert>(delta, x->get_element_type()));
 }


### PR DESCRIPTION
This fixes the bug and the MXNet python unit test for cast.  I.e. it's progress.  There is still the remaining open of the unit tests for the Convert operator which I will attempt to address in a separate commit.