### PR TITLE
Don't build mkl-dnn if user manually provides mkl-dnn.

### DIFF
--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -21,6 +21,18 @@ include(ExternalProject)
 #----------------------------------------------------------------------------------------------------------
 
 if(NGRAPH_CPU_ENABLE)
+    # User provided mkl-dnn
+    if(MKLDNN_INCLUDE_DIR AND MKLDNN_LIB_DIR)
+        ExternalProject_Add(
+            ext_mkldnn
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND ""
+            INSTALL_COMMAND ""
+            )
+        return()
+    endif()
 
     set(MKLDNN_GIT_REPO_URL https://github.com/intel/mkl-dnn)
     set(MKLDNN_GIT_TAG "0e7ca73")


### PR DESCRIPTION
If user manually provide MKLDNN_INCLUDE_DIR and MKLDNN_LIB_DIR, don't
build mkl-dnn and just add a dummy external project "ext-_mkldnn" to
satisfy target dependency for the rest of the build.
Supports usage case where a framework already uses mkl-dnn.