### PR TITLE
Force backends to register by calling dlopen

### DIFF
--- a/src/ngraph/CMakeLists.txt
+++ b/src/ngraph/CMakeLists.txt
@@ -333,6 +333,7 @@ if (NGRAPH_NNP_ENABLE)
 endif()
 
 target_include_directories(ngraph PUBLIC "${NGRAPH_INCLUDE_PATH}")
+target_link_libraries(ngraph PRIVATE dl)
 
 if((NGRAPH_CPU_ENABLE OR NGRAPH_GPU_ENABLE) AND LLVM_LINK_LIBS)
     target_link_libraries(ngraph PRIVATE ${LLVM_LINK_LIBS})

--- a/src/ngraph/runtime/backend.cpp
+++ b/src/ngraph/runtime/backend.cpp
@@ -53,6 +53,11 @@ void* runtime::Backend::open_shared_library(const string& type)
         handle = dlopen(name.c_str(), RTLD_NOW);
         if (handle)
         {
+            function<void()> create = reinterpret_cast<void (*)()>(dlsym(handle, "create_backend"));
+            if (create)
+            {
+                create();
+            }
             break;
         }
     }

--- a/src/ngraph/runtime/backend.cpp
+++ b/src/ngraph/runtime/backend.cpp
@@ -43,22 +43,14 @@ runtime::Backend::~Backend()
 void* runtime::Backend::open_shared_library(const string& type)
 {
     void* handle = nullptr;
-    vector<string> names;
-    names.push_back("lib" + type + ".so");
-    names.push_back("lib" + to_lower(type) + ".so");
-    names.push_back("lib" + type + "_backend.so");
-    names.push_back("lib" + to_lower(type) + "_backend.so");
-    for (const string& name : names)
+    string name = "lib" + type + "_backend.so";
+    handle = dlopen(name.c_str(), RTLD_NOW);
+    if (handle)
     {
-        handle = dlopen(name.c_str(), RTLD_NOW);
-        if (handle)
+        function<void()> create = reinterpret_cast<void (*)()>(dlsym(handle, "create_backend"));
+        if (create)
         {
-            function<void()> create = reinterpret_cast<void (*)()>(dlsym(handle, "create_backend"));
-            if (create)
-            {
-                create();
-            }
-            break;
+            create();
         }
     }
     return handle;

--- a/src/ngraph/runtime/backend.hpp
+++ b/src/ngraph/runtime/backend.hpp
@@ -83,6 +83,7 @@ namespace ngraph
                                const std::vector<std::shared_ptr<runtime::TensorView>>& inputs);
 
         private:
+            static void* open_shared_library(const std::string& name);
             static std::unordered_map<std::string, std::shared_ptr<Backend>>& get_backend_map();
         };
     }


### PR DESCRIPTION
If a user requests a backend like this `Backend::create("IE")` and that backend has not been registered yet then try opening it via dlopen which will force it to register.
We try the following name combinations for the name of the shared library:
```
libIE.so
libIE_backend.so
libie.so
libie_backend.so
```
If any of those work then the backend will register itself and all is well.
