### PR TITLE
Fix improper bracketing of certain kernel calls in CPU codegen

### DIFF
--- a/src/ngraph/runtime/cpu/cpu_emitter.cpp
+++ b/src/ngraph/runtime/cpu/cpu_emitter.cpp
@@ -1080,6 +1080,9 @@ void runtime::cpu::CPU_Emitter::EmitReduce(codegen::CodeWriter& writer,
     }
     else
     {
+        writer << "{   // " << n->get_name() << "\n";
+        writer.indent++;
+
         string type = f_result_element_type.c_type_string();
         writer << "auto f = [](" << type << " x, " << type << " y) -> " << type << "\n{";
         writer.indent++;
@@ -1099,6 +1102,9 @@ void runtime::cpu::CPU_Emitter::EmitReduce(codegen::CodeWriter& writer,
         writer << "               {" << join(out[0].get_shape()) << "},\n";
         writer << "               {" << join(reduce->get_reduction_axes()) << "},\n";
         writer << "               f);\n";
+
+        writer.indent--;
+        writer << "}\n";
     }
 #else
     writer << "{   // " << n->get_name() << " 1\n";
@@ -1875,6 +1881,9 @@ void runtime::cpu::CPU_Emitter::EmitReduceWindow(
     auto reduction_function = reduce_window->get_functions()[0];
     auto& f_result_element_type = out[0].get_element_type();
 
+    writer << "{   // " << n->get_name() << "\n";
+    writer.indent++;
+
     string type = f_result_element_type.c_type_string();
     writer << "auto f = [](" << type << " x, " << type << " y) -> " << type << "\n{";
     writer.indent++;
@@ -1896,6 +1905,9 @@ void runtime::cpu::CPU_Emitter::EmitReduceWindow(
     writer << "                      {" << join(reduce_window->get_window_shape()) << "},\n";
     writer << "                      {" << join(reduce_window->get_window_movement_strides())
            << "});\n";
+
+    writer.indent--;
+    writer << "}\n";
 }
 
 void runtime::cpu::CPU_Emitter::EmitSelectAndScatter(
@@ -1911,6 +1923,9 @@ void runtime::cpu::CPU_Emitter::EmitSelectAndScatter(
     auto arg0_shape = args[0].get_shape();
     auto arg1_shape = args[1].get_shape();
     auto result_shape = out[0].get_shape();
+
+    writer << "{   // " << n->get_name() << "\n";
+    writer.indent++;
 
     string type = n->get_output_element_type(0).c_type_string();
 
@@ -1949,6 +1964,9 @@ void runtime::cpu::CPU_Emitter::EmitSelectAndScatter(
     writer << "                {" << join(select_and_scatter->get_window_shape()) << "},\n";
     writer << "                {" << join(select_and_scatter->get_window_movement_strides())
            << "});\n";
+
+    writer.indent--;
+    writer << "}\n";
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This was causing some "redeclaration of `f`" errors on a topology @sharathns93 was working with.