### PR TITLE
Remove duplicate and unnused declarations

### DIFF
--- a/src/ngraph/autodiff/adjoints.hpp
+++ b/src/ngraph/autodiff/adjoints.hpp
@@ -75,10 +75,5 @@ namespace ngraph
         protected:
             std::unordered_map<Node*, std::shared_ptr<Node>> m_adjoint_map;
         };
-
-        /// @brief Returns a FunctionSpec for the backprop derivative of its argument.
-        /// @param f is f(X_i...)
-        /// @returns f'(X_i..., c) where f'(x_i, ..., c)_j is backprop for X_j
-        std::shared_ptr<Function> backprop_function(const std::shared_ptr<Function>& f);
     }
 }

--- a/test/util/autodiff/backprop_function.hpp
+++ b/test/util/autodiff/backprop_function.hpp
@@ -21,14 +21,7 @@
 
 namespace ngraph
 {
-    class Node;
     class Function;
-
-    namespace runtime
-    {
-        class Backend;
-        class Manager;
-    }
 
     namespace autodiff
     {


### PR DESCRIPTION
A while back some things were moved into test utils, but one of the moves was a copy, not a move.