### PR TITLE
Cannot end a single line c++ commend with a backslash.

### DIFF
--- a/src/ngraph/assertion.hpp
+++ b/src/ngraph/assertion.hpp
@@ -75,8 +75,8 @@ namespace ngraph
     ///
     ///   class CompileError : public AssertionFailure;
     ///
-    ///   #define COMPILE_ASSERT(node,cond)                                                  \
-    ///      NGRAPH_ASSERT_STREAM_WITH_LOC(::ngraph::CompileError, cond,                     \
+    ///   #define COMPILE_ASSERT(node,cond)                                       <backslash>
+    ///      NGRAPH_ASSERT_STREAM_WITH_LOC(::ngraph::CompileError, cond,          <backslash>
     ///                                    "While compiling node " + node->name())
     ///
     ///   ...


### PR DESCRIPTION
Causes an error like
/  /paddle/build/third_party/install/ngraph/include/ngraph/assertion.hpp:78:5: error: multi-line comment [-Werror=comment]