### PR TITLE
move static backend functions to BackendCache so there is only one copy

### DIFF
--- a/src/ngraph/CMakeLists.txt
+++ b/src/ngraph/CMakeLists.txt
@@ -132,6 +132,7 @@ set (SRC
     pattern/matcher.cpp
     runtime/aligned_buffer.cpp
     runtime/backend.cpp
+    runtime/backend_cache.cpp
     runtime/host_tensor_view.cpp
     runtime/tensor_view.cpp
     serializer.cpp

--- a/src/ngraph/runtime/backend.cpp
+++ b/src/ngraph/runtime/backend.cpp
@@ -14,120 +14,34 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <dlfcn.h>
 #include <sstream>
 
 #include "ngraph/file_util.hpp"
 #include "ngraph/runtime/backend.hpp"
+#include "ngraph/runtime/backend_cache.hpp"
 #include "ngraph/runtime/cpu/cpu_tensor_view.hpp"
 #include "ngraph/util.hpp"
 
 using namespace std;
 using namespace ngraph;
 
-std::unordered_map<string, void*> runtime::Backend::s_open_backends;
-
 bool runtime::Backend::register_backend(const string& name, shared_ptr<Backend> backend)
 {
-    get_backend_map().insert({name, backend});
-    return true;
-}
-
-unordered_map<string, shared_ptr<runtime::Backend>>& runtime::Backend::get_backend_map()
-{
-    static unordered_map<string, shared_ptr<Backend>> backend_map;
-    return backend_map;
+    return BackendCache::register_backend(name, backend);
 }
 
 runtime::Backend::~Backend()
 {
 }
 
-// This doodad finds the full path of the containing shared library
-static string find_my_file()
-{
-    Dl_info dl_info;
-    dladdr(reinterpret_cast<void*>(find_my_file), &dl_info);
-    return dl_info.dli_fname;
-}
-
-// This will be uncommented when we add support for listing all known backends
-// static bool is_backend(const string& path)
-// {
-//     bool rc = false;
-//     string name = file_util::get_file_name(path);
-//     if (name.find("_backend.") != string::npos)
-//     {
-//         NGRAPH_INFO << name;
-//     }
-//     return rc;
-// }
-
-void* runtime::Backend::open_shared_library(string type)
-{
-    string ext = SHARED_LIB_EXT;
-    string ver = LIBRARY_VERSION;
-
-    void* handle = nullptr;
-
-    // strip off attributes, IE:CPU becomes IE
-    auto colon = type.find(":");
-    if (colon != type.npos)
-    {
-        type = type.substr(0, colon);
-    }
-    string lib_name = "lib" + to_lower(type) + "_backend" + ext;
-    string my_directory = file_util::get_directory(find_my_file());
-    string full_path = file_util::path_join(my_directory, lib_name);
-    NGRAPH_INFO << full_path;
-    handle = dlopen(full_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
-    if (handle)
-    {
-        function<void()> create_backend =
-            reinterpret_cast<void (*)()>(dlsym(handle, "create_backend"));
-        if (create_backend)
-        {
-            create_backend();
-        }
-        else
-        {
-            dlclose(handle);
-            throw runtime_error("Failed to find create_backend function in library '" + lib_name +
-                                "'");
-        }
-        s_open_backends.insert({lib_name, handle});
-    }
-    else
-    {
-        string err = dlerror();
-        throw runtime_error("Library open for Backend '" + lib_name + "' failed with error:\n" +
-                            err);
-    }
-    return handle;
-}
-
 shared_ptr<runtime::Backend> runtime::Backend::create(const string& type)
 {
-    auto it = get_backend_map().find(type);
-    if (it == get_backend_map().end())
-    {
-        open_shared_library(type);
-        it = get_backend_map().find(type);
-        if (it == get_backend_map().end())
-        {
-            throw runtime_error("Backend '" + type + "' not found in registered backends.");
-        }
-    }
-    return it->second;
+    return BackendCache::create(type);
 }
 
 vector<string> runtime::Backend::get_registered_devices()
 {
     vector<string> rc;
-    for (const auto& p : get_backend_map())
-    {
-        rc.push_back(p.first);
-    }
     return rc;
 }
 

--- a/src/ngraph/runtime/backend.hpp
+++ b/src/ngraph/runtime/backend.hpp
@@ -81,11 +81,6 @@ namespace ngraph
             void validate_call(std::shared_ptr<const Function> func,
                                const std::vector<std::shared_ptr<runtime::TensorView>>& outputs,
                                const std::vector<std::shared_ptr<runtime::TensorView>>& inputs);
-
-        private:
-            static void* open_shared_library(std::string type);
-            static std::unordered_map<std::string, std::shared_ptr<Backend>>& get_backend_map();
-            static std::unordered_map<std::string, void*> s_open_backends;
         };
     }
 }

--- a/src/ngraph/runtime/backend_cache.cpp
+++ b/src/ngraph/runtime/backend_cache.cpp
@@ -1,0 +1,115 @@
+/*******************************************************************************
+* Copyright 2017-2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <dlfcn.h>
+
+#include "ngraph/file_util.hpp"
+#include "ngraph/runtime/backend_cache.hpp"
+#include "ngraph/util.hpp"
+
+using namespace std;
+using namespace ngraph;
+
+unordered_map<string, void*> runtime::BackendCache::s_open_backends;
+
+// This doodad finds the full path of the containing shared library
+static string find_my_file()
+{
+    Dl_info dl_info;
+    dladdr(reinterpret_cast<void*>(find_my_file), &dl_info);
+    return dl_info.dli_fname;
+}
+
+// This will be uncommented when we add support for listing all known backends
+// static bool is_backend(const string& path)
+// {
+//     bool rc = false;
+//     string name = file_util::get_file_name(path);
+//     if (name.find("_backend.") != string::npos)
+//     {
+//         NGRAPH_INFO << name;
+//     }
+//     return rc;
+// }
+
+void* runtime::BackendCache::open_shared_library(string type)
+{
+    string ext = SHARED_LIB_EXT;
+    string ver = LIBRARY_VERSION;
+
+    void* handle = nullptr;
+
+    // strip off attributes, IE:CPU becomes IE
+    auto colon = type.find(":");
+    if (colon != type.npos)
+    {
+        type = type.substr(0, colon);
+    }
+    string lib_name = "lib" + to_lower(type) + "_backend" + ext;
+    string my_directory = file_util::get_directory(find_my_file());
+    string full_path = file_util::path_join(my_directory, lib_name);
+    handle = dlopen(full_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    if (handle)
+    {
+        function<void()> create_backend =
+            reinterpret_cast<void (*)()>(dlsym(handle, "create_backend"));
+        if (create_backend)
+        {
+            create_backend();
+        }
+        else
+        {
+            dlclose(handle);
+            throw runtime_error("Failed to find create_backend function in library '" + lib_name +
+                                "'");
+        }
+        s_open_backends.insert({lib_name, handle});
+    }
+    else
+    {
+        string err = dlerror();
+        throw runtime_error("Library open for Backend '" + lib_name + "' failed with error:\n" +
+                            err);
+    }
+    return handle;
+}
+
+bool runtime::BackendCache::register_backend(const string& name, shared_ptr<Backend> backend)
+{
+    get_backend_map().insert({name, backend});
+    return true;
+}
+
+shared_ptr<runtime::Backend> runtime::BackendCache::create(const string& type)
+{
+    auto it = get_backend_map().find(type);
+    if (it == get_backend_map().end())
+    {
+        open_shared_library(type);
+        it = get_backend_map().find(type);
+        if (it == get_backend_map().end())
+        {
+            throw runtime_error("Backend '" + type + "' not found in registered backends.");
+        }
+    }
+    return it->second;
+}
+
+unordered_map<string, shared_ptr<runtime::Backend>>& runtime::BackendCache::get_backend_map()
+{
+    static unordered_map<string, shared_ptr<Backend>> backend_map;
+    return backend_map;
+}

--- a/src/ngraph/runtime/backend_cache.hpp
+++ b/src/ngraph/runtime/backend_cache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018 Intel Corporation
+* Copyright 2017-2018 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,23 +14,29 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "gtest/gtest.h"
-#include "ngraph/ngraph.hpp"
-#include "ngraph/runtime/backend.hpp"
-#include "ngraph/util.hpp"
+#pragma once
 
-using namespace std;
-using namespace ngraph;
+#include <memory>
+#include <string>
+#include <unordered_map>
 
-// TEST(backend_api, registered_devices)
-// {
-//     vector<string> devices = runtime::Backend::get_registered_devices();
-//     EXPECT_GE(devices.size(), 1);
-
-//     EXPECT_TRUE(contains(devices, "INTERPRETER"));
-// }
-
-TEST(backend_api, invalid_name)
+namespace ngraph
 {
-    ASSERT_ANY_THROW(ngraph::runtime::Backend::create("COMPLETELY-BOGUS-NAME"));
+    namespace runtime
+    {
+        class BackendCache;
+        class Backend;
+    }
 }
+
+class ngraph::runtime::BackendCache
+{
+public:
+    static std::shared_ptr<Backend> create(const std::string& type);
+    static bool register_backend(const std::string& name, std::shared_ptr<Backend>);
+
+private:
+    static void* open_shared_library(std::string type);
+    static std::unordered_map<std::string, std::shared_ptr<Backend>>& get_backend_map();
+    static std::unordered_map<std::string, void*> s_open_backends;
+};


### PR DESCRIPTION
This PR just moves all of the static functions and variables from the Backend class, which is the base class for all backends, to a new BackendCache class. The BackendCache class lives in the ngraph library and is not inherited by the backends so there will be only one copy of the static variables used internally.