### PR TITLE
IntelGPU backend: Allow zero size Shape

### DIFF
--- a/src/ngraph/runtime/intelgpu/intelgpu_layout.cpp
+++ b/src/ngraph/runtime/intelgpu/intelgpu_layout.cpp
@@ -82,16 +82,22 @@ cldnn::tensor runtime::intelgpu::IntelGPULayout::create_cldnn_tensor(const Shape
 {
     vector<size_t> idx(4, 1);
     size_t index = 0;
+    const size_t total_zise = shape_size<Shape>(element_shape);
 
-    for (auto i = element_shape.crbegin(); i != element_shape.crend() && index < 3; ++i, ++index)
+    // clDNN requires at least scalar tensor size. We can't create zero sized tensors
+    if (total_zise != 0)
     {
-        idx.at(index) = *i;
-    }
+        for (auto i = element_shape.crbegin(); i != element_shape.crend() && index < 3;
+             ++i, ++index)
+        {
+            idx.at(index) = *i;
+        }
 
-    if (element_shape.size() > 3)
-    {
-        idx.at(3) =
-            accumulate(element_shape.rbegin() + 3, element_shape.rend(), 1, multiplies<size_t>());
+        if (element_shape.size() > 3)
+        {
+            idx.at(3) = accumulate(
+                element_shape.rbegin() + 3, element_shape.rend(), 1, multiplies<size_t>());
+        }
     }
 
     //Parameters for this ctor: batch, feature, spatial_x, spatial_y


### PR DESCRIPTION
clDNN has a limitation in case of zero size memory creation. We must allocate at least one element for any Shape.