### PR TITLE
Zero init. GPU workspace allocations by default

### DIFF
--- a/src/ngraph/runtime/gpu/gpu_memory_manager.hpp
+++ b/src/ngraph/runtime/gpu/gpu_memory_manager.hpp
@@ -43,7 +43,7 @@ namespace ngraph
 
                 ~GPUAllocator();
                 size_t reserve_argspace(const void* data, size_t size);
-                size_t reserve_workspace(size_t size, bool zero_initialize = false);
+                size_t reserve_workspace(size_t size, bool zero_initialize = true);
 
             private:
                 GPUMemoryManager* m_manager;

--- a/src/ngraph/runtime/gpu/gpu_memory_manager.hpp
+++ b/src/ngraph/runtime/gpu/gpu_memory_manager.hpp
@@ -43,7 +43,7 @@ namespace ngraph
 
                 ~GPUAllocator();
                 size_t reserve_argspace(const void* data, size_t size);
-                size_t reserve_workspace(size_t size);
+                size_t reserve_workspace(size_t size, bool zero_initialize = false);
 
             private:
                 GPUMemoryManager* m_manager;


### PR DESCRIPTION
[Please merge this prior to PR #1070]

With this change, every time a workspace memory address is requested (invoked at JIT runtime), the device memory will be zeroed by default. It can be turned off by setting zero_initialize=false in order to cache results between kernels.