### PR TITLE
switching to using get_users()

### DIFF
--- a/src/ngraph/graph_util.cpp
+++ b/src/ngraph/graph_util.cpp
@@ -183,8 +183,9 @@ std::list<std::shared_ptr<ngraph::Node>>
         result_list.push_back(node_map[independent_node]);
         independent_nodes.pop_front();
 
-        for (auto user : independent_node->users())
+        for (auto user_sp : independent_node->get_users())
         {
+            Node* user = user_sp.get();
             node_dependency_count[user] -= 1;
             size_t count = node_dependency_count[user];
             if (count == 0)

--- a/src/ngraph/pattern/op/any.hpp
+++ b/src/ngraph/pattern/op/any.hpp
@@ -35,8 +35,6 @@ namespace ngraph
                     : Pattern("Any", NodeVector{arg}, predicate)
                 {
                     add_output(arg->get_element_type(), arg->get_shape());
-                    //m_arguments.push_back(arg);
-                    //const_cast<std::multiset<Node*>&>(arg->users()).insert(this);
                 }
             };
         }

--- a/src/ngraph/placement.cpp
+++ b/src/ngraph/placement.cpp
@@ -91,8 +91,9 @@ static vector<unordered_set<shared_ptr<Node>>>
         previous_placement = independent_node->get_placement();
         sorted_nodes.push_back(node_map.at(independent_node));
 
-        for (Node* user_node : independent_node->users())
+        for (auto user : independent_node->get_users())
         {
+            Node* user_node = user.get();
             node_dependency_count.at(user_node) -= 1;
             if (node_dependency_count.at(user_node) == 0)
             {

--- a/src/ngraph/serializer.cpp
+++ b/src/ngraph/serializer.cpp
@@ -304,8 +304,9 @@ static json write(const Function& f, bool binary_constant_data)
             result_list.push_back(node_map[independent_node]);
             independent_nodes.pop_front();
 
-            for (auto user : independent_node->users())
+            for (auto sp_user : independent_node->get_users())
             {
+                Node* user = sp_user.get();
                 node_depencency_count[user] -= 1;
                 size_t count = node_depencency_count[user];
                 if (count == 0)


### PR DESCRIPTION
After this change, the only uses of `users()` are the ones that keep I/O and node views in sync. In other words, we should be able to remove `m_arguments` and `m_users`