### PR TITLE
Move temporary buffer pools to CPU runtime context to avoid static va…

### DIFF
--- a/src/ngraph/runtime/cpu/cpu_external_function.hpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.hpp
@@ -79,7 +79,10 @@ namespace ngraph
 
                 const LayoutDescriptorPtrs& get_parameter_layout_descriptors();
                 const LayoutDescriptorPtrs& get_result_layout_descriptors();
-
+                const std::vector<size_t>& get_memory_buffer_sizes() const
+                {
+                    return m_memory_buffer_sizes;
+                }
                 const std::vector<OpAttributes>& get_op_attrs() const { return m_op_attrs; }
                 const std::unique_ptr<MKLDNNEmitter>& get_mkldnn_emitter() const
                 {
@@ -88,6 +91,9 @@ namespace ngraph
 
                 const std::string& get_function_name() const { return m_function_name; }
                 const std::shared_ptr<ngraph::Function> get_function() { return m_function; }
+                // Temporary Memory Pool alignment
+                static const size_t s_memory_pool_alignment = 4096;
+
             protected:
                 void compile();
 
@@ -130,6 +136,7 @@ namespace ngraph
 
                 LayoutDescriptorPtrs parameter_layout_descriptors;
                 LayoutDescriptorPtrs result_layout_descriptors;
+                std::vector<size_t> m_memory_buffer_sizes;
                 std::vector<OpAttributes> m_op_attrs;
 
                 std::unique_ptr<MKLDNNEmitter> m_mkldnn_emitter;

--- a/src/ngraph/runtime/cpu/cpu_runtime_context.hpp
+++ b/src/ngraph/runtime/cpu/cpu_runtime_context.hpp
@@ -28,6 +28,14 @@ namespace ngraph
 {
     namespace runtime
     {
+        class AlignedBuffer;
+    }
+}
+
+namespace ngraph
+{
+    namespace runtime
+    {
         namespace cpu
         {
             typedef std::chrono::high_resolution_clock Clock;
@@ -40,6 +48,7 @@ namespace ngraph
                 int64_t* op_durations;
                 bool* p_en;
                 mkldnn::primitive* const* mkldnn_primitives;
+                std::vector<AlignedBuffer*> memory_buffers;
                 char* const* mkldnn_workspaces;
             };
             }


### PR DESCRIPTION
…riable destruction issues with clang