### PR TITLE
Test cent os gcc 4.8 fix of bug in std::basic_string

### DIFF
--- a/src/ngraph/runtime/gpu/cuda_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cuda_emitter.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <limits>
 #include <ostream>
+#include <string>
 #include <vector>
 
 #include "ngraph/codegen/code_writer.hpp"


### PR DESCRIPTION
```
cd /home/dockuser/ngraph/BUILD-GCC/src/ngraph/runtime/gpu && /usr/bin/c++  -DNGRAPH_VERSION=\"0.5.0+40ddf45\" -Dgpu_backend_EXPORTS -I/home/dockuser/ngraph/src/ngraph -I/home/dockuser/ngraph/src -isystem /usr/local/cuda/include -isystem /home/dockuser/ngraph/BUILD-GCC/json/src/ext_json/include -isystem /home/dockuser/ngraph/BUILD-GCC  -DEIGEN_MPL2_ONLY -std=c++11 -march=native -O2 -fPIE -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector -DNGRAPH_CPU_ENABLE -DIN_NGRAPH_LIBRARY -DGRAPHVIZ_FOUND -g -fPIC   -o CMakeFiles/gpu_backend.dir/gpu_emitter.cpp.o -c /home/dockuser/ngraph/src/ngraph/runtime/gpu/gpu_emitter.cpp
In file included from /usr/include/c++/4.8.2/string:52:0,
                 from /usr/include/c++/4.8.2/random:41,
                 from /usr/include/c++/4.8.2/bits/stl_algo.h:65,
                 from /usr/include/c++/4.8.2/algorithm:62,
                 from /home/dockuser/ngraph/src/ngraph/runtime/gpu/cuda_emitter.cpp:16:
/usr/include/c++/4.8.2/bits/basic_string.h: In instantiation of 'static _CharT* std::basic_string<_CharT, _Traits, _Alloc>::_S_construct_aux(_InIterator, _InIterator, const _Alloc&, std::__false_type) [with _InIterator = std::basic_string<char>; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]':
/usr/include/c++/4.8.2/bits/basic_string.h:1746:58:   required from 'static _CharT* std::basic_string<_CharT, _Traits, _Alloc>::_S_construct(_InIterator, _InIterator, const _Alloc&) [with _InIterator = std::basic_string<char>; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]'
/usr/include/c++/4.8.2/bits/basic_string.tcc:229:49:   required from 'std::basic_string<_CharT, _Traits, _Alloc>::basic_string(_InputIterator, _InputIterator, const _Alloc&) [with _InputIterator = std::basic_string<char>; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]'
/home/dockuser/ngraph/src/ngraph/runtime/gpu/cuda_emitter.cpp:1373:97:   required from here
/usr/include/c++/4.8.2/bits/basic_string.h:1724:76: error: no type named 'iterator_category' in 'struct std::iterator_traits<std::basic_string<char> >'
           typedef typename iterator_traits<_InIterator>::iterator_category _Tag;
                                                                            ^
[ 61%] Building CXX object src/ngraph/runtime/gpu/CMakeFiles/gpu_backend.dir/gpu_external_function.cpp.o
cd /home/dockuser/ngraph/BUILD-GCC/src/ngraph/runtime/gpu && /usr/bin/c++  -DNGRAPH_VERSION=\"0.5.0+40ddf45\" -Dgpu_backend_EXPORTS -I/home/dockuser/ngraph/src/ngraph -I/home/dockuser/ngraph/src -isystem /usr/local/cuda/include -isystem /home/dockuser/ngraph/BUILD-GCC/json/src/ext_json/include -isystem /home/dockuser/ngraph/BUILD-GCC  -DEIGEN_MPL2_ONLY -std=c++11 -march=native -O2 -fPIE -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector -DNGRAPH_CPU_ENABLE -DIN_NGRAPH_LIBRARY -DGRAPHVIZ_FOUND -g -fPIC   -o CMakeFiles/gpu_backend.dir/gpu_external_function.cpp.o -c /home/dockuser/ngraph/src/ngraph/runtime/gpu/gpu_external_function.cpp
make[2]: *** [src/ngraph/runtime/gpu/CMakeFiles/gpu_backend.dir/cuda_emitter.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....

```