### PR TITLE
remove dlclose in backend destructor

### DIFF
--- a/src/ngraph/runtime/backend.cpp
+++ b/src/ngraph/runtime/backend.cpp
@@ -40,10 +40,6 @@ unordered_map<string, shared_ptr<runtime::Backend>>& runtime::Backend::get_backe
 
 runtime::Backend::~Backend()
 {
-    for (auto& p : s_open_backends)
-    {
-        dlclose(p.second);
-    }
 }
 
 void* runtime::Backend::open_shared_library(string type)


### PR DESCRIPTION
It is causing segfault on exit with python bindings