### PR TITLE
Bug fix for nvgpu GOE

### DIFF
--- a/src/ngraph/runtime/gpu/gpu_emitter.cpp
+++ b/src/ngraph/runtime/gpu/gpu_emitter.cpp
@@ -1302,7 +1302,7 @@ namespace ngraph
                 auto get_tuple_element = static_cast<const ngraph::op::GetOutputElement*>(node);
 
                 writer.block_begin();
-                writer << "runtime::gpu::cuda_memcpyDtH(" << out[0].get_name() << ", "
+                writer << "runtime::gpu::cuda_memcpyDtD(" << out[0].get_name() << ", "
                        << args[get_tuple_element->get_n()].get_name() << ", "
                        << out[0].get_size() * out[0].get_element_type().size() << ");\n";
                 writer.block_end();


### PR DESCRIPTION
When the GetOutputElement Elimination pass does not eliminate the memcpy, this should be a device-to-device transfer.