### PR TITLE
Fix proxy settings in contrib/docker so that builds work both on the Internet and within Intel

### DIFF
--- a/contrib/docker/make-dimage.sh
+++ b/contrib/docker/make-dimage.sh
@@ -49,7 +49,13 @@ DIMAGE_VERSION=`date -Iseconds | sed -e 's/:/-/g'`
 
 DIMAGE_ID="${DIMAGE_NAME}:${DIMAGE_VERSION}"
 
-cd ${CONTEXTDIR}
+# Auto-detect proxy settings when running from within Intel's network
+hostname | grep '\.intel\.com$'
+if [ $? = 0 ] ; then  # Within .intel.com
+    DOCKER_PROXIES='--build-arg http_proxy=http://proxy-fm.intel.com:911 --build-arg https_proxy=http://proxy-fm.intel.com:912'
+else
+    DOCKER_PROXIES=' '
+fi
 
 echo ' '
 echo "Building docker image ${DIMAGE_ID} from Dockerfile ${DFILE}, context ${CONTEXT}"
@@ -57,6 +63,7 @@ echo ' '
 
 # build the docker base image
 docker build  --rm=true \
+       ${DOCKER_PROXIES} \
        -f="${DFILE}" \
        -t="${DIMAGE_ID}" \
        ${CONTEXT}


### PR DESCRIPTION
Implements fix described in NGRAPH-1999

PR#1062 removed all proxy settings from ngraph/contrib/docker, since the proxy settings were preventing developers (external to Intel) from using the docker builds. Presumably, since nGraph builds had moved to cje-algo, nothing was using the build system in ngraph/contrib/docker.
Unfortunately, the ngraph-mxnet Jenkins automation was still using the ngraph/contrib/docker build system, and PR#1062 broke the ngraph-mxnet CI merge-check builds.

ChrisL came up with a quick switch that checks whether the hostname contains ".intel.com", and if so uses proxy settings that are appropriate for Intel's network. If not, then no proxies are used – which should work for external developers. Nguyen, Lam and Ketineni, Rama requested that this switch be added to ngraph/contrib/docker's build system, to unblock the broken ngraph-mxnet builds.

This PR implements the fix.