### PR TITLE
one should not inherit from standard containers

### DIFF
--- a/src/ngraph/coordinate.hpp
+++ b/src/ngraph/coordinate.hpp
@@ -26,7 +26,7 @@ namespace ngraph
 {
     /// \brief Coordinates for a tensor element
     using Coordinate = std::vector<std::size_t>;
-    
+
     // Removes some values from a vector of axis values
     template <typename AXIS_VALUES>
     AXIS_VALUES project(const AXIS_VALUES& axis_values, const AxisSet& deleted_axes)

--- a/src/ngraph/coordinate.hpp
+++ b/src/ngraph/coordinate.hpp
@@ -25,54 +25,8 @@
 namespace ngraph
 {
     /// \brief Coordinates for a tensor element
-    class Coordinate : public std::vector<size_t>
-    {
-    public:
-        Coordinate() {}
-        Coordinate(const std::initializer_list<size_t>& axes)
-            : std::vector<size_t>(axes)
-        {
-        }
-
-        Coordinate(const Shape& shape)
-            : std::vector<size_t>(static_cast<const std::vector<size_t>&>(shape))
-        {
-        }
-
-        Coordinate(const std::vector<size_t>& axes)
-            : std::vector<size_t>(axes)
-        {
-        }
-
-        Coordinate(const Coordinate& axes)
-            : std::vector<size_t>(axes)
-        {
-        }
-
-        Coordinate(size_t n, size_t initial_value = 0)
-            : std::vector<size_t>(n, initial_value)
-        {
-        }
-
-        template <class InputIterator>
-        Coordinate(InputIterator first, InputIterator last)
-            : std::vector<size_t>(first, last)
-        {
-        }
-
-        Coordinate& operator=(const Coordinate& v)
-        {
-            static_cast<std::vector<size_t>*>(this)->operator=(v);
-            return *this;
-        }
-
-        Coordinate& operator=(Coordinate&& v)
-        {
-            static_cast<std::vector<size_t>*>(this)->operator=(v);
-            return *this;
-        }
-    };
-
+    using Coordinate = std::vector<std::size_t>;
+    
     // Removes some values from a vector of axis values
     template <typename AXIS_VALUES>
     AXIS_VALUES project(const AXIS_VALUES& axis_values, const AxisSet& deleted_axes)

--- a/src/ngraph/node_vector.hpp
+++ b/src/ngraph/node_vector.hpp
@@ -23,32 +23,6 @@ namespace ngraph
 {
     class Node;
 
-    namespace op
-    {
-        class Result;
-    }
-
     /// \brief Zero or more nodes.
-    class NodeVector : public std::vector<std::shared_ptr<Node>>
-    {
-    public:
-        NodeVector(const std::initializer_list<std::shared_ptr<Node>>& nodes)
-            : std::vector<std::shared_ptr<Node>>(nodes)
-        {
-        }
-
-        NodeVector(const std::vector<std::shared_ptr<Node>>& nodes)
-            : std::vector<std::shared_ptr<Node>>(nodes)
-        {
-        }
-
-        NodeVector(const NodeVector& nodes)
-            : std::vector<std::shared_ptr<Node>>(nodes)
-        {
-        }
-
-        NodeVector& operator=(const NodeVector& other) = default;
-
-        NodeVector() {}
-    };
+    using NodeVector = std::vector<std::shared_ptr<Node>>;
 }

--- a/src/ngraph/op/parameter_vector.hpp
+++ b/src/ngraph/op/parameter_vector.hpp
@@ -26,6 +26,6 @@ namespace ngraph
     namespace op
     {
         /// \brief Zero or more nodes.
-	using ParameterVector = std::vector<std::shared_ptr<Parameter>>;
+        using ParameterVector = std::vector<std::shared_ptr<Parameter>>;
     }
 }

--- a/src/ngraph/op/parameter_vector.hpp
+++ b/src/ngraph/op/parameter_vector.hpp
@@ -26,25 +26,6 @@ namespace ngraph
     namespace op
     {
         /// \brief Zero or more nodes.
-        class ParameterVector : public std::vector<std::shared_ptr<op::Parameter>>
-        {
-        public:
-            ParameterVector(const std::initializer_list<std::shared_ptr<op::Parameter>>& parameters)
-                : std::vector<std::shared_ptr<op::Parameter>>(parameters)
-            {
-            }
-
-            ParameterVector(const std::vector<std::shared_ptr<op::Parameter>>& parameters)
-                : std::vector<std::shared_ptr<op::Parameter>>(parameters)
-            {
-            }
-
-            ParameterVector(const ParameterVector& parameters)
-                : std::vector<std::shared_ptr<op::Parameter>>(parameters)
-            {
-            }
-
-            ParameterVector() {}
-        };
+	using ParameterVector = std::vector<std::shared_ptr<Parameter>>;
     }
 }

--- a/src/ngraph/runtime/cpu/cpu_kernels.hpp
+++ b/src/ngraph/runtime/cpu/cpu_kernels.hpp
@@ -19,6 +19,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "ngraph/shape.hpp"
+
 // CBLAS types and wrappers
 
 namespace cblas
@@ -124,7 +126,6 @@ namespace mkl
 
 namespace ngraph
 {
-    class Shape;
     class AxisSet;
     class AxisVector;
 

--- a/src/ngraph/shape.hpp
+++ b/src/ngraph/shape.hpp
@@ -25,47 +25,7 @@
 namespace ngraph
 {
     /// \brief Shape for a tensor.
-    class Shape : public std::vector<size_t>
-    {
-    public:
-        Shape(const std::initializer_list<size_t>& axis_lengths)
-            : std::vector<size_t>(axis_lengths)
-        {
-        }
-
-        Shape(const std::vector<size_t>& axis_lengths)
-            : std::vector<size_t>(axis_lengths)
-        {
-        }
-
-        Shape(const Shape& axis_lengths)
-            : std::vector<size_t>(axis_lengths)
-        {
-        }
-
-        explicit Shape(size_t n, size_t initial_value = 0)
-            : std::vector<size_t>(n, initial_value)
-        {
-        }
-
-        template <class InputIterator>
-        Shape(InputIterator first, InputIterator last)
-            : std::vector<size_t>(first, last)
-        {
-        }
-
-        Shape() {}
-        Shape& operator=(const Shape& v)
-        {
-            static_cast<std::vector<size_t>*>(this)->operator=(v);
-            return *this;
-        }
-        Shape& operator=(Shape&& v)
-        {
-            static_cast<std::vector<size_t>*>(this)->operator=(v);
-            return *this;
-        }
-    };
+    using Shape = std::vector<std::size_t>;
 
     /// Number of elements in spanned by a shape
     template <typename SHAPE_TYPE>


### PR DESCRIPTION
The thing is standard containers **do not have virtual destructors**. One should never use something polymorphically that does not have a virtual destructor. There's no guarantee for the proper cleanup in derived classes.

Signed-off-by: Artur Wojcik <artur.wojcik@intel.com>