### PR TITLE
Remove usage of CMAKE_MAKE_PROGRAM as it slows down parallel build

### DIFF
--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -39,7 +39,6 @@ if(NGRAPH_CPU_ENABLE)
                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                 -DCMAKE_INSTALL_PREFIX=${EXTERNAL_PROJECTS_ROOT}/mkldnn
-            BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} mkldnn
             TMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/tmp"
             STAMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/stamp"
             DOWNLOAD_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/download"
@@ -60,7 +59,6 @@ if(NGRAPH_CPU_ENABLE)
                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                 -DCMAKE_INSTALL_PREFIX=${EXTERNAL_PROJECTS_ROOT}/mkldnn
-            BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} mkldnn
             TMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/tmp"
             STAMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/stamp"
             DOWNLOAD_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/download"

--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -39,7 +39,6 @@ if(NGRAPH_CPU_ENABLE)
                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                 -DCMAKE_INSTALL_PREFIX=${EXTERNAL_PROJECTS_ROOT}/mkldnn
-            BUILD_COMMAND $(MAKE) mkldnn
             TMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/tmp"
             STAMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/stamp"
             DOWNLOAD_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/download"
@@ -60,7 +59,6 @@ if(NGRAPH_CPU_ENABLE)
                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                 -DCMAKE_INSTALL_PREFIX=${EXTERNAL_PROJECTS_ROOT}/mkldnn
-            BUILD_COMMAND $(MAKE) mkldnn
             TMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/tmp"
             STAMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/stamp"
             DOWNLOAD_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/download"

--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -39,6 +39,7 @@ if(NGRAPH_CPU_ENABLE)
                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                 -DCMAKE_INSTALL_PREFIX=${EXTERNAL_PROJECTS_ROOT}/mkldnn
+            BUILD_COMMAND $(MAKE) mkldnn
             TMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/tmp"
             STAMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/stamp"
             DOWNLOAD_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/download"
@@ -59,6 +60,7 @@ if(NGRAPH_CPU_ENABLE)
                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                 -DCMAKE_INSTALL_PREFIX=${EXTERNAL_PROJECTS_ROOT}/mkldnn
+            BUILD_COMMAND $(MAKE) mkldnn
             TMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/tmp"
             STAMP_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/stamp"
             DOWNLOAD_DIR "${EXTERNAL_PROJECTS_ROOT}/mkldnn/download"


### PR DESCRIPTION
Current build process for external mkl-dnn tries to speed up compilation by invoking just part of the Make rules bt doing `BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} mkldnn` But that effectively disables parallel build. This PR remove the explicit BUILD_COMMAND and enables parallel build. Now more work is done but in parallel and the build time is faster.