### PR TITLE
add EXCLUDE_FROM_ALL to codegen directory

### DIFF
--- a/cmake/external_llvm.cmake
+++ b/cmake/external_llvm.cmake
@@ -175,5 +175,6 @@ else()
 endif()
 
 add_library(libllvm INTERFACE)
+add_dependencies(libllvm ext_llvm)
 target_include_directories(libllvm SYSTEM INTERFACE ${EXTERNAL_PROJECTS_ROOT}/llvm/include)
 target_link_libraries(libllvm INTERFACE ${LLVM_LINK_LIBS})

--- a/cmake/external_llvm_prebuilt.cmake
+++ b/cmake/external_llvm_prebuilt.cmake
@@ -139,5 +139,6 @@ set(LLVM_LINK_LIBS
 )
 
 add_library(libllvm INTERFACE)
+add_dependencies(libllvm ext_llvm)
 target_include_directories(libllvm SYSTEM INTERFACE ${SOURCE_DIR}/include)
 target_link_libraries(libllvm INTERFACE ${LLVM_LINK_LIBS})

--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -165,6 +165,7 @@ add_custom_command(TARGET ext_mkldnn POST_BUILD
 )
 
 add_library(libmkldnn INTERFACE)
+add_dependencies(libmkldnn ext_mkldnn)
 target_include_directories(libmkldnn SYSTEM INTERFACE ${EXTERNAL_PROJECTS_ROOT}/mkldnn/include)
 target_link_libraries(libmkldnn INTERFACE
     ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/libmkldnn${CMAKE_SHARED_LIBRARY_SUFFIX}

--- a/src/ngraph/CMakeLists.txt
+++ b/src/ngraph/CMakeLists.txt
@@ -183,7 +183,7 @@ endif()
 
 include_directories("${NGRAPH_INCLUDE_PATH}")
 
-add_subdirectory(codegen)
+add_subdirectory(codegen EXCLUDE_FROM_ALL)
 add_subdirectory(runtime)
 
 add_library(ngraph SHARED ${SRC})

--- a/src/ngraph/codegen/CMakeLists.txt
+++ b/src/ngraph/codegen/CMakeLists.txt
@@ -69,13 +69,9 @@ add_custom_target(header_resource
     BYPRODUCTS
 )
 
-# The conditional is a hack. I want to use EXCLUDE_FROM_ALL and OPTIONAL but that does not
-# seem to be working for me.
-if ((NGRAPH_CPU_ENABLE AND NOT NGRAPH_DEX_ONLY) OR NGRAPH_GPU_ENABLE)
-    add_library(codegen SHARED ${SRC})
-    set_target_properties(codegen PROPERTIES VERSION ${NGRAPH_VERSION} SOVERSION ${NGRAPH_API_VERSION})
-    add_dependencies(codegen header_resource libmkldnn libeigen)
-    target_include_directories(codegen SYSTEM PUBLIC ${CMAKE_BINARY_DIR})
-    target_link_libraries(codegen PRIVATE libllvm ngraph)
-    install(TARGETS codegen DESTINATION ${NGRAPH_INSTALL_LIB})
-endif()
+add_library(codegen SHARED ${SRC})
+set_target_properties(codegen PROPERTIES VERSION ${NGRAPH_VERSION} SOVERSION ${NGRAPH_API_VERSION})
+add_dependencies(codegen header_resource libmkldnn libeigen)
+target_include_directories(codegen SYSTEM PUBLIC ${CMAKE_BINARY_DIR})
+target_link_libraries(codegen PRIVATE libllvm ngraph)
+install(TARGETS codegen DESTINATION ${NGRAPH_INSTALL_LIB})


### PR DESCRIPTION
so we don't need to using conditionals in build. If codegen is needed it will be built.

Now cmake does the right thing and builds codegen when some other target depends on it and does not build it otherwise. I tried adding EXCLUDE_FROM_ALL in the codegen cmake but that gave a warning. This method seems to work and no warnings