### PR TITLE
facility to name matchers to make debugging easier

### DIFF
--- a/src/ngraph/pass/graph_rewrite.cpp
+++ b/src/ngraph/pass/graph_rewrite.cpp
@@ -32,11 +32,11 @@ bool ngraph::pass::GraphRewrite::run_matchers_on_nodes_list(
     {
         for (auto matcher : matchers)
         {
-            NGRAPH_DEBUG << "Running matcher " << matcher << " on " << node << " , "
-                         << node->get_name() << " , is_output = " << node->is_output();
+            NGRAPH_DEBUG << "Running matcher " << matcher->get_name() << "("
+                         << matcher->get_pattern()->get_name() << ") on " << node->get_name();
             if (matcher->match(node))
             {
-                NGRAPH_DEBUG << "Matcher " << matcher << " matched " << node << " , "
+                NGRAPH_DEBUG << "Matcher " << matcher << matcher->get_name() << " matched "
                              << node->get_name();
                 rewritten = true;
                 if (matcher->process_match())
@@ -64,12 +64,10 @@ bool ngraph::pass::RecurrentGraphRewrite::run_on_function(std::shared_ptr<ngraph
         {
             for (auto matcher : m_matchers)
             {
-                NGRAPH_DEBUG << "Running matcher " << matcher << " on " << node << " , "
-                             << node->get_name() << " , is_output = " << node->is_output();
+                NGRAPH_DEBUG << "Running matcher " << matcher << " on " << node->get_name();
                 if (matcher->match(node))
                 {
-                    NGRAPH_DEBUG << "Matcher " << matcher << " matched " << node << " , "
-                                 << node->get_name();
+                    NGRAPH_DEBUG << "Matcher " << matcher << " matched " << node->get_name();
                     if (matcher->process_match())
                     {
                         changed = true;

--- a/src/ngraph/pattern/matcher.hpp
+++ b/src/ngraph/pattern/matcher.hpp
@@ -66,12 +66,15 @@ namespace ngraph
             /// \param pattern_node is a pattern sub graph that will be matched against input graphs
             /// \param callback is a callback function that will be called on a successful match
             Matcher(const std::shared_ptr<Node> pattern_node = nullptr,
-                    graph_rewrite_callback callback = nullptr)
+                    graph_rewrite_callback callback = nullptr,
+                    const std::string& name = "Unnamed")
                 : m_pattern_node(pattern_node)
                 , m_callback(callback)
                 , m_depth(0)
+                , m_name(name)
             {
             }
+
             virtual ~Matcher() {}
             /// \brief Matches a pattern to \p graph_node
             ///
@@ -108,6 +111,7 @@ namespace ngraph
             bool process_match(graph_rewrite_callback callback = nullptr);
 
             void reset() {}
+            std::string get_name() { return m_name; }
             std::shared_ptr<Node> get_pattern() { return m_pattern_node; }
             std::shared_ptr<Node> get_match_root();
             PatternMap get_pattern_map() { return PatternMap{m_pattern_map}; }
@@ -149,6 +153,7 @@ namespace ngraph
 
             graph_rewrite_callback m_callback;
             size_t m_depth;
+            std::string m_name;
         };
 
         class RecurrentMatcher


### PR DESCRIPTION
So we get nice trace like this : `Running matcher folded_batch_norm(BatchNorm_515) on Add_501`