### PR TITLE
[Py] Python nGraph API doc

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -19,8 +19,12 @@
 
 import os
 import sys
+
 # Add path to nGraph Python API.
-sys.path.append(os.path.abspath('../../../python'))
+
+#sys.path.append(os.path.abspath('../../../python/ngraph'))
+
+sys.path.insert(0, os.path.abspath('../../../python'))
 
 # -- General configuration ------------------------------------------------
 
@@ -33,6 +37,8 @@ needs_sphinx = '1.6.5'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.inheritance_diagram',
+    'sphinx.ext.graphviz',
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -21,9 +21,6 @@ import os
 import sys
 
 # Add path to nGraph Python API.
-
-#sys.path.append(os.path.abspath('../../../python/ngraph'))
-
 sys.path.insert(0, os.path.abspath('../../../python'))
 
 # -- General configuration ------------------------------------------------
@@ -37,6 +34,7 @@ needs_sphinx = '1.6.5'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.graphviz',
     'sphinx.ext.mathjax',
@@ -219,3 +217,7 @@ rst_epilog = u"""
 # -- autodoc Extension configuration --------------------------------------
 
 autodoc_mock_imports = ['ngraph.impl', 'ngraph.utils']
+
+# -- autosummary Extension configuration ----------------------------------
+
+autosummary_generate = ['python_api/structure.rst']

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -16,11 +16,11 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
 
+import os
+import sys
+# Add path to nGraph Python API.
+sys.path.append(os.path.abspath('../../../python'))
 
 # -- General configuration ------------------------------------------------
 
@@ -31,10 +31,12 @@ needs_sphinx = '1.6.5'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.mathjax',
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'breathe'
+    'breathe',
     ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -208,4 +210,6 @@ rst_epilog = u"""
    
 """
 
+# -- autodoc Extension configuration --------------------------------------
 
+autodoc_mock_imports = ['ngraph.impl', 'ngraph.utils']

--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -145,6 +145,7 @@ Contents
    project/index.rst
    framework-integration-guides.rst
    optimize/index.rst
+   python_api/index.rst
 
 
 Indices and tables

--- a/doc/sphinx/source/python_api/_autosummary/ngraph.exceptions.rst
+++ b/doc/sphinx/source/python_api/_autosummary/ngraph.exceptions.rst
@@ -1,0 +1,15 @@
+=================
+ngraph.exceptions
+=================
+
+.. automodule:: ngraph.exceptions
+
+   .. rubric:: Exceptions
+
+   .. autosummary::
+   
+      NgraphError
+      NgraphTypeError
+      UserInputError
+   
+   

--- a/doc/sphinx/source/python_api/_autosummary/ngraph.ops.rst
+++ b/doc/sphinx/source/python_api/_autosummary/ngraph.ops.rst
@@ -1,0 +1,68 @@
+==========
+ngraph.ops
+==========
+
+.. automodule:: ngraph.ops
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :nosignatures:
+
+      absolute
+      acos
+      add
+      asin
+      atan
+      avg_pool
+      batch_norm
+      broadcast
+      ceiling
+      concat
+      constant
+      convert
+      convolution
+      cos
+      cosh
+      divide
+      dot
+      equal
+      exp
+      floor
+      function_call
+      get_output_element
+      greater
+      greater_eq
+      less
+      less_eq
+      log
+      logical_not
+      max
+      max_pool
+      maximum
+      min
+      minimum
+      multiply
+      negative
+      not_equal
+      one_hot
+      pad
+      parameter
+      power
+      prod
+      reduce
+      relu
+      replace_slice
+      reshape
+      reverse
+      select
+      sign
+      sin
+      sinh
+      slice
+      softmax
+      sqrt
+      subtract
+      sum
+      tan
+      tanh

--- a/doc/sphinx/source/python_api/_autosummary/ngraph.rst
+++ b/doc/sphinx/source/python_api/_autosummary/ngraph.rst
@@ -7,9 +7,6 @@ ngraph
 
 .. automodule:: ngraph
    :members:
-   :public-members:
-
-
 
 Submodules
 ==========
@@ -23,7 +20,6 @@ Exceptions
    :undoc-members:
    :show-inheritance:
 
-
 Ops
 ---
 
@@ -32,7 +28,6 @@ Ops
    :undoc-members:
    :show-inheritance:
 
-
 Runtime
 --------
 
@@ -40,5 +35,4 @@ Runtime
    :members:
    :undoc-members:
    :show-inheritance:
-
 

--- a/doc/sphinx/source/python_api/_autosummary/ngraph.runtime.rst
+++ b/doc/sphinx/source/python_api/_autosummary/ngraph.runtime.rst
@@ -1,0 +1,20 @@
+==============
+ngraph.runtime
+==============
+
+.. automodule:: ngraph.runtime
+
+.. rubric:: Functions
+
+.. autosummary::
+   :nosignatures:
+
+   runtime
+
+.. rubric:: Classes
+
+.. autosummary::
+   :nosignatures:
+
+   Computation
+   Runtime

--- a/doc/sphinx/source/python_api/index.rst
+++ b/doc/sphinx/source/python_api/index.rst
@@ -6,8 +6,9 @@ Python API
 
 This section contains nGraph™ Python API documentation.
 
-Packages
-++++++++
+Module Index
+============
+
 .. toctree::
    :maxdepth: 1
 
@@ -18,8 +19,8 @@ Packages
 =======
 
 
-Simple example of API usage:
-++++++++++++++++++++++++++++
+Simple example of API usage
+===========================
 
 .. literalinclude:: /../../../python/examples/basic.py
    :language: python

--- a/doc/sphinx/source/python_api/index.rst
+++ b/doc/sphinx/source/python_api/index.rst
@@ -4,24 +4,18 @@
 Python API
 ##########
 
-This section contains nGraph™ Python API documentation.
-
-Module Index
-============
-
-.. toctree::
-   :maxdepth: 1
-
-   ngraph
-
-* :ref:`modindex`
-
-=======
-
-
-Simple example of API usage
-===========================
+This section contains nGraph™ Python API documentation. Python API exposes
+nGraph™ C++ operations to Python users. For quick-start you can find API usage
+example below.
 
 .. literalinclude:: /../../../python/examples/basic.py
    :language: python
    :lines: 18-48
+
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   structure
+   supported_ops

--- a/doc/sphinx/source/python_api/index.rst
+++ b/doc/sphinx/source/python_api/index.rst
@@ -1,0 +1,26 @@
+.. python_api/index.rst
+
+##########
+Python API
+##########
+
+This section contains nGraph™ Python API documentation.
+
+Packages
+++++++++
+.. toctree::
+   :maxdepth: 1
+
+   ngraph
+
+* :ref:`modindex`
+
+=======
+
+
+Simple example of API usage:
+++++++++++++++++++++++++++++
+
+.. literalinclude:: /../../../python/examples/basic.py
+   :language: python
+   :lines: 18-48

--- a/doc/sphinx/source/python_api/index.rst
+++ b/doc/sphinx/source/python_api/index.rst
@@ -5,8 +5,8 @@ Python API
 ##########
 
 This section contains nGraph™ Python API documentation. Python API exposes
-nGraph™ C++ operations to Python users. For quick-start you can find API usage
-example below.
+nGraph™ C++ operations to Python users. For quick-start you can find an example
+of the API usage below.
 
 .. literalinclude:: /../../../python/examples/basic.py
    :language: python

--- a/doc/sphinx/source/python_api/ngraph.rst
+++ b/doc/sphinx/source/python_api/ngraph.rst
@@ -4,39 +4,41 @@
 ngraph
 ######
 
+
 .. automodule:: ngraph
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :public-members:
+
 
 
 Submodules
+==========
+
+
+Exceptions
 ----------
 
-ngraph.exceptions module
-------------------------
-
 .. automodule:: ngraph.exceptions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
-ngraph.ops module
------------------
+Ops
+---
 
 .. automodule:: ngraph.ops
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
-ngraph.runtime module
----------------------
+Runtime
+--------
 
 .. automodule:: ngraph.runtime
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 

--- a/doc/sphinx/source/python_api/ngraph.rst
+++ b/doc/sphinx/source/python_api/ngraph.rst
@@ -1,0 +1,42 @@
+.. ngraph.rst
+
+######
+ngraph
+######
+
+.. automodule:: ngraph
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Submodules
+----------
+
+ngraph.exceptions module
+------------------------
+
+.. automodule:: ngraph.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+ngraph.ops module
+-----------------
+
+.. automodule:: ngraph.ops
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+ngraph.runtime module
+---------------------
+
+.. automodule:: ngraph.runtime
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/doc/sphinx/source/python_api/structure.rst
+++ b/doc/sphinx/source/python_api/structure.rst
@@ -1,0 +1,12 @@
+=================
+Package structure
+=================
+
+.. autosummary::
+   :toctree: _autosummary
+   :nosignatures:
+
+   ngraph
+   ngraph.exceptions
+   ngraph.ops
+   ngraph.runtime

--- a/doc/sphinx/source/python_api/structure.rst
+++ b/doc/sphinx/source/python_api/structure.rst
@@ -1,6 +1,7 @@
-=================
-Package structure
-=================
+==================
+nGraph Python APIs
+==================
+
 
 .. autosummary::
    :toctree: _autosummary

--- a/doc/sphinx/source/python_api/supported_ops.rst
+++ b/doc/sphinx/source/python_api/supported_ops.rst
@@ -1,0 +1,68 @@
+============================
+List of operations
+============================
+
+.. currentmodule:: ngraph.ops
+
+.. rubric:: Functions
+
+.. autosummary::
+   :nosignatures:
+
+   absolute
+   acos
+   add
+   asin
+   atan
+   avg_pool
+   batch_norm
+   broadcast
+   ceiling
+   concat
+   constant
+   convert
+   convolution
+   cos
+   cosh
+   divide
+   dot
+   equal
+   exp
+   floor
+   function_call
+   get_output_element
+   greater
+   greater_eq
+   less
+   less_eq
+   log
+   logical_not
+   max
+   max_pool
+   maximum
+   min
+   minimum
+   multiply
+   negative
+   not_equal
+   one_hot
+   pad
+   parameter
+   power
+   prod
+   reduce
+   relu
+   replace_slice
+   reshape
+   reverse
+   select
+   sign
+   sin
+   sinh
+   slice
+   softmax
+   sqrt
+   subtract
+   sum
+   tan
+   tanh

--- a/python/ngraph/ops.py
+++ b/python/ngraph/ops.py
@@ -825,5 +825,5 @@ def function_call(function_to_call, args):  # type: (Node, NodeVector) -> Node
 
 @nameable_op
 def get_output_element(data, index):  # type: (Node, int) -> Node
-    """Return the `n`th element of the input tuple."""
+    """Return the n-th element of the input tuple."""
     return GetOutputElement(data, index)


### PR DESCRIPTION
Currently there are few layout issues:
- [x] How to remove from the sidebar elements under 'Python API' (subparagraphs from respective page)
- [x] How to enforce that when we go under Python API -> ngraph  page to be visible in breadcrumb.
- [x]  Is it possible to unroll inplace the page "Modules Index" ?