### PR TITLE
Remove MLP MNIST Benchmark Test

### DIFF
--- a/test/backend_performance.cpp
+++ b/test/backend_performance.cpp
@@ -44,12 +44,6 @@ TEST(benchmark, mxnet_mnist_mlp_forward)
     run_benchmark(json_path, "CPU", 1000);
 }
 
-TEST(benchmark, gpu_mxnet_mnist_mlp_forward)
-{
-    const string json_path = file_util::path_join(SERIALIZED_ZOO, "mxnet/mnist_mlp_forward.json");
-    run_benchmark(json_path, "GPU", 1000);
-}
-
 TEST(benchmark, mxnet_10_bucket_lstm)
 {
     const string json_path = file_util::path_join(SERIALIZED_ZOO, "mxnet/10_bucket_LSTM.json");


### PR DESCRIPTION
Unresolved bug in this test. It is currently passing, but stalls intermittently depending on machine state. Should we disable it prior to open source release?