### PR TITLE
Disable copy constructor for TVL

### DIFF
--- a/src/ngraph/descriptor/layout/tensor_view_layout.hpp
+++ b/src/ngraph/descriptor/layout/tensor_view_layout.hpp
@@ -41,6 +41,8 @@ namespace ngraph
             {
             protected:
                 TensorViewLayout(const ngraph::descriptor::TensorView& tensor_view);
+                TensorViewLayout(const TensorViewLayout&) = delete;
+                TensorViewLayout& operator=(const TensorViewLayout&) = delete;
 
             public:
                 virtual ~TensorViewLayout() {}

--- a/src/ngraph/runtime/cpu/cpu_emitter.cpp
+++ b/src/ngraph/runtime/cpu/cpu_emitter.cpp
@@ -3312,11 +3312,12 @@ namespace ngraph
             {
                 auto input_tvl =
                     node->get_inputs()[0].get_output().get_tensor_view()->get_tensor_view_layout();
-                auto input_cpu_tvl = dynamic_cast<runtime::cpu::LayoutDescriptor&>(*input_tvl);
-                auto input_format = input_cpu_tvl.get_mkldnn_format();
+                auto input_cpu_tvl =
+                    dynamic_pointer_cast<runtime::cpu::LayoutDescriptor>(input_tvl);
+                auto input_format = input_cpu_tvl->get_mkldnn_format();
 
                 // Reorder input shape if needed
-                auto input_axis_order = input_cpu_tvl.get_axis_order();
+                auto input_axis_order = input_cpu_tvl->get_axis_order();
                 Shape input_shape(input_axis_order.size());
                 for (size_t idx = 0; idx < input_axis_order.size(); idx++)
                 {


### PR DESCRIPTION
Similar to `Tensor` and `TensorView`, copy constructor is disabled for `TensorViewLayout`.

This fixes the following error in clang:
```
In file included from /home/yixing/repo/ngraph/src/ngraph/runtime/cpu/cpu_emitter.cpp:17:
In file included from /home/yixing/repo/ngraph/src/ngraph/runtime/cpu/cpu_emitter.hpp:24:
In file included from /home/yixing/repo/ngraph/src/ngraph/runtime/cpu/cpu_external_function.hpp:32:
In file included from /home/yixing/repo/ngraph/src/ngraph/runtime/cpu/cpu_call_frame.hpp:24:
/home/yixing/repo/ngraph/src/ngraph/runtime/cpu/cpu_layout_descriptor.hpp:42:17: error: definition of implicit copy constructor for 'LayoutDescriptor' is
      deprecated because it has a user-declared destructor [-Werror,-Wdeprecated]
                ~LayoutDescriptor() override {}
                ^
/home/yixing/repo/ngraph/src/ngraph/runtime/cpu/cpu_emitter.cpp:3315:38: note: implicit copy constructor for 'LayoutDescriptor' first required here
                auto input_cpu_tvl = dynamic_cast<runtime::cpu::LayoutDescriptor&>(*input_tvl);```