### PR TITLE
start kahan summation residuals with 0 instead of 1e-8

### DIFF
--- a/src/ngraph/runtime/cpu/cpu_kernel_emitters.cpp
+++ b/src/ngraph/runtime/cpu/cpu_kernel_emitters.cpp
@@ -309,7 +309,7 @@ void ngraph::runtime::cpu::kernel::emit_sum(codegen::CodeWriter& writer,
         auto output_vars = open_for_loops(writer, out_shape);
 
         writer << dest_nd_name << emit_bracketed_string(output_vars) << " = 0;\n";
-        writer << "residual" << emit_bracketed_string(output_vars) << " = 1e-8;\n";
+        writer << "residual" << emit_bracketed_string(output_vars) << " = 0;\n";
 
         close_for_loops(writer, output_vars);
     }


### PR DESCRIPTION
Properly implements the Kahan aglorithm and gives us better accuracy when summing small numbers.

Don't remember why I used 1e-8 in the first place, oops.

Reimplementng with pairwise summation or Eigen's loop unrolling algorithm might give us the stability with faster execution