### PR TITLE
Compiler work-arounds.

### DIFF
--- a/doc/examples/update.cpp
+++ b/doc/examples/update.cpp
@@ -35,13 +35,13 @@ int main()
     std::cout << "Stateless: ";
     int counter = 0;
     {
-        auto r{stateless_count(counter)};
+        auto r(stateless_count(counter));
         counter = std::get<1>(r);
         std::cout << std::get<0>(r);
     }
     std::cout << ", ";
     {
-        auto r{stateless_count(counter)};
+        auto r(stateless_count(counter));
         counter = std::get<1>(r);
         std::cout << std::get<0>(r);
     }

--- a/src/ngraph/builder/tensor_mask.hpp
+++ b/src/ngraph/builder/tensor_mask.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <numeric>
+
 #include "ngraph/axis_set.hpp"
 #include "ngraph/node.hpp"
 #include "ngraph/op/broadcast.hpp"


### PR DESCRIPTION
Works around a gcc 4.8 problem on Centos where { } initialization was treated as an initializer list.
Adds a missing include.