### PR TITLE
Add #include <numeric> header to tensor_mask.cpp

### DIFF
--- a/src/ngraph/builder/tensor_mask.cpp
+++ b/src/ngraph/builder/tensor_mask.cpp
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
+#include <numeric>
 
 #include "ngraph/builder/tensor_mask.hpp"
 


### PR DESCRIPTION
Fixes on `clang`:

```
src/ngraph/builder/tensor_mask.cpp:66:10: error: no member named 'iota' in namespace 'std'
    std::iota(sequence_data.begin(), sequence_data.end(), 0);
    ~~~~~^
```