### PR TITLE
enable TensorView to use pre-allocated mem

### DIFF
--- a/src/ngraph/runtime/backend.hpp
+++ b/src/ngraph/runtime/backend.hpp
@@ -52,6 +52,12 @@ namespace ngraph
                 make_primary_tensor_view(const ngraph::element::Type& element_type,
                                          const Shape& shape) = 0;
 
+            /// @brief Return a handle for a tensor for given mem on backend device
+            virtual std::shared_ptr<ngraph::runtime::TensorView>
+                make_primary_tensor_view(const ngraph::element::Type& element_type,
+                                         const Shape& shape,
+                                         void* mem_handle) = 0;
+
             template <typename T>
             std::shared_ptr<ngraph::runtime::TensorView>
                 make_primary_tensor_view(const Shape& shape)

--- a/src/ngraph/runtime/backend.hpp
+++ b/src/ngraph/runtime/backend.hpp
@@ -56,7 +56,7 @@ namespace ngraph
             virtual std::shared_ptr<ngraph::runtime::TensorView>
                 make_primary_tensor_view(const ngraph::element::Type& element_type,
                                          const Shape& shape,
-                                         void* mem_handle) = 0;
+                                         void* memory_pointer) = 0;
 
             template <typename T>
             std::shared_ptr<ngraph::runtime::TensorView>

--- a/src/ngraph/runtime/cpu/cpu_backend.cpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.cpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "ngraph/runtime/cpu/cpu_backend.hpp"
 #include "ngraph/log.hpp"
+#include "ngraph/runtime/cpu/cpu_backend.hpp"
 #include "ngraph/runtime/cpu/cpu_tensor_view.hpp"
 #include "ngraph/runtime/external_function.hpp"
 
@@ -33,5 +33,12 @@ std::shared_ptr<ngraph::runtime::TensorView>
                                                         const Shape& shape)
 {
     auto rc = make_shared<runtime::cpu::CPUTensorView>(element_type, shape);
+    return dynamic_pointer_cast<runtime::TensorView>(rc);
+}
+
+std::shared_ptr<ngraph::runtime::TensorView> runtime::cpu::CPU_Backend::make_primary_tensor_view(
+    const ngraph::element::Type& element_type, const Shape& shape, void* mem_handle)
+{
+    auto rc = make_shared<runtime::cpu::CPUTensorView>(element_type, shape, mem_handle);
     return dynamic_pointer_cast<runtime::TensorView>(rc);
 }

--- a/src/ngraph/runtime/cpu/cpu_backend.cpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.cpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "ngraph/log.hpp"
 #include "ngraph/runtime/cpu/cpu_backend.hpp"
+#include "ngraph/log.hpp"
 #include "ngraph/runtime/cpu/cpu_tensor_view.hpp"
 #include "ngraph/runtime/external_function.hpp"
 

--- a/src/ngraph/runtime/cpu/cpu_backend.cpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.cpp
@@ -37,8 +37,8 @@ std::shared_ptr<ngraph::runtime::TensorView>
 }
 
 std::shared_ptr<ngraph::runtime::TensorView> runtime::cpu::CPU_Backend::make_primary_tensor_view(
-    const ngraph::element::Type& element_type, const Shape& shape, void* mem_handle)
+    const ngraph::element::Type& element_type, const Shape& shape, void* memory_pointer)
 {
-    auto rc = make_shared<runtime::cpu::CPUTensorView>(element_type, shape, mem_handle);
+    auto rc = make_shared<runtime::cpu::CPUTensorView>(element_type, shape, memory_pointer);
     return dynamic_pointer_cast<runtime::TensorView>(rc);
 }

--- a/src/ngraph/runtime/cpu/cpu_backend.hpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.hpp
@@ -34,6 +34,11 @@ namespace ngraph
                 std::shared_ptr<ngraph::runtime::TensorView>
                     make_primary_tensor_view(const ngraph::element::Type& element_type,
                                              const Shape& shape) override;
+
+                std::shared_ptr<ngraph::runtime::TensorView>
+                    make_primary_tensor_view(const ngraph::element::Type& element_type,
+                                             const Shape& shape,
+                                             void* mem_handle) override;
             };
         }
     }

--- a/src/ngraph/runtime/cpu/cpu_backend.hpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.hpp
@@ -38,7 +38,7 @@ namespace ngraph
                 std::shared_ptr<ngraph::runtime::TensorView>
                     make_primary_tensor_view(const ngraph::element::Type& element_type,
                                              const Shape& shape,
-                                             void* mem_handle) override;
+                                             void* memory_pointer) override;
             };
         }
     }

--- a/src/ngraph/runtime/cpu/cpu_tensor_view.cpp
+++ b/src/ngraph/runtime/cpu/cpu_tensor_view.cpp
@@ -51,7 +51,7 @@ runtime::cpu::CPUTensorView::CPUTensorView(const ngraph::element::Type& element_
 
     buffer_size = shape_size(shape) * element_type.size();
 
-    if (mem_handle)
+    if (mem_handle != nullptr)
     {
         aligned_buffer = static_cast<char*>(mem_handle);
         return;

--- a/src/ngraph/runtime/cpu/cpu_tensor_view.cpp
+++ b/src/ngraph/runtime/cpu/cpu_tensor_view.cpp
@@ -36,7 +36,7 @@ const size_t runtime::cpu::CPUTensorView::BufferAlignment = 64;
 
 runtime::cpu::CPUTensorView::CPUTensorView(const ngraph::element::Type& element_type,
                                            const Shape& shape,
-                                           void* mem_handle,
+                                           void* memory_pointer,
                                            const string& name)
     : runtime::TensorView(std::make_shared<ngraph::descriptor::PrimaryTensorView>(
           std::make_shared<ngraph::TensorViewType>(element_type, shape), name, true, true, false))
@@ -51,9 +51,9 @@ runtime::cpu::CPUTensorView::CPUTensorView(const ngraph::element::Type& element_
 
     buffer_size = shape_size(shape) * element_type.size();
 
-    if (mem_handle != nullptr)
+    if (memory_pointer != nullptr)
     {
-        aligned_buffer = static_cast<char*>(mem_handle);
+        aligned_buffer = static_cast<char*>(memory_pointer);
         return;
     }
 
@@ -90,7 +90,9 @@ runtime::cpu::CPUTensorView::CPUTensorView(const ngraph::element::Type& element_
 runtime::cpu::CPUTensorView::~CPUTensorView()
 {
     if (buffer != nullptr)
+    {
         free(buffer);
+    }
 }
 
 char* runtime::cpu::CPUTensorView::get_data_ptr()

--- a/src/ngraph/runtime/cpu/cpu_tensor_view.cpp
+++ b/src/ngraph/runtime/cpu/cpu_tensor_view.cpp
@@ -87,10 +87,7 @@ runtime::cpu::CPUTensorView::CPUTensorView(const ngraph::element::Type& element_
 
 runtime::cpu::CPUTensorView::~CPUTensorView()
 {
-    if (buffer != nullptr)
-    {
-        free(buffer);
-    }
+    free(buffer);
 }
 
 char* runtime::cpu::CPUTensorView::get_data_ptr()

--- a/src/ngraph/runtime/cpu/cpu_tensor_view.cpp
+++ b/src/ngraph/runtime/cpu/cpu_tensor_view.cpp
@@ -54,10 +54,8 @@ runtime::cpu::CPUTensorView::CPUTensorView(const ngraph::element::Type& element_
     if (memory_pointer != nullptr)
     {
         aligned_buffer = static_cast<char*>(memory_pointer);
-        return;
     }
-
-    if (buffer_size)
+    else if (buffer_size > 0)
     {
         size_t allocation_size = buffer_size + BufferAlignment;
         auto ptr = malloc(allocation_size);

--- a/src/ngraph/runtime/cpu/cpu_tensor_view.hpp
+++ b/src/ngraph/runtime/cpu/cpu_tensor_view.hpp
@@ -35,7 +35,7 @@ namespace ngraph
                               const std::string& name = "external");
                 CPUTensorView(const ngraph::element::Type& element_type,
                               const Shape& shape,
-                              void* mem_handle,
+                              void* memory_pointer,
                               const std::string& name = "external");
                 virtual ~CPUTensorView() override;
 

--- a/src/ngraph/runtime/cpu/cpu_tensor_view.hpp
+++ b/src/ngraph/runtime/cpu/cpu_tensor_view.hpp
@@ -33,6 +33,10 @@ namespace ngraph
                 CPUTensorView(const ngraph::element::Type& element_type,
                               const Shape& shape,
                               const std::string& name = "external");
+                CPUTensorView(const ngraph::element::Type& element_type,
+                              const Shape& shape,
+                              void* mem_handle,
+                              const std::string& name = "external");
                 virtual ~CPUTensorView() override;
 
                 char* get_data_ptr();

--- a/src/ngraph/runtime/gpu/gpu_backend.cpp
+++ b/src/ngraph/runtime/gpu/gpu_backend.cpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "ngraph/runtime/gpu/gpu_backend.hpp"
 #include "ngraph/runtime/external_function.hpp"
+#include "ngraph/runtime/gpu/gpu_backend.hpp"
 #include "ngraph/runtime/gpu/gpu_tensor_view.hpp"
 
 using namespace ngraph;
@@ -32,5 +32,12 @@ std::shared_ptr<ngraph::runtime::TensorView>
                                                         const Shape& shape)
 {
     auto rc = make_shared<runtime::gpu::GPU_TensorView>(element_type, shape);
+    return dynamic_pointer_cast<runtime::TensorView>(rc);
+}
+
+std::shared_ptr<ngraph::runtime::TensorView> runtime::gpu::GPU_Backend::make_primary_tensor_view(
+    const ngraph::element::Type& element_type, const Shape& shape, void* memory_pointer)
+{
+    auto rc = make_shared<runtime::gpu::GPU_TensorView>(element_type, shape, memory_pointer);
     return dynamic_pointer_cast<runtime::TensorView>(rc);
 }

--- a/src/ngraph/runtime/gpu/gpu_backend.cpp
+++ b/src/ngraph/runtime/gpu/gpu_backend.cpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "ngraph/runtime/external_function.hpp"
 #include "ngraph/runtime/gpu/gpu_backend.hpp"
+#include "ngraph/runtime/external_function.hpp"
 #include "ngraph/runtime/gpu/gpu_tensor_view.hpp"
 
 using namespace ngraph;

--- a/src/ngraph/runtime/gpu/gpu_backend.hpp
+++ b/src/ngraph/runtime/gpu/gpu_backend.hpp
@@ -36,6 +36,11 @@ namespace ngraph
                 std::shared_ptr<ngraph::runtime::TensorView>
                     make_primary_tensor_view(const ngraph::element::Type& element_type,
                                              const Shape& shape) override;
+
+                std::shared_ptr<ngraph::runtime::TensorView>
+                    make_primary_tensor_view(const ngraph::element::Type& element_type,
+                                             const Shape& shape,
+                                             void* memory_pointer) override;
             };
         }
     }

--- a/src/ngraph/runtime/gpu/gpu_tensor_view.hpp
+++ b/src/ngraph/runtime/gpu/gpu_tensor_view.hpp
@@ -37,6 +37,9 @@ class ngraph::runtime::gpu::GPU_TensorView : public ngraph::runtime::TensorView
 {
 public:
     GPU_TensorView(const ngraph::element::Type& element_type, const Shape& shape);
+    GPU_TensorView(const ngraph::element::Type& element_type,
+                   const Shape& shape,
+                   void* memory_pointer);
     virtual ~GPU_TensorView();
 
     /// @brief Write bytes directly into the tensor
@@ -53,4 +56,5 @@ public:
 
     void* m_allocated_buffer_pool;
     size_t m_buffer_size;
+    bool m_custom_memory;
 };

--- a/src/ngraph/runtime/host_tensor_view.cpp
+++ b/src/ngraph/runtime/host_tensor_view.cpp
@@ -26,6 +26,7 @@ using namespace std;
 
 runtime::HostTensorView::HostTensorView(const ngraph::element::Type& element_type,
                                         const Shape& shape,
+                                        void* mem_handle,
                                         const string& name)
     : runtime::TensorView(std::make_shared<ngraph::descriptor::PrimaryTensorView>(
           std::make_shared<ngraph::TensorViewType>(element_type, shape), name, true, true, false))
@@ -37,6 +38,13 @@ runtime::HostTensorView::HostTensorView(const ngraph::element::Type& element_typ
         std::make_shared<ngraph::descriptor::layout::DenseTensorViewLayout>(*m_descriptor));
 
     m_buffer_size = m_descriptor->get_tensor_view_layout()->get_size() * element_type.size();
+
+    if (mem_handle != nullptr)
+    {
+        m_aligned_buffer_pool = static_cast<char*>(mem_handle);
+        return;
+    }
+
     if (m_buffer_size > 0)
     {
         size_t allocation_size = m_buffer_size + runtime::alignment;
@@ -48,6 +56,13 @@ runtime::HostTensorView::HostTensorView(const ngraph::element::Type& element_typ
             m_aligned_buffer_pool += (alignment - mod);
         }
     }
+}
+
+runtime::HostTensorView::HostTensorView(const ngraph::element::Type& element_type,
+                                        const Shape& shape,
+                                        const string& name)
+    : HostTensorView(element_type, shape, nullptr, name)
+{
 }
 
 runtime::HostTensorView::~HostTensorView()

--- a/src/ngraph/runtime/host_tensor_view.cpp
+++ b/src/ngraph/runtime/host_tensor_view.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 runtime::HostTensorView::HostTensorView(const ngraph::element::Type& element_type,
                                         const Shape& shape,
-                                        void* mem_handle,
+                                        void* memory_pointer,
                                         const string& name)
     : runtime::TensorView(std::make_shared<ngraph::descriptor::PrimaryTensorView>(
           std::make_shared<ngraph::TensorViewType>(element_type, shape), name, true, true, false))
@@ -39,13 +39,12 @@ runtime::HostTensorView::HostTensorView(const ngraph::element::Type& element_typ
 
     m_buffer_size = m_descriptor->get_tensor_view_layout()->get_size() * element_type.size();
 
-    if (mem_handle != nullptr)
+    if (memory_pointer != nullptr)
     {
-        m_aligned_buffer_pool = static_cast<char*>(mem_handle);
+        m_aligned_buffer_pool = static_cast<char*>(memory_pointer);
         return;
     }
-
-    if (m_buffer_size > 0)
+    else if (m_buffer_size > 0)
     {
         size_t allocation_size = m_buffer_size + runtime::alignment;
         m_allocated_buffer_pool = static_cast<char*>(malloc(allocation_size));

--- a/src/ngraph/runtime/host_tensor_view.cpp
+++ b/src/ngraph/runtime/host_tensor_view.cpp
@@ -42,7 +42,6 @@ runtime::HostTensorView::HostTensorView(const ngraph::element::Type& element_typ
     if (memory_pointer != nullptr)
     {
         m_aligned_buffer_pool = static_cast<char*>(memory_pointer);
-        return;
     }
     else if (m_buffer_size > 0)
     {

--- a/src/ngraph/runtime/host_tensor_view.hpp
+++ b/src/ngraph/runtime/host_tensor_view.hpp
@@ -37,6 +37,10 @@ public:
     HostTensorView(const ngraph::element::Type& element_type,
                    const Shape& shape,
                    const std::string& name = "external");
+    HostTensorView(const ngraph::element::Type& element_type,
+                   const Shape& shape,
+                   void* mem_handle,
+                   const std::string& name = "external");
     virtual ~HostTensorView() override;
 
     char* get_data_ptr();

--- a/src/ngraph/runtime/host_tensor_view.hpp
+++ b/src/ngraph/runtime/host_tensor_view.hpp
@@ -39,7 +39,7 @@ public:
                    const std::string& name = "external");
     HostTensorView(const ngraph::element::Type& element_type,
                    const Shape& shape,
-                   void* mem_handle,
+                   void* memory_pointer,
                    const std::string& name = "external");
     virtual ~HostTensorView() override;
 

--- a/src/ngraph/runtime/interpreter/int_backend.cpp
+++ b/src/ngraph/runtime/interpreter/int_backend.cpp
@@ -14,10 +14,10 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "ngraph/runtime/interpreter/int_backend.hpp"
 #include "ngraph/log.hpp"
 #include "ngraph/runtime/external_function.hpp"
 #include "ngraph/runtime/host_tensor_view.hpp"
+#include "ngraph/runtime/interpreter/int_backend.hpp"
 
 using namespace ngraph;
 using namespace std;
@@ -33,5 +33,12 @@ shared_ptr<runtime::TensorView>
                                                                 const Shape& shape)
 {
     auto rc = make_shared<runtime::HostTensorView>(element_type, shape, "external");
+    return static_pointer_cast<runtime::TensorView>(rc);
+}
+
+shared_ptr<runtime::TensorView> runtime::interpreter::INT_Backend::make_primary_tensor_view(
+    const element::Type& element_type, const Shape& shape, void* mem_handle)
+{
+    auto rc = make_shared<runtime::HostTensorView>(element_type, shape, mem_handle, "external");
     return static_pointer_cast<runtime::TensorView>(rc);
 }

--- a/src/ngraph/runtime/interpreter/int_backend.cpp
+++ b/src/ngraph/runtime/interpreter/int_backend.cpp
@@ -37,8 +37,8 @@ shared_ptr<runtime::TensorView>
 }
 
 shared_ptr<runtime::TensorView> runtime::interpreter::INT_Backend::make_primary_tensor_view(
-    const element::Type& element_type, const Shape& shape, void* mem_handle)
+    const element::Type& element_type, const Shape& shape, void* memory_pointer)
 {
-    auto rc = make_shared<runtime::HostTensorView>(element_type, shape, mem_handle, "external");
+    auto rc = make_shared<runtime::HostTensorView>(element_type, shape, memory_pointer, "external");
     return static_pointer_cast<runtime::TensorView>(rc);
 }

--- a/src/ngraph/runtime/interpreter/int_backend.cpp
+++ b/src/ngraph/runtime/interpreter/int_backend.cpp
@@ -14,10 +14,10 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "ngraph/runtime/interpreter/int_backend.hpp"
 #include "ngraph/log.hpp"
 #include "ngraph/runtime/external_function.hpp"
 #include "ngraph/runtime/host_tensor_view.hpp"
-#include "ngraph/runtime/interpreter/int_backend.hpp"
 
 using namespace ngraph;
 using namespace std;

--- a/src/ngraph/runtime/interpreter/int_backend.hpp
+++ b/src/ngraph/runtime/interpreter/int_backend.hpp
@@ -34,6 +34,11 @@ namespace ngraph
                 std::shared_ptr<ngraph::runtime::TensorView>
                     make_primary_tensor_view(const ngraph::element::Type& element_type,
                                              const Shape& shape) override;
+
+                std::shared_ptr<ngraph::runtime::TensorView>
+                    make_primary_tensor_view(const ngraph::element::Type& element_type,
+                                             const Shape& shape,
+                                             void* mem_handle) override;
             };
         }
     }

--- a/src/ngraph/runtime/interpreter/int_backend.hpp
+++ b/src/ngraph/runtime/interpreter/int_backend.hpp
@@ -38,7 +38,7 @@ namespace ngraph
                 std::shared_ptr<ngraph::runtime::TensorView>
                     make_primary_tensor_view(const ngraph::element::Type& element_type,
                                              const Shape& shape,
-                                             void* mem_handle) override;
+                                             void* memory_pointer) override;
             };
         }
     }


### PR DESCRIPTION
Enable users to pass aligned pre-allocated mem, for use by TensorView.