### PR TITLE
Disable GPU by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ endif()
 #-----------------------------------------------------------------------------------------------
 # Setup CUDA and cuDNN if NGRAPH_GPU_ENABLE=TRUE
 find_package(CUDA 8 QUIET)
-if(CUDA_FOUND AND (NOT DEFINED NGRAPH_GPU_ENABLE OR NGRAPH_GPU_ENABLE))
+if(CUDA_FOUND AND NGRAPH_GPU_ENABLE)
     message(STATUS "GPU Backend Enabled")
     set(NGRAPH_GPU_ENABLE TRUE)
     find_package(CUDNN 5 QUIET REQUIRED)


### PR DESCRIPTION
Enabling GPU in ngraph can cause errors in the bridges since GPU support isn't complete. I'd like to disable it by default until we can provide full backend functionality to the bridges.