### PR TITLE
IntelGPU backend. Use common nGraph optimization passes

### DIFF
--- a/src/ngraph/runtime/intelgpu/intelgpu_backend.cpp
+++ b/src/ngraph/runtime/intelgpu/intelgpu_backend.cpp
@@ -32,6 +32,11 @@
 #include <CPP/softmax.hpp>
 #include <CPP/topology.hpp>
 
+#include "ngraph/pass/algebraic_simplification.hpp"
+#include "ngraph/pass/cse.hpp"
+#include "ngraph/pass/get_output_element_elimination.hpp"
+#include "ngraph/pass/manager.hpp"
+#include "ngraph/pass/nop_elimination.hpp"
 #include "ngraph/runtime/intelgpu/intelgpu_backend.hpp"
 #include "ngraph/runtime/intelgpu/intelgpu_layout.hpp"
 #include "ngraph/runtime/intelgpu/intelgpu_op_batchnorm.hpp"
@@ -256,6 +261,17 @@ bool runtime::intelgpu::IntelGPUBackend::compile(shared_ptr<Function> func)
     {
         return true;
     }
+
+    ngraph::pass::Manager pass_manager;
+
+    pass_manager.register_pass<ngraph::pass::NopElimination>();
+    pass_manager.register_pass<ngraph::pass::AlgebraicSimplification>();
+    pass_manager.register_pass<ngraph::pass::CommonSubexpressionElimination>();
+
+    // GetOutputElementElimination must be after CommonSubexpressionElimination
+    pass_manager.register_pass<ngraph::pass::GetOutputElementElimination>();
+
+    pass_manager.run_passes(func);
 
     cldnn::topology topology;
 

--- a/src/ngraph/runtime/intelgpu/intelgpu_backend.cpp
+++ b/src/ngraph/runtime/intelgpu/intelgpu_backend.cpp
@@ -262,6 +262,7 @@ bool runtime::intelgpu::IntelGPUBackend::compile(shared_ptr<Function> func)
         return true;
     }
 
+    cldnn::topology topology;
     ngraph::pass::Manager pass_manager;
 
     pass_manager.register_pass<ngraph::pass::NopElimination>();
@@ -272,8 +273,6 @@ bool runtime::intelgpu::IntelGPUBackend::compile(shared_ptr<Function> func)
     pass_manager.register_pass<ngraph::pass::GetOutputElementElimination>();
 
     pass_manager.run_passes(func);
-
-    cldnn::topology topology;
 
     for (shared_ptr<Node> op : func->get_ops())
     {


### PR DESCRIPTION
These optimizations reduces number of operation in Function:
- ResNet50 training mode with 26% (from 3182 to 2337 and "no operation" from 640 to 287)
- mxnet-ngraph-Function_6-CompileForward-fprop.json with 33% (from 488407 to 322926 and "no operation" from 69868 to 35372)

"ngraph::pass::CoreFusion" was not used due to number of operations with ResNet50 (inference mode) increases 2x and final performance became worse.