### PR TITLE
nbench cleanup

### DIFF
--- a/src/tools/nbench/CMakeLists.txt
+++ b/src/tools/nbench/CMakeLists.txt
@@ -16,11 +16,10 @@
 
 set (SRC
     nbench.cpp
-    ${PROJECT_SOURCE_DIR}/test/util/benchmark.cpp
+    benchmark.cpp
 )
 
 add_executable(nbench ${SRC})
-add_dependencies(nbench ngraph)
 
 target_link_libraries(nbench ngraph)
 if (NGRAPH_CPU_ENABLE)
@@ -35,7 +34,5 @@ endif()
 if (NGRAPH_INTERPRETER_ENABLE)
     target_link_libraries(nbench interpreter_backend)
 endif()
-
-include_directories("${PROJECT_SOURCE_DIR}/test")
 
 install(TARGETS nbench RUNTIME DESTINATION ${NGRAPH_INSTALL_BIN})

--- a/src/tools/nbench/benchmark.cpp
+++ b/src/tools/nbench/benchmark.cpp
@@ -15,14 +15,16 @@
 *******************************************************************************/
 
 #include <iomanip>
+#include <random>
 
 #include "benchmark.hpp"
+#include "ngraph/file_util.hpp"
 #include "ngraph/graph_util.hpp"
 #include "ngraph/runtime/backend.hpp"
 #include "ngraph/runtime/tensor_view.hpp"
+#include "ngraph/runtime/tensor_view.hpp"
 #include "ngraph/serializer.hpp"
 #include "ngraph/util.hpp"
-#include "random.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -116,25 +118,27 @@ static default_random_engine s_random_engine;
 template <typename T>
 void init_int_tv(shared_ptr<runtime::TensorView> tv, T min, T max)
 {
+    size_t size = tv->get_element_count();
     uniform_int_distribution<T> dist(min, max);
-    std::vector<T> vec = read_vector<T>(tv);
+    vector<T> vec(size);
     for (T& element : vec)
     {
         element = dist(s_random_engine);
     }
-    write_vector(tv, vec);
+    tv->write(vec.data(), 0, vec.size());
 }
 
 template <typename T>
 void init_real_tv(shared_ptr<runtime::TensorView> tv, T min, T max)
 {
+    size_t size = tv->get_element_count();
     uniform_real_distribution<T> dist(min, max);
-    std::vector<T> vec = read_vector<T>(tv);
+    vector<T> vec(size);
     for (T& element : vec)
     {
         element = dist(s_random_engine);
     }
-    write_vector(tv, vec);
+    tv->write(vec.data(), 0, vec.size());
 }
 
 static void random_init(shared_ptr<runtime::TensorView> tv)

--- a/src/tools/nbench/benchmark.hpp
+++ b/src/tools/nbench/benchmark.hpp
@@ -17,9 +17,9 @@
 #pragma once
 
 #include <map>
-#include <vector>
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "ngraph/function.hpp"
 #include "ngraph/runtime/performance_counter.hpp"

--- a/src/tools/nbench/benchmark.hpp
+++ b/src/tools/nbench/benchmark.hpp
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <map>
+#include <vector>
+#include <string>
+#include <memory>
 
-#include <ngraph/function.hpp>
-
+#include "ngraph/function.hpp"
 #include "ngraph/runtime/performance_counter.hpp"
-#include "test_tools.hpp"
 
 /// performance test utilities
 std::multimap<size_t, std::string>

--- a/src/tools/nbench/nbench.cpp
+++ b/src/tools/nbench/nbench.cpp
@@ -21,15 +21,14 @@
 // sample models are under ../../test/models
 
 #include <fstream>
-#include <ngraph/file_util.hpp>
-#include <ngraph/file_util.hpp>
-#include <ngraph/pass/manager.hpp>
-#include <ngraph/pass/visualize_tree.hpp>
-#include <ngraph/runtime/backend.hpp>
-#include <ngraph/util.hpp>
 
-#include "util/benchmark.hpp"
-#include "util/test_tools.hpp"
+#include "benchmark.hpp"
+#include "ngraph/file_util.hpp"
+#include "ngraph/pass/manager.hpp"
+#include "ngraph/pass/visualize_tree.hpp"
+#include "ngraph/runtime/backend.hpp"
+#include "ngraph/serializer.hpp"
+#include "ngraph/util.hpp"
 
 using namespace std;
 using namespace ngraph;

--- a/test/backend_performance.cpp
+++ b/test/backend_performance.cpp
@@ -28,68 +28,11 @@
 #include "ngraph/runtime/backend.hpp"
 #include "ngraph/serializer.hpp"
 #include "ngraph/util.hpp"
-#include "util/benchmark.hpp"
 #include "util/random.hpp"
 #include "util/test_tools.hpp"
 
 using namespace std;
 using namespace ngraph;
-
-TEST(benchmark, mxnet_mnist_mlp_forward)
-{
-    const string json_path = file_util::path_join(SERIALIZED_ZOO, "mxnet/mnist_mlp_forward.json");
-    run_benchmark(json_path, "CPU", 1000);
-}
-
-TEST(benchmark, gpu_mxnet_mnist_mlp_forward)
-{
-    const string json_path = file_util::path_join(SERIALIZED_ZOO, "mxnet/mnist_mlp_forward.json");
-    run_benchmark(json_path, "GPU", 1000);
-}
-
-TEST(benchmark, mxnet_10_bucket_lstm)
-{
-    const string json_path = file_util::path_join(SERIALIZED_ZOO, "mxnet/10_bucket_LSTM.json");
-    run_benchmark(json_path, "CPU", 10);
-}
-
-TEST(benchmark, mxnet_lstm_backward)
-{
-    const string json_path = file_util::path_join(SERIALIZED_ZOO, "mxnet/LSTM_backward.json");
-    run_benchmark(json_path, "CPU", 10);
-}
-
-TEST(benchmark, mxnet_lstm_forward)
-{
-    const string json_path = file_util::path_join(SERIALIZED_ZOO, "mxnet/LSTM_forward.json");
-    run_benchmark(json_path, "CPU", 10);
-}
-
-TEST(benchmark, mxnet_seq2seq_forward)
-{
-    const string json_path = file_util::path_join(SERIALIZED_ZOO, "mxnet/Seq2Seq_forward.json");
-    run_benchmark(json_path, "CPU", 10);
-}
-
-TEST(benchmark, mxnet_seq2seq_backward)
-{
-    const string json_path = file_util::path_join(SERIALIZED_ZOO, "mxnet/Seq2Seq_backward.json");
-    run_benchmark(json_path, "CPU", 10);
-}
-
-TEST(benchmark, mxnet_sockeye_seq2seq_forward)
-{
-    const string json_path =
-        file_util::path_join(SERIALIZED_ZOO, "mxnet/Sockeye_Seq2Seq_forward.json");
-    run_benchmark(json_path, "CPU", 10);
-}
-
-TEST(benchmark, mxnet_sockeye_seq2seq_backward)
-{
-    const string json_path =
-        file_util::path_join(SERIALIZED_ZOO, "mxnet/Sockeye_Seq2Seq_backward.json");
-    run_benchmark(json_path, "CPU", 10);
-}
 
 //
 // Benchmarks a graph that concatenates six 32x1x200 arrays along the middle axis.

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -18,7 +18,6 @@ set (SRC
     autodiff/backprop_function.cpp
     all_close_f.cpp
     test_tools.cpp
-    benchmark.cpp
     test_control.cpp
 )
 
@@ -32,6 +31,5 @@ include_directories(
 add_library(ngraph_test_util SHARED ${SRC})
 set_target_properties(ngraph_test_util PROPERTIES VERSION ${NGRAPH_VERSION} SOVERSION ${NGRAPH_API_VERSION})
 target_link_libraries(ngraph_test_util ngraph libgtest)
-add_dependencies(ngraph_test_util ngraph libgtest)
 
 install(TARGETS ngraph_test_util DESTINATION ${NGRAPH_INSTALL_LIB})


### PR DESCRIPTION
Move the benchmark.?pp files to be in the nbench directory. There is no need to have benchmarks in unit test when we have nbench.