### PR TITLE
Workaround for gcc limitation

### DIFF
--- a/src/ngraph/ops/constant.cpp
+++ b/src/ngraph/ops/constant.cpp
@@ -119,11 +119,22 @@ std::vector<std::string> op::Constant::get_value_strings() const
     return rc;
 }
 
-template <>
-void op::Constant::write_to_buffer<std::string>(const element::Type& target_type,
-                                                const Shape& target_shape,
-                                                const std::vector<std::string>& source,
-                                                void* target,
-                                                size_t target_element_count)
+//
+// We have to open up namespace blocks here to work around a problem with gcc:
+//
+// https://stackoverflow.com/questions/25594644/warning-specialization-of-template-in-different-namespace
+//
+namespace ngraph
 {
+    namespace op
+    {
+        template <>
+        void Constant::write_to_buffer<std::string>(const element::Type& target_type,
+                                                    const Shape& target_shape,
+                                                    const std::vector<std::string>& source,
+                                                    void* target,
+                                                    size_t target_element_count)
+        {
+        }
+    }
 }


### PR DESCRIPTION
We seem to be encountering this bug when building with gcc:

https://stackoverflow.com/questions/25594644/warning-specialization-of-template-in-different-namespace