### PR TITLE
add-sphinx-docs-target to contrib/docker/Makefile

### DIFF
--- a/contrib/docker/Makefile
+++ b/contrib/docker/Makefile
@@ -77,7 +77,7 @@ build_docker: build_docker_image
 docs: sphinx_doc doxygen_doc
 
 doxygen_doc:
-	# sphinx html docs build
+	# doxygen html docs build
 	docker run --rm --tty \
             ${VOLUME} \
 	    ${DOCKER_RUN_ENV} \


### PR DESCRIPTION
added separate sphinx_doc and doxygen_doc targets to the contrib/docker/Makefile to build html docs for PR #377

Intended as a workaround to enable docs development while cmake/make changes are in progress.