### PR TITLE
add ISO C++ Guideline Support Library (gsl-lite)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,8 @@ if(NOT DEFINED EXTERNAL_PROJECTS_ROOT)
     set(EXTERNAL_PROJECTS_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
+include(cmake/external_gsl-lite.cmake)
+
 if (NGRAPH_ONNX_IMPORT_ENABLE)
     if (NOT NGRAPH_USE_SYSTEM_PROTOBUF)
         include(cmake/external_protobuf.cmake)

--- a/cmake/external_gsl-lite.cmake
+++ b/cmake/external_gsl-lite.cmake
@@ -1,0 +1,74 @@
+# ******************************************************************************
+# Copyright 2017-2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ******************************************************************************
+
+# Enable ExternalProject CMake module
+include(ExternalProject)
+
+#------------------------------------------------------------------------------
+# Download and install gsl-lite...
+#------------------------------------------------------------------------------
+
+set(GSL_LITE_GIT_REPO_URL https://github.com/martinmoene/gsl-lite.git)
+set(GSL_LITE_GIT_SHA1 119af9fcd3138cf0b7ee8f556cef884814b46095)
+
+if (${CMAKE_VERSION} VERSION_LESS 3.6)
+    ExternalProject_Add(
+            ext_gsl-lite
+            PREFIX ext_gsl-lite
+            GIT_REPOSITORY ${GSL_LITE_GIT_REPO_URL}
+            GIT_TAG ${GSL_LITE_GIT_SHA1}
+            INSTALL_COMMAND ""
+            UPDATE_COMMAND ""
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND ""
+            TMP_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/tmp"
+            STAMP_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/stamp"
+            DOWNLOAD_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/download"
+            SOURCE_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/src"
+            BINARY_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/bin"
+            INSTALL_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite"
+            EXCLUDE_FROM_ALL TRUE)
+else()
+    # To speed things up prefer 'shallow copy' for CMake 3.6 and later
+    ExternalProject_Add(
+            ext_gsl-lite
+            PREFIX ext_gsl-lite
+            GIT_REPOSITORY ${GSL_LITE_GIT_REPO_URL}
+            GIT_TAG ${GSL_LITE_GIT_SHA1}
+            GIT_SHALLOW TRUE
+            INSTALL_COMMAND ""
+            UPDATE_COMMAND ""
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND ""
+            TMP_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/tmp"
+            STAMP_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/stamp"
+            DOWNLOAD_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/download"
+            SOURCE_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/src"
+            BINARY_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite/bin"
+            INSTALL_DIR "${EXTERNAL_PROJECTS_ROOT}/gsl-lite"
+            EXCLUDE_FROM_ALL TRUE)
+endif()
+
+# -----------------------------------------------------------------------------
+
+ExternalProject_Get_Property(ext_gsl-lite SOURCE_DIR)
+
+set(GSL_LITE_INCLUDE_DIR ${SOURCE_DIR}/include
+    CACHE INTERNAL "Include directory for gsl-lite")
+
+add_library(gsl INTERFACE)
+target_include_directories(gsl SYSTEM INTERFACE ${GSL_LITE_INCLUDE_DIR})
+add_dependencies(gsl ext_gsl-lite)

--- a/src/ngraph/frontend/onnxifi/CMakeLists.txt
+++ b/src/ngraph/frontend/onnxifi/CMakeLists.txt
@@ -15,7 +15,7 @@
 # ******************************************************************************
 
 add_library(onnxifi-ngraph SHARED onnxifi.cpp backend.hpp backend_manager.hpp backend_manager.cpp)
-target_link_libraries(onnxifi-ngraph PRIVATE ngraph)
+target_link_libraries(onnxifi-ngraph PRIVATE ngraph gsl)
 
 add_dependencies(onnxifi-ngraph onnx::libonnx)
 target_include_directories(onnxifi-ngraph SYSTEM PRIVATE ${ONNX_INCLUDE_DIR})


### PR DESCRIPTION
Currently, only ONNXIFI is using it, but in the future, nGraph may benefit, too.

The Guideline Support Library (GSL) contains functions and types that are suggested for use by the _C++ Core Guidelines_ maintained by the _Standard C++ Foundation_. The library includes types like `owner<>`, `not_null<>`, `span<>`, `string_span` and much more.

The `gsl-lite` recognizes when it is compiled for the CUDA platform and decorates functions (methods) with `__host__` and `__device__`.

Refer to https://github.com/isocpp/CppCoreGuidelines for more details.

Signed-off-by: Artur Wojcik <artur.wojcik@intel.com>