### PR TITLE
GPU backend. Fix compilation on Ubuntu 18. std::iota requires <numeri…

### DIFF
--- a/src/ngraph/runtime/gpu/gpu_emitter.cpp
+++ b/src/ngraph/runtime/gpu/gpu_emitter.cpp
@@ -21,6 +21,7 @@
 #include <cuda_runtime.h>
 #include <cudnn.h>
 #include <iostream>
+#include <numeric>
 #include <nvrtc.h>
 #include <set>
 #include <string>


### PR DESCRIPTION
Fix compilation on Ubuntu 18. 
std::iota requires <numeric> header