### PR TITLE
contrib/docker/Makefile updated to set NGRAPH_USE_PREBUILT_LLVM for Ubuntu

### DIFF
--- a/contrib/docker/Makefile
+++ b/contrib/docker/Makefile
@@ -65,6 +65,7 @@ ifeq ("$(shell echo ${OS} | grep centos)","centos74")
 else
     DOCKERFILE ?= "Dockerfile.ngraph"
     RUN_AS_USER_SCRIPT ?= ${DOCKUSER_HOME}/ngraph-test/contrib/docker/run_as_ubuntu_user.sh
+    CMAKE_OPTIONS_EXTRA+=-DNGRAPH_USE_PREBUILT_LLVM=TRUE
 endif
 
 # For gcc builds, we do NOT regard warnings as errors


### PR DESCRIPTION
fixed contrib/docker/Makefile to set NGRAPH_USE_PREBUILT_LLVM=TRUE with Ubuntu builds