### PR TITLE
Broadcast optimization

### DIFF
--- a/src/ngraph/runtime/gpu/cuda_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cuda_emitter.cpp
@@ -1781,7 +1781,7 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
     std::unique_ptr<gpu::primitive> broadcast(new gpu::primitive{[=](void** inputs,
                                                                      void** outputs) mutable {
 
-        void** args_list = args.get_argument_list(&inputs[0], &outputs[0]);
+        void** args_list = args.get_argument_list({&inputs[0], &outputs[0]});
         CUDA_SAFE_CALL(cuLaunchKernel(*compiled_kernel.get(),
                                       aligned_grid_size_x,
                                       1,

--- a/src/ngraph/runtime/gpu/cuda_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cuda_emitter.cpp
@@ -1719,8 +1719,6 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
         return primitive_index;
     }
 
-
-
     // calculate strides
     GPUShape strides = row_major_strides(result_shape);
     // precacluate invariants for integer division via multiplication
@@ -1745,16 +1743,6 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
     {
         reduced_strides[axis] = 0;
     }
-
-    // GPUAllocator allocator = this->m_primitive_emitter->get_memory_allocator();
-    // size_t idx_strides = allocator.reserve_argspace(strides.data(), strides.size() * sizeof(int));
-    // size_t idx_stride_magic =
-    //     allocator.reserve_argspace(stride_magic.data(), stride_magic.size() * sizeof(int));
-    // size_t idx_stride_shift =
-    //     allocator.reserve_argspace(stride_shift.data(), stride_shift.size() * sizeof(int));
-    // size_t idx_reduced_strides =
-    //     allocator.reserve_argspace(reduced_strides.data(), reduced_strides.size() * sizeof(int));
-
 
     // TODO: blending factors are not currently implemented
     float alpha = 1.0f;

--- a/src/ngraph/runtime/gpu/cuda_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cuda_emitter.cpp
@@ -1719,16 +1719,7 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
         return primitive_index;
     }
 
-    // if the kernel has not been compiled, build it
-    auto compiled_kernel = m_ctx->compiled_kernel_pool->get(kernel_name);
-    if (compiled_kernel == nullptr)
-    {
-        codegen::CodeWriter writer;
-        writer << include_helpers();
-        runtime::gpu::CudaKernelBuilder::get_broadcast_op(
-            writer, kernel_name, dtypes, result_shape.size());
-        compiled_kernel = m_ctx->compiled_kernel_pool->set(kernel_name, writer.get_code());
-    }
+
 
     // calculate strides
     GPUShape strides = row_major_strides(result_shape);
@@ -1755,14 +1746,15 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
         reduced_strides[axis] = 0;
     }
 
-    GPUAllocator allocator = this->m_primitive_emitter->get_memory_allocator();
-    size_t idx_strides = allocator.reserve_argspace(strides.data(), strides.size() * sizeof(int));
-    size_t idx_stride_magic =
-        allocator.reserve_argspace(stride_magic.data(), stride_magic.size() * sizeof(int));
-    size_t idx_stride_shift =
-        allocator.reserve_argspace(stride_shift.data(), stride_shift.size() * sizeof(int));
-    size_t idx_reduced_strides =
-        allocator.reserve_argspace(reduced_strides.data(), reduced_strides.size() * sizeof(int));
+    // GPUAllocator allocator = this->m_primitive_emitter->get_memory_allocator();
+    // size_t idx_strides = allocator.reserve_argspace(strides.data(), strides.size() * sizeof(int));
+    // size_t idx_stride_magic =
+    //     allocator.reserve_argspace(stride_magic.data(), stride_magic.size() * sizeof(int));
+    // size_t idx_stride_shift =
+    //     allocator.reserve_argspace(stride_shift.data(), stride_shift.size() * sizeof(int));
+    // size_t idx_reduced_strides =
+    //     allocator.reserve_argspace(reduced_strides.data(), reduced_strides.size() * sizeof(int));
+
 
     // TODO: blending factors are not currently implemented
     float alpha = 1.0f;
@@ -1774,23 +1766,34 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
     uint32_t aligned_grid_size_x =
         align_to_block_size(static_cast<uint32_t>(nthreads), block_size_x);
 
+    auto args = this->m_primitive_emitter->add_kernel_args();
+    args.add_placeholder(dtypes[0], "in")
+        .add_placeholder(dtypes[1], "out")
+        .add("strides", strides)
+        .add("stride_magic", stride_magic)
+        .add("stride_shift", stride_shift)
+        .add("reduced_strides", reduced_strides)
+        .add("alpha", alpha)
+        .add("beta", beta)
+        .add("nthreads", nthreads);
+
+    // if the kernel has not been compiled, build it
+    auto compiled_kernel = m_ctx->compiled_kernel_pool->get(kernel_name);
+    if (compiled_kernel == nullptr)
+    {
+        codegen::CodeWriter writer;
+        writer << include_helpers();
+        runtime::gpu::CudaKernelBuilder::get_kernel_signature(
+            writer, kernel_name, dtypes, args.get_input_signature());
+        runtime::gpu::CudaKernelBuilder::get_broadcast_op(
+            writer, result_shape.size());
+        compiled_kernel = m_ctx->compiled_kernel_pool->set(kernel_name, writer.get_code());
+    }
+
     std::unique_ptr<gpu::primitive> broadcast(new gpu::primitive{[=](void** inputs,
                                                                      void** outputs) mutable {
-        void* strides_d = runtime::gpu::invoke_memory_primitive(m_ctx, idx_strides);
-        void* stride_magic_d = runtime::gpu::invoke_memory_primitive(m_ctx, idx_stride_magic);
-        void* stride_shift_d = runtime::gpu::invoke_memory_primitive(m_ctx, idx_stride_shift);
-        void* reduced_strides_d = runtime::gpu::invoke_memory_primitive(m_ctx, idx_reduced_strides);
 
-        void* args_list[] = {&inputs[0],
-                             &outputs[0],
-                             &strides_d,
-                             &stride_magic_d,
-                             &stride_shift_d,
-                             &reduced_strides_d,
-                             &alpha,
-                             &beta,
-                             &nthreads};
-
+        void** args_list = args.get_argument_list(inputs[0], outputs[0]);
         CUDA_SAFE_CALL(cuLaunchKernel(*compiled_kernel.get(),
                                       aligned_grid_size_x,
                                       1,

--- a/src/ngraph/runtime/gpu/cuda_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cuda_emitter.cpp
@@ -1780,8 +1780,10 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
 
     std::unique_ptr<gpu::primitive> broadcast(new gpu::primitive{[=](void** inputs,
                                                                      void** outputs) mutable {
+                void** args_list = args.resolve_placeholder(0, &inputs[0])
+                    .resolve_placeholder(1, &outputs[0])
+                    .get_argument_list();
 
-        void** args_list = args.get_argument_list({&inputs[0], &outputs[0]});
         CUDA_SAFE_CALL(cuLaunchKernel(*compiled_kernel.get(),
                                       aligned_grid_size_x,
                                       1,

--- a/src/ngraph/runtime/gpu/cuda_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cuda_emitter.cpp
@@ -1793,7 +1793,7 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
     std::unique_ptr<gpu::primitive> broadcast(new gpu::primitive{[=](void** inputs,
                                                                      void** outputs) mutable {
 
-        void** args_list = args.get_argument_list(inputs[0], outputs[0]);
+        void** args_list = args.get_argument_list(&inputs[0], &outputs[0]);
         CUDA_SAFE_CALL(cuLaunchKernel(*compiled_kernel.get(),
                                       aligned_grid_size_x,
                                       1,

--- a/src/ngraph/runtime/gpu/cuda_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cuda_emitter.cpp
@@ -1784,7 +1784,7 @@ size_t runtime::gpu::CUDAEmitter::build_broadcast(const std::array<std::string, 
         codegen::CodeWriter writer;
         writer << include_helpers();
         runtime::gpu::CudaKernelBuilder::get_kernel_signature(
-            writer, kernel_name, dtypes, args.get_input_signature());
+            writer, kernel_name, args.get_input_signature());
         runtime::gpu::CudaKernelBuilder::get_broadcast_op(
             writer, result_shape.size());
         compiled_kernel = m_ctx->compiled_kernel_pool->set(kernel_name, writer.get_code());

--- a/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.cpp
+++ b/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.cpp
@@ -147,19 +147,8 @@ void runtime::gpu::CudaKernelBuilder::get_ew_collective_op(
 }
 
 void runtime::gpu::CudaKernelBuilder::get_broadcast_op(codegen::CodeWriter& writer,
-                                                       const std::string& name,
-                                                       const std::array<std::string, 2>& data_types,
                                                        const size_t rank)
 {
-    writer << "extern \"C\" __global__ void cuda_" << name << "(" << data_types[0] << "* in, "
-           << data_types[1] << "* out, "
-           << "int* strides, "
-           << "int* stride_magic, "
-           << "int* stride_shift, "
-           << "int* reduced_strides, "
-           << "float alpha, float beta, "
-           << "size_t nthreads"
-           << ")\n";
     writer.block_begin();
     {
         writer << "const int tid = blockDim.x*blockIdx.x + threadIdx.x;\n";

--- a/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.cpp
+++ b/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.cpp
@@ -163,7 +163,8 @@ void runtime::gpu::CudaKernelBuilder::get_broadcast_op(codegen::CodeWriter& writ
                                                                              "stride_shift",
                                                                              "reduced_strides",
                                                                              "coordinate",
-                                                                             rank);
+                                                                             rank,
+                                                                             true);
             writer << "out[tid] = load(in, " << reduced_idx << ");\n";
         }
         writer.block_end();
@@ -1167,8 +1168,12 @@ void runtime::gpu::CudaKernelBuilder::coordinate_transform_to_multi_d(codegen::C
                                                                       std::string i_stride_shift,
                                                                       std::string i_coord_product,
                                                                       std::string o_coordinates,
-                                                                      size_t rank)
+                                                                      size_t rank,
+                                                                      bool register_arguments)
 {
+    std::string brace_open = (register_arguments) ? "" : "[";
+    std::string brace_close = (register_arguments) ? "" : "]";
+
     // Translation from flat index to dense tensor coordinates:
     // Given tensor shape [d0 d1 ... dN] with strides [d1*...*dN, d2*...*dN, ... 1],
     // calculate coordinates as:
@@ -1184,11 +1189,11 @@ void runtime::gpu::CudaKernelBuilder::coordinate_transform_to_multi_d(codegen::C
         if (i != 0)
         {
             writer << "coordinate_product -= (" << o_coordinates << i - 1 << " * " << i_strides
-                   << "[" << i - 1 << "]);\n";
+                   << brace_open << i - 1 << brace_close << ");\n";
         }
         writer << "int " << o_coordinates << i << " = division_by_invariant_multiplication("
-               << "coordinate_product, " << i_stride_magic << "[" << i << "], " << i_stride_shift
-               << "[" << i << "]);\n";
+               << "coordinate_product, " << i_stride_magic << brace_open << i << brace_close << ", " << i_stride_shift
+               << brace_open << i << brace_close << ");\n";
     }
 }
 std::string runtime::gpu::CudaKernelBuilder::collective_coordinate_transform_helper(
@@ -1199,22 +1204,27 @@ std::string runtime::gpu::CudaKernelBuilder::collective_coordinate_transform_hel
     std::string i_stride_shift,
     std::string i_reduced_strides,
     std::string o_coordinates,
-    size_t rank)
+    size_t rank,
+    bool register_arguments)
 {
     coordinate_transform_to_multi_d(
-        writer, i_strides, i_stride_magic, i_stride_shift, i_thread_index, o_coordinates, rank);
+        writer, i_strides, i_stride_magic, i_stride_shift, i_thread_index, o_coordinates, rank, register_arguments);
+
+    std::string brace_open = (register_arguments) ? "" : "[";
+    std::string brace_close = (register_arguments) ? "" : "]";
 
     // index into reduced tensor from coordinates of non-reduced tensor
     std::string reduced_idx = "reduced_idx";
     writer << "int " << reduced_idx << " = 0;\n";
     for (size_t i = 0; i < rank; i++)
     {
-        writer << "reduced_idx += " << o_coordinates << i << " * " << i_reduced_strides << "[" << i
-               << "];\n";
+        writer << "reduced_idx += " << o_coordinates << i << " * " << i_reduced_strides << brace_open << i
+               << brace_close << ";\n";
     }
 
     return reduced_idx;
 }
+
 void runtime::gpu::CudaKernelBuilder::get_device_helper(codegen::CodeWriter& writer,
                                                         const std::string& name,
                                                         const std::string& math_kernel,

--- a/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.cpp
+++ b/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.cpp
@@ -1192,8 +1192,8 @@ void runtime::gpu::CudaKernelBuilder::coordinate_transform_to_multi_d(codegen::C
                    << brace_open << i - 1 << brace_close << ");\n";
         }
         writer << "int " << o_coordinates << i << " = division_by_invariant_multiplication("
-               << "coordinate_product, " << i_stride_magic << brace_open << i << brace_close << ", " << i_stride_shift
-               << brace_open << i << brace_close << ");\n";
+               << "coordinate_product, " << i_stride_magic << brace_open << i << brace_close << ", "
+               << i_stride_shift << brace_open << i << brace_close << ");\n";
     }
 }
 std::string runtime::gpu::CudaKernelBuilder::collective_coordinate_transform_helper(
@@ -1207,8 +1207,14 @@ std::string runtime::gpu::CudaKernelBuilder::collective_coordinate_transform_hel
     size_t rank,
     bool register_arguments)
 {
-    coordinate_transform_to_multi_d(
-        writer, i_strides, i_stride_magic, i_stride_shift, i_thread_index, o_coordinates, rank, register_arguments);
+    coordinate_transform_to_multi_d(writer,
+                                    i_strides,
+                                    i_stride_magic,
+                                    i_stride_shift,
+                                    i_thread_index,
+                                    o_coordinates,
+                                    rank,
+                                    register_arguments);
 
     std::string brace_open = (register_arguments) ? "" : "[";
     std::string brace_close = (register_arguments) ? "" : "]";
@@ -1218,8 +1224,8 @@ std::string runtime::gpu::CudaKernelBuilder::collective_coordinate_transform_hel
     writer << "int " << reduced_idx << " = 0;\n";
     for (size_t i = 0; i < rank; i++)
     {
-        writer << "reduced_idx += " << o_coordinates << i << " * " << i_reduced_strides << brace_open << i
-               << brace_close << ";\n";
+        writer << "reduced_idx += " << o_coordinates << i << " * " << i_reduced_strides
+               << brace_open << i << brace_close << ";\n";
     }
 
     return reduced_idx;

--- a/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.hpp
+++ b/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.hpp
@@ -47,8 +47,7 @@ namespace ngraph
                                                const std::string& op,
                                                const std::vector<std::string>& data_types);
 
-                static void get_broadcast_op(codegen::CodeWriter& writer,
-                                             const size_t rank);
+                static void get_broadcast_op(codegen::CodeWriter& writer, const size_t rank);
 
                 static void get_concat_op(codegen::CodeWriter& writer,
                                           const std::string& name,

--- a/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.hpp
+++ b/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.hpp
@@ -34,17 +34,11 @@ namespace ngraph
             class CudaKernelBuilder
             {
             public:
-                template <typename T>
                 static void get_kernel_signature(codegen::CodeWriter& writer,
                                                  const std::string& name,
-                                                 const T& data_types,
                                                  const std::string& input_signature)
                 {
                     writer << "extern \"C\" __global__ void cuda_" << name;
-                    for (auto const& type : data_types)
-                    {
-                        writer << "_" << type;
-                    }
                     writer << input_signature;
                 }
 

--- a/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.hpp
+++ b/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.hpp
@@ -34,14 +34,26 @@ namespace ngraph
             class CudaKernelBuilder
             {
             public:
+                template <typename T>
+                static void get_kernel_signature(codegen::CodeWriter& writer,
+                                                 const std::string& name,
+                                                 const T& data_types,
+                                                 const std::string& input_signature)
+                {
+                    writer << "extern \"C\" __global__ void cuda_" << name;
+                    for (auto const& type : data_types)
+                    {
+                        writer << "_" << type;
+                    }
+                    writer << input_signature;
+                }
+
                 static void get_elementwise_op(codegen::CodeWriter& writer,
                                                const std::string& name,
                                                const std::string& op,
                                                const std::vector<std::string>& data_types);
 
                 static void get_broadcast_op(codegen::CodeWriter& writer,
-                                             const std::string& name,
-                                             const std::array<std::string, 2>& data_types,
                                              const size_t rank);
 
                 static void get_concat_op(codegen::CodeWriter& writer,

--- a/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.hpp
+++ b/src/ngraph/runtime/gpu/gpu_cuda_kernel_builder.hpp
@@ -144,14 +144,16 @@ namespace ngraph
                                                            std::string i_stride_shift,
                                                            std::string i_reduced_strides,
                                                            std::string o_coordinates,
-                                                           size_t rank);
+                                                           size_t rank,
+                                                           bool register_arguments = false);
                 static void coordinate_transform_to_multi_d(codegen::CodeWriter& writer,
                                                             std::string i_strides,
                                                             std::string i_stride_magic,
                                                             std::string i_stride_shift,
                                                             std::string i_coord_product,
                                                             std::string o_coordinates,
-                                                            size_t rank);
+                                                            size_t rank,
+                                                            bool register_arguments = false);
             };
         }
     }


### PR DESCRIPTION
Use new GPUKernelArgs helper to generate broadcast kernel signature and automatically expand array arguments into registers. Removes the need for GPUAllocator argspace memory reservations.

~5x performance improvement.

```
Benchmarking batch_size/1024/mxnet-ngraph-Function_1-MakeForwardFunction-pre-optimized-fprop.json, GPU backend, 10 iterations.
compile time: 7,345ms
142.1ms per iteration
```
Before: 
```
---- Aggregate times per op type ----
Softmax       66,174us
Broadcast     25,137us
Slice          9,076us
Add            7,898us
Dot            7,366us
Concat         5,105us
Divide         1,505us
Multiply       1,382us
Exp            1,111us
Reshape        1,098us
Negative       1,082us
Result         1,054us
Tanh             767us
```

After"
```
---- Aggregate times per op type ----
Softmax       70,324us
Slice          9,729us
Add            7,970us
Dot            7,894us
Broadcast      5,293us
Concat         4,942us
Divide         1,549us
Multiply       1,402us
Reshape        1,143us
Exp            1,122us
Negative       1,086us
Result         1,054us
Tanh             786us
```