### PR TITLE
Expose ngraph unit test util as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,8 +238,8 @@ if (NGRAPH_UNIT_TEST_ENABLE)
     add_subdirectory(test)
     message(STATUS "unit tests enabled")
 else()
-    message(STATUS "unit tests disabled")
+    add_subdirectory(test/util)
+    message(STATUS "unit tests disabled, but libngraph_test_util.so will be built")
 endif()
 
 add_subdirectory(doc)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,7 @@ if (NGRAPH_UNIT_TEST_ENABLE)
     message(STATUS "unit tests enabled")
 else()
     add_subdirectory(test/util)
-    message(STATUS "unit tests disabled, but libngraph_test_util.so will be built")
+    message(STATUS "unit tests disabled")
 endif()
 
 add_subdirectory(doc)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,10 +20,6 @@ include_directories(
     ${EIGEN_INCLUDE_DIR}
     )
 
-include_directories(
-    ${NGRAPH_INCLUDE_DIR}
-    )
-
 set (SRC
     backend_api.cpp
     algebraic_simplification.cpp
@@ -51,9 +47,6 @@ set (SRC
     reshape_elimination.cpp
     tensor.cpp
     type_prop.cpp
-    util/autodiff/backprop_function.cpp
-    util/test_tools.cpp
-    util/benchmark.cpp
     util.cpp
     uuid.cpp
     zero_dim_tensor_elimination.cpp
@@ -61,6 +54,7 @@ set (SRC
 
 add_subdirectory(models)
 add_subdirectory(files)
+add_subdirectory(util)
 
 #================================================================================================
 # To auto generate a suite of unit tests for a backend add a line like this
@@ -151,6 +145,8 @@ if(NGRAPH_ADDRESS_SANITIZER)
 endif()
 
 add_executable(unit-test ${SRC})
+target_link_libraries(unit-test ngraph_test_util)
+add_dependencies(unit-test ngraph_test_util)
 
 if(MPI_C_INCLUDE_PATH)
     target_link_libraries(unit-test ${MPI_CXX_LIBRARIES})

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -26,3 +26,4 @@ include_directories(
 )
 
 add_library(ngraph_test_util SHARED ${SRC})
+install(TARGETS ngraph_test_util DESTINATION ${NGRAPH_INSTALL_LIB})  # libngraph_test_util.so

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -26,4 +26,4 @@ include_directories(
 )
 
 add_library(ngraph_test_util SHARED ${SRC})
-install(TARGETS ngraph_test_util DESTINATION ${NGRAPH_INSTALL_LIB})  # libngraph_test_util.so
+install(TARGETS ngraph_test_util DESTINATION ${NGRAPH_INSTALL_LIB})

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -1,0 +1,28 @@
+# ******************************************************************************
+# Copyright 2017-2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ******************************************************************************
+
+set (SRC
+    autodiff/backprop_function.cpp
+    test_tools.cpp
+    benchmark.cpp
+)
+
+include_directories(
+    ${NGRAPH_INCLUDE_PATH}
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+add_library(ngraph_test_util SHARED ${SRC})


### PR DESCRIPTION
Expose ngraph unit test utils as a library `libngraph_test_util.so`. This allows external backends to link against it.