### PR TITLE
IntelGPU backend: Broken compilation fixed

### DIFF
--- a/src/ngraph/runtime/intelgpu/intelgpu_tensor_view.cpp
+++ b/src/ngraph/runtime/intelgpu/intelgpu_tensor_view.cpp
@@ -25,12 +25,11 @@
 using namespace ngraph;
 using namespace std;
 
-runtime::intelgpu::IntelGPUTensorView::IntelGPUTensorView(const ngraph::element::Type& element_type,
+runtime::intelgpu::IntelGPUTensorView::IntelGPUTensorView(const element::Type& element_type,
                                                           const Shape& shape,
                                                           const cldnn::engine& backend_engine,
                                                           void* memory_pointer)
-    : runtime::TensorView(std::make_shared<ngraph::descriptor::TensorView>(
-          std::make_shared<ngraph::TensorViewType>(element_type, shape), "external"))
+    : runtime::TensorView(make_shared<descriptor::TensorView>(element_type, shape, "external"))
 {
     const cldnn::layout layout = IntelGPULayout::create_cldnn_layout(element_type, shape);
 

--- a/src/ngraph/runtime/intelgpu/intelgpu_tensor_view.hpp
+++ b/src/ngraph/runtime/intelgpu/intelgpu_tensor_view.hpp
@@ -35,7 +35,7 @@ namespace ngraph
 class ngraph::runtime::intelgpu::IntelGPUTensorView : public ngraph::runtime::TensorView
 {
 public:
-    IntelGPUTensorView(const ngraph::element::Type& element_type,
+    IntelGPUTensorView(const element::Type& element_type,
                        const Shape& shape,
                        const cldnn::engine& backend_engine,
                        void* memory_pointer = nullptr);


### PR DESCRIPTION
Since we have not yet implemented live (jenkins) compilation status check for IntelGPU backend, the PR #1463 broked the backend compilation.

It is quite simple to build IntelGPU backend in nGraph. It does not require any special HW to build.
It requires several include sources and a library. I can provide tar archive with it.
After this, just put `-DNGRAPH_INTELGPU_ENABLE=TRUE` and `-DCLDNN_ROOT_DIR=${path_to_cldnn_headers}` and the backend should be built.
