### PR TITLE
Fix launch parameter bug for broadcast and pad.

### DIFF
--- a/src/ngraph/runtime/gpu/cuda_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cuda_emitter.cpp
@@ -101,7 +101,8 @@ size_t runtime::gpu::CUDAEmitter::build_pad(const std::array<std::string, 2>& dt
     size_t nthreads = shape_size(output_shape);
     //TODO: currently we set it to 64, will add tuning method later
     uint32_t block_size_x = 64;
-    uint32_t aligned_grid_size_x = align_to_block_size(static_cast<uint32_t>(nthreads), block_size_x);
+    uint32_t aligned_grid_size_x =
+        align_to_block_size(static_cast<uint32_t>(nthreads), block_size_x);
 
     // if the kernel has not been compiled, build it
     auto compiled_kernel = m_ctx->compiled_kernel_pool->get(hash);
@@ -1377,7 +1378,6 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
     uint32_t block_size_x = 64;
     uint32_t aligned_grid_size_x =
         align_to_block_size(static_cast<uint32_t>(nthreads), block_size_x);
-
 
     std::unique_ptr<gpu::primitive> broadcast(new gpu::primitive{[=](void** inputs,
                                                                      void** outputs) mutable {

--- a/src/ngraph/runtime/gpu/cuda_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cuda_emitter.cpp
@@ -98,10 +98,10 @@ size_t runtime::gpu::CUDAEmitter::build_pad(const std::array<std::string, 2>& dt
         return primitive_index;
     }
 
-    uint32_t nthreads = static_cast<uint32_t>(shape_size(output_shape));
+    size_t nthreads = shape_size(output_shape);
     //TODO: currently we set it to 64, will add tuning method later
     uint32_t block_size_x = 64;
-    uint32_t aligned_grid_size_x = align_to_block_size(nthreads, block_size_x);
+    uint32_t aligned_grid_size_x = align_to_block_size(static_cast<uint32_t>(nthreads), block_size_x);
 
     // if the kernel has not been compiled, build it
     auto compiled_kernel = m_ctx->compiled_kernel_pool->get(hash);
@@ -1372,11 +1372,12 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
     float alpha = 1.0f;
     float beta = 0.0f;
 
-    int nthreads = static_cast<int>(shape_size(result_shape));
+    size_t nthreads = shape_size(result_shape);
     //TODO: currently we set it to 64, will add tuning method later
     uint32_t block_size_x = 64;
     uint32_t aligned_grid_size_x =
-        align_to_block_size(static_cast<uint32_t>(shape_size(result_shape)), block_size_x);
+        align_to_block_size(static_cast<uint32_t>(nthreads), block_size_x);
+
 
     std::unique_ptr<gpu::primitive> broadcast(new gpu::primitive{[=](void** inputs,
                                                                      void** outputs) mutable {


### PR DESCRIPTION
Bug: The Broadcast and Pad kernels expect `nthreads` to be size_t, but only a 32-bit wide unsigned int was being passed to the device.