### PR TITLE
[Py] Bugfix in tox.ini

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -11,6 +11,7 @@ setenv =
   NGRAPH_CPP_BUILD_PATH = {env:NGRAPH_CPP_BUILD_PATH:build/ngraph_dist}
   LD_LIBRARY_PATH = {env:LD_LIBRARY_PATH:build/ngraph_dist/lib}
   DYLD_LIBRARY_PATH = {env:DYLD_LIBRARY_PATH:build/ngraph_dist/lib}
+  PYBIND_HEADERS_PATH = {env:PYBIND_HEADERS_PATH}
 
 [testenv:py35]
 deps =


### PR DESCRIPTION
Fixes a bug, which prevented `PYBIND_HEADERS_PATH` to be passed into `tox`
Should enable `tox` in CI.