### PR TITLE
Turn on option to generate compilation database file compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ endif()
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
+# Create compilation database compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # set directory where the custom finders live
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 


### PR DESCRIPTION
Cmake has an option CMAKE_EXPORT_COMPILE_COMMANDS for Makefile and Ninja targets.
This option controls creation of compile_commands.json
Some tools like Visual Studio Code and YouCompleteMe (A Vim plugin) can take advantage of compile_commands.json to support features like auto completion, find declaration and find definition.
