### PR TITLE
fix bug in dot op, add another test to catch the error, enable more tests

### DIFF
--- a/src/ngraph/runtime/gpu/gpu_emitter.cpp
+++ b/src/ngraph/runtime/gpu/gpu_emitter.cpp
@@ -508,7 +508,7 @@ CUDNN_SAFE_CALL(cudnnSetOpTensorDescriptor(opTensorDesc,
                               "CUBLAS_POINTER_MODE_HOST));\n";
                     writer << "CUBLAS_SAFE_CALL(cublasSgemv("
                            << "*ctx->cublas_handle,"
-                           << "CUBLAS_OP_T," << arg0_shape[0] << "," << arg0_shape[1] << ","
+                           << "CUBLAS_OP_T," << arg0_shape[1] << "," << arg0_shape[0] << ","
                            << "&alpha," // Alpha
                            << args[0].get_name() << "," << arg0_shape[1] << ","
                            << args[1].get_name() << ","

--- a/src/ngraph/runtime/gpu/unit_test.manifest
+++ b/src/ngraph/runtime/gpu/unit_test.manifest
@@ -7,7 +7,6 @@ backwards_concat_axis_0
 backwards_concat_axis_1
 backwards_concat_vector
 backwards_divide
-backwards_dot_tensor_vector
 backwards_dot_tensor2_tensor2
 backwards_dot_tensor3_tensor3
 backwards_log
@@ -67,11 +66,7 @@ convolution_4d_4items_strided_dilated_padded_same
 divide_adjoint_stability
 divide_by_zero_float32
 divide_by_zero_int32
-dot_3d_multi_axis
-dot_3d_one_axis_arbitrary
-dot_4d_5d_multi_axis
 dot_4d_5d_multi_axis_big_fp64_VERY_SLOW
-dot_4d_5d_multi_axis_more
 dot_matrix_vector_int64
 function_call
 logical_and

--- a/test/backend_test.in.cpp
+++ b/test/backend_test.in.cpp
@@ -1156,6 +1156,28 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_scalar_scalar)
     EXPECT_EQ((vector<float>{48}), read_vector<float>(result));
 }
 
+NGRAPH_TEST(${BACKEND_NAME}, dot_matrix_vector_4_3)
+{
+    Shape shape_a{4, 3};
+    Shape shape_b{3};
+    auto A = make_shared<op::Parameter>(element::f32, shape_a);
+    auto B = make_shared<op::Parameter>(element::f32, shape_b);
+    auto f = make_shared<Function>(make_shared<op::Dot>(A, B), op::ParameterVector{A, B});
+    Shape shape_r{4};
+
+    auto backend = runtime::Backend::create("${BACKEND_NAME}");
+
+    // Create some tensors for input/output
+    auto a = backend->create_tensor(element::f32, shape_a);
+    copy_data(a, vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+    auto b = backend->create_tensor(element::f32, shape_b);
+    copy_data(b, vector<float>{17, 18, 19});
+    auto result = backend->create_tensor(element::f32, shape_r);
+
+    backend->call(f, {result}, {a, b});
+    EXPECT_EQ((vector<float>{110, 272, 434, 596}), read_vector<float>(result));
+}
+
 NGRAPH_TEST(${BACKEND_NAME}, dot_matrix_vector)
 {
     Shape shape_a{4, 4};


### PR DESCRIPTION
the bug is in dot op, due to use n, m instead of m,n for transposed matrix in matrix*vector mode. 

Previously forward dot tests does not catch because the `dot_matrix_vector` is 4x4 and vector size is 4.  Add an 4x3 matrix with size 3 vector to catch the error. 