### PR TITLE
turn off building unneeded components in MKLDNN

### DIFF
--- a/cmake/external_llvm_prebuilt.cmake
+++ b/cmake/external_llvm_prebuilt.cmake
@@ -39,6 +39,7 @@ if(${CMAKE_VERSION} VERSION_LESS 3.2)
         BUILD_COMMAND ""
         INSTALL_COMMAND ""
         UPDATE_COMMAND ""
+        DOWNLOAD_NO_PROGRESS TRUE
         EXCLUDE_FROM_ALL TRUE
         )
 else()
@@ -50,6 +51,7 @@ else()
         BUILD_COMMAND ""
         INSTALL_COMMAND ""
         UPDATE_COMMAND ""
+        DOWNLOAD_NO_PROGRESS TRUE
         BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/ext_llvm-prefix/src/ext_llvm/lib/libLLVMCore.a"
         EXCLUDE_FROM_ALL TRUE
         )

--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -54,6 +54,8 @@ if(${CMAKE_VERSION} VERSION_LESS 3.2)
         # Uncomment below with any in-flight MKL-DNN patches
         # PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/third-party/patches/mkldnn-cmake-openmp.patch
         CMAKE_ARGS
+            -DWITH_TEST=FALSE
+            -DWITH_EXAMPLE=FALSE
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
             -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
@@ -75,6 +77,8 @@ else()
         # Uncomment below with any in-flight MKL-DNN patches
         # PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/third-party/patches/mkldnn-cmake-openmp.patch
         CMAKE_ARGS
+            -DWITH_TEST=FALSE
+            -DWITH_EXAMPLE=FALSE
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
             -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
@@ -103,9 +107,9 @@ ExternalProject_Add_Step(
 add_library(libmkldnn INTERFACE)
 target_include_directories(libmkldnn SYSTEM INTERFACE ${EXTERNAL_PROJECTS_ROOT}/mkldnn/include)
 target_link_libraries(libmkldnn INTERFACE
-    ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/libmkldnn.so
-    ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/libmklml_intel.so
-    ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/libiomp5.so
+    ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/libmkldnn${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/libmklml_intel${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/libiomp5${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
 
 install(DIRECTORY ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/ DESTINATION ${NGRAPH_INSTALL_LIB})


### PR DESCRIPTION
turn off building mkldnn tests and examples. set the suffix for shared libraries.