### PR TITLE
remove parameter check from Function::get_ops()

### DIFF
--- a/src/ngraph/function.cpp
+++ b/src/ngraph/function.cpp
@@ -176,21 +176,7 @@ shared_ptr<Node> Function::get_result() const
 std::list<shared_ptr<Node>> Function::get_ops() const
 {
     std::list<std::shared_ptr<Node>> ops;
-    traverse_nodes(this, [&](shared_ptr<Node> node) {
-        ops.push_back(node);
-
-        std::shared_ptr<op::Parameter> p = std::dynamic_pointer_cast<op::Parameter>(node);
-        if (nullptr != p)
-        {
-            auto it = std::find_if(m_parameters.begin(),
-                                   m_parameters.end(),
-                                   [p](std::shared_ptr<op::Parameter> q) { return (p == q); });
-            if (it == m_parameters.end())
-            {
-                throw ngraph_error("Function references undeclared parameter");
-            }
-        }
-    });
+    traverse_nodes(this, [&](shared_ptr<Node> node) { ops.push_back(node); });
     return ops;
 }
 


### PR DESCRIPTION
The test to check the parameters is done every time we call get_ops(). This check increases the get_ops() call from 8ms to 164ms. Since this method is call multiple times during codegen is it adding to compile time causing the LSTM_backewards.json test to go from 7.5s to 9s.

If we want this test it should be something that is done in a pass and done only once.