### PR TITLE
Serializer test: use INTERPRETER, not CPU

### DIFF
--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -75,7 +75,7 @@ TEST(serialize, main)
     shared_ptr<Function> sfunc = deserialize(in);
 
     // Now call g on some test vectors.
-    auto manager = runtime::Manager::get("CPU");
+    auto manager = runtime::Manager::get("INTERPRETER");
     auto external = manager->compile(sfunc);
     auto backend = manager->allocate_backend();
     auto cf = backend->make_call_frame(external);


### PR DESCRIPTION
This test is still failing on Mac since it is hard-wired to use the CPU backend. If we switch it to interpreter it passes, and if I understand the intent of the test interpreter should be fine.