### PR TITLE
Disable one_hot tests which throw exceptions.

### DIFF
--- a/src/ngraph/runtime/gpu/unit_test.manifest
+++ b/src/ngraph/runtime/gpu/unit_test.manifest
@@ -45,6 +45,11 @@ mkldnn_layouts
 numeric_double_nan
 numeric_float_inf
 numeric_float_nan
+one_hot_scalar_fp_nonint_in_3
+one_hot_scalar_oob_in_3
+one_hot_vector_1_barely_oob
+one_hot_vector_1_far_oob
+one_hot_vector_1_fp_nonint
 parameter_as_output
 reverse_sequence_n4d2c3h2w2
 reverse_sequence_n4c3h2w2


### PR DESCRIPTION
The GPU transformer doesn't yet handle these special cases in op::OneHot and so these tests should be failing but are not on some systems. Disabling them until they are handled.