### PR TITLE
Cache functions so the backend does not need to recompile

### DIFF
--- a/test/autodiff.in.cpp
+++ b/test/autodiff.in.cpp
@@ -1063,6 +1063,8 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_select)
                                      std::vector<std::shared_ptr<op::Parameter>>{X0, X1, X2});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x0 = backend->create_tensor(element::boolean, shape);
@@ -1071,7 +1073,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_select)
         auto x2 = rng.initialize(backend->create_tensor<float>(shape));
 
         EXPECT_TRUE(autodiff_numeric_compare_selective<float>(
-            backend, make_graph, {x0, x1, x2}, .01f, .01f, std::vector<bool>{false, true, true}));
+            backend, f, g, {x0, x1, x2}, .01f, .01f, std::vector<bool>{false, true, true}));
     }
 }
 
@@ -1089,6 +1091,8 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_select_nested)
                                      std::vector<std::shared_ptr<op::Parameter>>{X0, X1, X2});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x0 = backend->create_tensor(element::boolean, shape);
@@ -1097,7 +1101,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_select_nested)
         auto x2 = rng.initialize(backend->create_tensor<float>(shape));
 
         EXPECT_TRUE(autodiff_numeric_compare_selective<float>(
-            backend, make_graph, {x0, x1, x2}, .01f, .01f, std::vector<bool>{false, true, true}));
+            backend, f, g, {x0, x1, x2}, .01f, .01f, std::vector<bool>{false, true, true}));
     }
 }
 

--- a/test/autodiff.in.cpp
+++ b/test/autodiff.in.cpp
@@ -294,10 +294,12 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_avgpool_n2_c2_hw4x4_numeric)
 
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor(element::f32, shape_a));
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x}, .01f, .01f));
     }
 }
 
@@ -316,10 +318,12 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_avgpool_n2_c2_hw4x4_win_2x2_str_1x1_numer
 
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor(element::f32, shape_a));
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x}, .01f, .01f));
     }
 }
 
@@ -340,10 +344,12 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_avgpool_n2_c2_hw2x2_win_2x2_str_1x1_paddi
 
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor(element::f32, shape_a));
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x}, .01f, .01f));
     }
 }
 
@@ -363,15 +369,17 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_abs)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x_neg = rng_neg.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_neg}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_neg}, .01f, .01f));
 
         auto x_pos = rng_pos.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_pos}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_pos}, .01f, .01f));
     }
 }
 
@@ -573,19 +581,21 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_ceiling)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x_minusone = rng_minusone.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_minusone}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_minusone}, .01f, .01f));
 
         auto x_plusone = rng_plusone.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_plusone}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_plusone}, .01f, .01f));
 
         auto x_plustwo = rng_plustwo.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_plustwo}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_plustwo}, .01f, .01f));
     }
 }
 
@@ -601,11 +611,13 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_cos)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x}, .01f, .01f));
     }
 }
 
@@ -621,11 +633,13 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_cosh)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x}, .01f, .01f));
     }
 }
 
@@ -816,19 +830,21 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_floor)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x_minusone = rng_minusone.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_minusone}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_minusone}, .01f, .01f));
 
         auto x_plusone = rng_plusone.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_plusone}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_plusone}, .01f, .01f));
 
         auto x_plustwo = rng_plustwo.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_plustwo}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_plustwo}, .01f, .01f));
     }
 }
 
@@ -977,15 +993,17 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_relu)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x_neg = rng_neg.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_neg}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_neg}, .01f, .01f));
 
         auto x_pos = rng_pos.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_pos}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_pos}, .01f, .01f));
     }
 }
 
@@ -1004,12 +1022,14 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_replace_slice)
             std::vector<std::shared_ptr<op::Parameter>>{X, Y});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor<float>(shape_x));
         auto y = rng.initialize(backend->create_tensor<float>(shape_y));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x, y}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x, y}, .01f, .01f));
     }
 }
 
@@ -1097,15 +1117,17 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_sigmoid)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x_neg = rng_neg.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_neg}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_neg}, .01f, .01f));
 
         auto x_pos = rng_pos.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_pos}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_pos}, .01f, .01f));
     }
 }
 
@@ -1125,15 +1147,17 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_sign)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x_neg = rng_neg.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_neg}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_neg}, .01f, .01f));
 
         auto x_pos = rng_pos.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_pos}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_pos}, .01f, .01f));
     }
 }
 
@@ -1149,11 +1173,13 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_sin)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x}, .01f, .01f));
     }
 }
 
@@ -1169,11 +1195,13 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_sinh)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x}, .01f, .01f));
     }
 }
 
@@ -1188,11 +1216,13 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_slice)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x}, .01f, .01f));
     }
 }
 
@@ -1404,15 +1434,17 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_tan)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x_r = rng_r.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_r}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_r}, .01f, .01f));
 
         auto x_l = rng_l.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x_l}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x_l}, .01f, .01f));
     }
 }
 
@@ -1428,11 +1460,13 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_tanh)
                                      std::vector<std::shared_ptr<op::Parameter>>{X});
     };
 
+    auto f = make_graph();
+    auto g = make_graph();
     for (auto i = 0; i < ${TEST_LOOPS}; i++)
     {
         auto x = rng.initialize(backend->create_tensor<float>(shape));
 
-        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x}, .01f, .01f));
+        EXPECT_TRUE(autodiff_numeric_compare<float>(backend, f, g, {x}, .01f, .01f));
     }
 }
 
@@ -1453,6 +1487,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_abc)
         return make_shared<Function>((X0 + X1) * X2,
                                      std::vector<std::shared_ptr<op::Parameter>>{X0, X1, X2});
     };
+
     EXPECT_TRUE(autodiff_numeric_compare<float>(backend, make_graph, {x0, x1, x2}, .01f, .01f));
 }
 

--- a/test/util/autodiff/backprop_derivative.hpp
+++ b/test/util/autodiff/backprop_derivative.hpp
@@ -34,6 +34,7 @@ namespace ngraph
 
     static std::unordered_map<std::shared_ptr<Function>, std::shared_ptr<Function>> s_df_map;
     static std::unordered_map<std::shared_ptr<Function>, std::shared_ptr<Function>> s_clone_fwd_map;
+    static std::unordered_map<std::shared_ptr<Function>, std::shared_ptr<Function>> s_clone_bwd_map;
 
     namespace runtime
     {
@@ -200,7 +201,11 @@ namespace ngraph
             backend->call(clone_fwd, mod_f_output_args, f_input_args);
 
             // call modfied f'(c, cached) to get df/dX*
-            auto clone_bwd = clone_function(*fprop_cache.bprop);
+            if (!s_clone_bwd_map[f])
+            {
+                s_clone_bwd_map[f] = clone_function(*fprop_cache.bprop);
+            }
+            auto clone_bwd = s_clone_bwd_map[f];
             auto cache_dfdx = get_autodiff<T>(backend, clone_bwd, mod_df_input_args, indep_params);
 
             const auto numpy_atol = 1e-5f;

--- a/test/util/autodiff/numeric_compare.hpp
+++ b/test/util/autodiff/numeric_compare.hpp
@@ -81,54 +81,14 @@ bool autodiff_numeric_compare(const std::shared_ptr<ngraph::runtime::Backend>& b
                               T rtol,
                               T atol)
 {
-    T delta = static_cast<T>(0.0009765625f); // Binary-representable number near 0.001
-
-    // Use INTERPRETER to compute numerical derivatives
-    auto interpreter_backend = ngraph::runtime::Backend::create("INTERPRETER");
-    auto f = make_graph();
-
-    std::vector<std::shared_ptr<ngraph::runtime::TensorView>> interpreter_args;
-    for (auto arg : args)
-    {
-        auto interpreter_arg = interpreter_backend->create_tensor(
-            arg->get_tensor().get_element_type(), arg->get_shape());
-
-        // TODO: copy_data should not require T. Quick fix here for bool used in `Select`
-        if (arg->get_tensor().get_element_type() == ngraph::element::boolean)
-        {
-            copy_data(interpreter_arg, read_vector<char>(arg));
-        }
-        else
-        {
-            copy_data(interpreter_arg, read_vector<T>(arg));
-        }
-        interpreter_args.push_back(interpreter_arg);
-    }
-    auto results_num = ngraph::autodiff::numeric_derivative<T>(
-        interpreter_backend, f, interpreter_args, delta, f->get_parameters());
-
-    // Use the backend being tested to compute symbolic derivatives
-    auto g = make_graph();
-    auto results_sym =
-        ngraph::autodiff::backprop_derivative<T>(backend, g, args, g->get_parameters());
-
-    // Cast to HostTensorView for comparision
-    std::vector<std::shared_ptr<ngraph::runtime::TensorView>> interpreter_results_sym;
-    for (auto result : results_sym)
-    {
-        auto interpreter_result =
-            interpreter_backend->create_tensor(ngraph::element::from<T>(), result->get_shape());
-        copy_data(interpreter_result, read_vector<T>(result));
-        interpreter_results_sym.push_back(interpreter_result);
-    }
-
-    return ngraph::test::all_close(results_num, interpreter_results_sym, rtol, atol);
+    return autodiff_numeric_compare(backend, make_graph(), make_graph(), args, rtol, atol);
 }
 
 template <typename T>
 bool autodiff_numeric_compare_selective(
     const std::shared_ptr<ngraph::runtime::Backend>& backend,
-    std::function<std::shared_ptr<ngraph::Function>()> make_graph,
+    std::shared_ptr<ngraph::Function> f,
+    std::shared_ptr<ngraph::Function> g,
     const std::vector<std::shared_ptr<ngraph::runtime::TensorView>>& args,
     T rtol,
     T atol,
@@ -136,7 +96,6 @@ bool autodiff_numeric_compare_selective(
 {
     // Use INTERPRETER to compute numerical derivatives
     std::vector<std::shared_ptr<ngraph::op::Parameter>> f_indep_params;
-    auto f = make_graph();
 
     size_t i = 0;
 
@@ -173,7 +132,6 @@ bool autodiff_numeric_compare_selective(
 
     // Use the backend being tested to compute symbolic derivatives
     std::vector<std::shared_ptr<ngraph::op::Parameter>> g_indep_params;
-    auto g = make_graph();
 
     i = 0;
 
@@ -199,4 +157,17 @@ bool autodiff_numeric_compare_selective(
     }
 
     return ngraph::test::all_close(results_num, interpreter_results_sym, rtol, atol);
+}
+
+template <typename T>
+bool autodiff_numeric_compare_selective(
+    const std::shared_ptr<ngraph::runtime::Backend>& backend,
+    std::function<std::shared_ptr<ngraph::Function>()> make_graph,
+    const std::vector<std::shared_ptr<ngraph::runtime::TensorView>>& args,
+    T rtol,
+    T atol,
+    const std::vector<bool>& indep_param_mask)
+{
+    return autodiff_numeric_compare_selective(
+        backend, make_graph(), make_graph(), args, rtol, atol, indep_param_mask);
 }


### PR DESCRIPTION
I ran tests on the CPU only.

Before optimization: 66 tests from CPU (62047 ms total)
After optimization: 66 tests from CPU (43083 ms total)

The GPU will see even more improvement as compiles take a little longer there.
I even played with cranking the number of iterations to 100 and it still only took ~55 seconds to run all of these tests (We can up the number for this PR if you want).

Win!