### PR TITLE
[WIP] Change CPU emitter function signature.

### DIFF
--- a/src/ngraph/runtime/cpu/cpu_emitter.cpp
+++ b/src/ngraph/runtime/cpu/cpu_emitter.cpp
@@ -159,7 +159,6 @@ namespace ngraph
                         runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 1);
                     auto result_format =
                         runtime::cpu::mkldnn_utils::get_output_mkldnn_format(node, 0);
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto input0_data_desc =
                         mkldnn_emitter->build_memory_descriptor(args[0], input0_format);
                     auto input1_data_desc =
@@ -396,7 +395,6 @@ namespace ngraph
                     auto variance_format =
                         runtime::cpu::mkldnn_utils::get_output_mkldnn_format(node, 2);
 
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto weights_shape = Shape{2, args[0].get_size()};
                     auto input_desc =
                         mkldnn_emitter->build_memory_descriptor(args[2], input_format);
@@ -441,7 +439,6 @@ namespace ngraph
                         runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 4);
                     auto result_format =
                         runtime::cpu::mkldnn_utils::get_output_mkldnn_format(node, 0);
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto weights_shape = Shape{2, args[0].get_size()};
                     auto input_desc =
                         mkldnn_emitter->build_memory_descriptor(args[2], input_format);
@@ -507,7 +504,6 @@ namespace ngraph
                 auto delta_format = runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 5);
                 auto dinput_format = runtime::cpu::mkldnn_utils::get_output_mkldnn_format(node, 0);
 
-                auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                 auto weights_shape = Shape{2, args[0].get_size()};
                 auto weights_desc = mkldnn_emitter->build_memory_descriptor(
                     weights_shape, args[0].get_element_type(), mkldnn::memory::format::nc);
@@ -1224,18 +1220,6 @@ namespace ngraph
             template <>
             void CPU_Emitter::EMITTER_DECL(ngraph::op::Constant)
             {
-                // If an output is a constant then copy it
-                size_t output_index = 0;
-                for (shared_ptr<Node> result : external_function->get_function()->get_results())
-                {
-                    if (result.get() == node)
-                    {
-                        const descriptor::Tensor& tensor = node->get_output_tensor(0);
-                        writer << "memcpy(outputs[" << output_index << "], " << tensor.get_name()
-                               << ", " << tensor.size() << ");\n";
-                    }
-                    output_index++;
-                }
             }
 
             template <>
@@ -2260,7 +2244,6 @@ namespace ngraph
                     auto output_format =
                         runtime::cpu::mkldnn_utils::get_output_mkldnn_format(node, 0);
 
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto input_data_desc =
                         mkldnn_emitter->build_memory_descriptor(args[0], input_format);
                     auto weights_desc =
@@ -2331,7 +2314,6 @@ namespace ngraph
                     auto output_format =
                         runtime::cpu::mkldnn_utils::get_output_mkldnn_format(node, 0);
 
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto input_data_desc =
                         mkldnn_emitter->build_memory_descriptor(args[0], input_format);
                     auto weights_desc =
@@ -2401,7 +2383,6 @@ namespace ngraph
                         window_dilation_strides_adjusted.push_back(s - 1);
                     }
 
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto input_desc = mkldnn_emitter->build_memory_descriptor(
                         args[0], runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 0));
                     auto delta_desc = mkldnn_emitter->build_memory_descriptor(
@@ -2471,7 +2452,6 @@ namespace ngraph
                         window_dilation_strides_adjusted.push_back(s - 1);
                     }
 
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     // HACK to help MKLDNN pick the right implementation
                     auto weights_format =
                         runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 0);
@@ -2549,7 +2529,6 @@ namespace ngraph
                     auto bias_format = mkldnn_utils::get_input_mkldnn_format(node, 2);
                     auto result_format = mkldnn_utils::get_output_mkldnn_format(node, 0);
 
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto data_desc = mkldnn_emitter->build_memory_descriptor(data, data_format);
                     auto weights_desc =
                         mkldnn_emitter->build_memory_descriptor(weights, weights_format);
@@ -2620,7 +2599,6 @@ namespace ngraph
                     auto weights_delta_format = mkldnn_utils::get_output_mkldnn_format(node, 0);
                     auto bias_delta_format = mkldnn_utils::get_output_mkldnn_format(node, 1);
 
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto data_desc = mkldnn_emitter->build_memory_descriptor(data, data_format);
                     auto delta_desc = mkldnn_emitter->build_memory_descriptor(delta, delta_format);
                     auto weights_delta_desc = mkldnn_emitter->build_memory_descriptor(
@@ -2682,7 +2660,6 @@ namespace ngraph
                 if (arg_rank == 4 && max_pool->get_window_shape().size() == 2 &&
                     args[0].get_element_type() == element::f32)
                 {
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto input_desc = mkldnn_emitter->build_memory_descriptor(
                         args[0], runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 0));
                     auto result_desc = mkldnn_emitter->build_memory_descriptor(
@@ -2850,7 +2827,6 @@ namespace ngraph
                 // TODO(jmenon): Remove element type restriction
                 if (runtime::cpu::mkldnn_utils::use_mkldnn_kernel(node))
                 {
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto input_desc = mkldnn_emitter->build_memory_descriptor(
                         args[0], runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 0));
                     auto result_desc = mkldnn_emitter->build_memory_descriptor(
@@ -2941,7 +2917,6 @@ namespace ngraph
 
                 if (runtime::cpu::mkldnn_utils::use_mkldnn_kernel(node))
                 {
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto diff_dst_desc = mkldnn_emitter->build_memory_descriptor(
                         args[0], runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 0));
                     auto diff_src_desc = mkldnn_emitter->build_memory_descriptor(
@@ -2997,7 +2972,6 @@ namespace ngraph
 
                 if (runtime::cpu::mkldnn_utils::use_mkldnn_kernel(node))
                 {
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto fprop_src_desc = mkldnn_emitter->build_memory_descriptor(
                         args[0], runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 0));
                     auto diff_dst_desc = mkldnn_emitter->build_memory_descriptor(
@@ -3311,7 +3285,6 @@ namespace ngraph
                     output_format = mkldnn::memory::format::oihw;
                 }
 
-                auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                 auto input_desc = mkldnn_emitter->build_memory_descriptor(args[0], input_format);
                 auto result_desc = mkldnn_emitter->build_memory_descriptor(out[0], output_format);
 
@@ -3332,7 +3305,6 @@ namespace ngraph
             {
                 if (runtime::cpu::mkldnn_utils::use_mkldnn_kernel(node))
                 {
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto input_desc = mkldnn_emitter->build_memory_descriptor(
                         args[0], runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 0));
                     auto delta_desc = mkldnn_emitter->build_memory_descriptor(
@@ -3370,7 +3342,6 @@ namespace ngraph
             {
                 if (runtime::cpu::mkldnn_utils::use_mkldnn_kernel(node))
                 {
-                    auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto input_desc = mkldnn_emitter->build_memory_descriptor(
                         args[0], runtime::cpu::mkldnn_utils::get_input_mkldnn_format(node, 0));
                     auto result_desc = mkldnn_emitter->build_memory_descriptor(
@@ -3406,7 +3377,6 @@ namespace ngraph
                 int input_1d_size = static_cast<int>(shape_size(input_shape));
                 int result_1d_size = static_cast<int>(shape_size(result_shape));
 
-                auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                 auto input_desc = mkldnn::memory::desc(
                     {input_1d_size},
                     mkldnn_utils::get_mkldnn_data_type(args[0].get_element_type()),
@@ -3439,7 +3409,6 @@ namespace ngraph
                 int delta_1d_size = static_cast<int>(shape_size(delta_shape));
                 int result_1d_size = static_cast<int>(shape_size(result_shape));
 
-                auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                 auto input_desc = mkldnn::memory::desc(
                     {input_1d_size},
                     mkldnn_utils::get_mkldnn_data_type(args[0].get_element_type()),

--- a/src/ngraph/runtime/cpu/cpu_emitter.hpp
+++ b/src/ngraph/runtime/cpu/cpu_emitter.hpp
@@ -25,7 +25,7 @@
 #include "ngraph/runtime/cpu/cpu_tensor_view_wrapper.hpp"
 
 #define EMITTER_DECL(op_name)                                                                      \
-    emit<op_name>(CPU_ExternalFunction * external_function,                                        \
+    emit<op_name>(MKLDNNEmitter * mkldnn_emitter,                                                  \
                   codegen::CodeWriter & writer,                                                    \
                   const ngraph::Node* node,                                                        \
                   const std::vector<TensorViewWrapper>& args,                                      \
@@ -41,7 +41,7 @@ namespace ngraph
             {
             public:
                 template <typename OP>
-                static void emit(CPU_ExternalFunction* external_function,
+                static void emit(MKLDNNEmitter* mkldnn_emitter,
                                  codegen::CodeWriter& writer,
                                  const ngraph::Node* node,
                                  const std::vector<TensorViewWrapper>& args,
@@ -50,7 +50,7 @@ namespace ngraph
                     throw std::runtime_error("Unimplemented op in CPU emitter");
                 }
 
-                static void nop(CPU_ExternalFunction* external_function,
+                static void nop(MKLDNNEmitter* mkldnn_emitter,
                                 codegen::CodeWriter& writer,
                                 const ngraph::Node* node,
                                 const std::vector<TensorViewWrapper>& args,

--- a/src/ngraph/runtime/cpu/cpu_external_function.cpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.cpp
@@ -278,7 +278,6 @@ const runtime::cpu::OpFunction* runtime::cpu::CPU_ExternalFunction::get_emitter(
     auto handler = dispatcher.find(type_index(typeid(node)));
     if (handler == dispatcher.end())
     {
-        NGRAPH_INFO;
         throw runtime_error("did not find emitter for " + node.get_name());
     }
     return &(handler->second);

--- a/src/ngraph/runtime/cpu/cpu_external_function.cpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.cpp
@@ -273,6 +273,17 @@ static const runtime::cpu::OpMap dispatcher{
     {TI(ngraph::op::SigmoidBackprop), &runtime::cpu::CPU_Emitter::emit<op::SigmoidBackprop>},
 };
 
+const runtime::cpu::OpFunction* runtime::cpu::CPU_ExternalFunction::get_emitter(const Node& node)
+{
+    auto handler = dispatcher.find(type_index(typeid(node)));
+    if (handler == dispatcher.end())
+    {
+        NGRAPH_INFO;
+        throw runtime_error("did not find emitter for " + node.get_name());
+    }
+    return &(handler->second);
+}
+
 runtime::cpu::CPU_ExternalFunction::CPU_ExternalFunction(
     const shared_ptr<ngraph::Function>& function, bool release_function)
     : ngraph::runtime::ExternalFunction(function, release_function)
@@ -672,6 +683,22 @@ using namespace ngraph::runtime;
                 node_output_names.emplace_back(tv->get_tensor().get_name());
             }
 
+            if (node->is_constant())
+            {
+                // If an output is a constant then copy it
+                size_t output_index = 0;
+                for (shared_ptr<Node> result : get_function()->get_results())
+                {
+                    if (result == node)
+                    {
+                        const descriptor::Tensor& tensor = node->get_output_tensor(0);
+                        writer << "memcpy(outputs[" << output_index << "], " << tensor.get_name()
+                               << ", " << tensor.size() << ");\n";
+                    }
+                    output_index++;
+                }
+            }
+
             // Emit operation prologue
             if (!node->is_parameter() && !node->is_constant())
             {
@@ -714,7 +741,7 @@ using namespace ngraph::runtime;
             auto it = match_functions.find(node.get());
             if (it == match_functions.end())
             {
-                handler->second(this, writer, node.get(), in, out);
+                handler->second(&*get_mkldnn_emitter(), writer, node.get(), in, out);
             }
             else
             {
@@ -988,7 +1015,7 @@ string runtime::cpu::CPU_ExternalFunction::emit_op_as_function(const Node& node,
     writer << "\n)\n";
     writer << "{\n";
     writer.indent++;
-    handler->second(this, writer, &node, in, out);
+    handler->second(&*get_mkldnn_emitter(), writer, &node, in, out);
     writer.indent--;
     writer << "}\n";
 

--- a/src/ngraph/runtime/cpu/cpu_external_function.hpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.hpp
@@ -45,7 +45,7 @@ namespace ngraph
             class CPU_Emitter;
             class CPU_CallFrame;
 
-            using OpFunction = std::function<void(CPU_ExternalFunction* external_function,
+            using OpFunction = std::function<void(MKLDNNEmitter* mkldnn_emitter,
                                                   codegen::CodeWriter&,
                                                   const ngraph::Node*,
                                                   const std::vector<TensorViewWrapper>& inputs,
@@ -87,6 +87,8 @@ namespace ngraph
                 {
                     return m_mkldnn_emitter;
                 }
+
+                static const OpFunction* get_emitter(const Node& node);
 
                 const std::string& get_function_name() const { return m_function_name; }
             protected:


### PR DESCRIPTION
Make CPU emitters callable from NNP backend without the need for a CPU External Function.

For the hybrid NNP backend we want to use some of the CPU functions for things not yet implemented on the NNP. This change makes it easier.