### PR TITLE
Problem: Compile error on Mac with gcc 7.2

### DIFF
--- a/src/ngraph/util.hpp
+++ b/src/ngraph/util.hpp
@@ -16,13 +16,13 @@
 
 #include <algorithm>
 #include <chrono>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <functional>
 
 namespace ngraph
 {


### PR DESCRIPTION
Solution: Should include \<functional\> to use std::function.