### PR TITLE
CPU codegen compiler enhancements

### DIFF
--- a/src/ngraph/codegen/compiler.hpp
+++ b/src/ngraph/codegen/compiler.hpp
@@ -88,6 +88,7 @@ private:
     bool m_precompiled_header_valid;
     bool m_debuginfo_enabled;
     bool m_enable_diag_output;
+    bool m_enable_pass_report;
     std::string m_source_name;
     std::vector<std::string> m_extra_search_path_list;
     std::string m_pch_path;


### PR DESCRIPTION
This PR provides two enhancements to the clang compiler usage:
* added an option to generate vectorization reports when `NGRAPH_COMPILER_DIAG_ENABLE` and `NGRAPH_COMPILER_REPORT_ENABLE` (this is new) are defined.
* handle clang parameter parsing error behavior, instead of segfault, clang/llvm error message will be output when `NGRAPH_COMPILER_DIAG_ENABLE` is defined.
