### PR TITLE
remove -j option for make

### DIFF
--- a/doc/sphinx/source/installation.rst
+++ b/doc/sphinx/source/installation.rst
@@ -78,16 +78,7 @@ information about how to change or customize this location.
    .. code-block:: console
 
       $ cd build && cmake ../ [-DNGRAPH_USE_PREBUILT_LLVM=TRUE]
-
-#. (Optional) Run ``$ make [-jN]`` where ``-jN`` specifies the number of physical
-   cores to use to build. The example here uses a configuration of ``j8``, 
-   which is good for a system install using an 8-core Intel® Xeon® CPU processor. 
-   This step is **not recommended** for machines with too little RAM available, 
-   such as those whose RAM is superceded by Docker or VM tasks.  
-
-   .. code-block:: console
-      
-      $ make -j8
+      $ make
 
 #. Run ``make install`` to install ``libngraph.so`` and the header files to the 
    default location of ``$HOME/ngraph_dist``


### PR DESCRIPTION
Adding the -j option is tempting fate. Failure is much more common when using -j. Things work with simple `make` albeit slowly.