### PR TITLE
add checks that allow GPU to be build without CPU

### DIFF
--- a/src/ngraph/codegen/compiler.cpp
+++ b/src/ngraph/codegen/compiler.cpp
@@ -408,9 +408,15 @@ void codegen::CompilerCore::configure_search_path()
 #endif
 
 #if defined(__APPLE__)
+#ifdef EIGEN_HEADERS_PATH
     add_header_search_path(EIGEN_HEADERS_PATH);
+#endif
+#ifdef MKLDNN_HEADERS_PATH
     add_header_search_path(MKLDNN_HEADERS_PATH);
+#endif
+#ifdef TBB_HEADERS_PATH
     add_header_search_path(TBB_HEADERS_PATH);
+#endif
     add_header_search_path(NGRAPH_HEADERS_PATH);
     add_header_search_path(CLANG_BUILTIN_HEADERS_PATH);
 
@@ -422,9 +428,15 @@ void codegen::CompilerCore::configure_search_path()
     // Instead of re-implementing all of that functionality in a custom toolchain
     // just hardcode the paths relevant to frequently used build/test machines for now
     add_header_search_path(CLANG_BUILTIN_HEADERS_PATH);
+#ifdef EIGEN_HEADERS_PATH
     add_header_search_path(EIGEN_HEADERS_PATH);
+#endif
+#ifdef MKLDNN_HEADERS_PATH
     add_header_search_path(MKLDNN_HEADERS_PATH);
+#endif
+#ifdef TBB_HEADERS_PATH
     add_header_search_path(TBB_HEADERS_PATH);
+#endif
     add_header_search_path(NGRAPH_HEADERS_PATH);
 
     string header_version = find_header_version("/usr/include/c++");


### PR DESCRIPTION
Change to codegen search paths to not include CPU specific header paths if CPU is not part of the build