### PR TITLE
cudnnFind/Get interoperability

### DIFF
--- a/src/ngraph/runtime/gpu/cudnn_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cudnn_emitter.cpp
@@ -946,7 +946,8 @@ size_t runtime::gpu::CUDNNEmitter::build_convolution(const std::string& dtype,
     int max_algos = 0;
     CUDNN_SAFE_CALL(cudnnGetConvolutionForwardAlgorithmMaxCount(*m_ctx->cudnn_handle, &max_algos));
     std::vector<cudnnConvolutionFwdAlgoPerf_t> results(max_algos);
-    auto cudnn_algo_search = find_algo ? cudnnFindConvolutionForwardAlgorithm : cudnnGetConvolutionForwardAlgorithm_v7;
+    auto cudnn_algo_search =
+        find_algo ? cudnnFindConvolutionForwardAlgorithm : cudnnGetConvolutionForwardAlgorithm_v7;
     CUDNN_SAFE_CALL((*cudnn_algo_search)(*m_ctx->cudnn_handle,
                                          tensor_desc_0,
                                          filter_desc,
@@ -956,7 +957,8 @@ size_t runtime::gpu::CUDNNEmitter::build_convolution(const std::string& dtype,
                                          &num_algos,
                                          results.data()));
     results.resize(num_algos);
-    auto conv_fwd_algo = select_cudnn_algo<cudnnConvolutionFwdAlgoPerf_t, cudnnConvolutionFwdAlgo_t>(results);
+    auto conv_fwd_algo =
+        select_cudnn_algo<cudnnConvolutionFwdAlgoPerf_t, cudnnConvolutionFwdAlgo_t>(results);
 
     void* alpha = m_host_parameters.allocate_by_datatype(data_type, 1.0);
     void* beta = m_host_parameters.allocate_by_datatype(data_type, 0);
@@ -1022,9 +1024,11 @@ size_t runtime::gpu::CUDNNEmitter::build_convolution_backward_data(
 
     int num_algos;
     int max_algos = 0;
-    CUDNN_SAFE_CALL(cudnnGetConvolutionBackwardDataAlgorithmMaxCount(*m_ctx->cudnn_handle, &max_algos));
+    CUDNN_SAFE_CALL(
+        cudnnGetConvolutionBackwardDataAlgorithmMaxCount(*m_ctx->cudnn_handle, &max_algos));
     std::vector<cudnnConvolutionBwdDataAlgoPerf_t> results(max_algos);
-    auto cudnn_algo_search = find_algo ? cudnnFindConvolutionBackwardDataAlgorithm : cudnnGetConvolutionBackwardDataAlgorithm_v7;
+    auto cudnn_algo_search = find_algo ? cudnnFindConvolutionBackwardDataAlgorithm
+                                       : cudnnGetConvolutionBackwardDataAlgorithm_v7;
     CUDNN_SAFE_CALL((*cudnn_algo_search)(*m_ctx->cudnn_handle,
                                          filter_desc,
                                          tensor_desc_0,
@@ -1034,7 +1038,9 @@ size_t runtime::gpu::CUDNNEmitter::build_convolution_backward_data(
                                          &num_algos,
                                          results.data()));
     results.resize(num_algos);
-    auto conv_bwd_data_algo = select_cudnn_algo<cudnnConvolutionBwdDataAlgoPerf_t, cudnnConvolutionBwdDataAlgo_t>(results);
+    auto conv_bwd_data_algo =
+        select_cudnn_algo<cudnnConvolutionBwdDataAlgoPerf_t, cudnnConvolutionBwdDataAlgo_t>(
+            results);
 
     void* alpha = m_host_parameters.allocate_by_datatype(data_type, 1.0);
     void* beta = m_host_parameters.allocate_by_datatype(data_type, 0);
@@ -1100,9 +1106,11 @@ size_t runtime::gpu::CUDNNEmitter::build_convolution_backward_filter(
 
     int num_algos;
     int max_algos = 0;
-    CUDNN_SAFE_CALL(cudnnGetConvolutionBackwardFilterAlgorithmMaxCount(*m_ctx->cudnn_handle, &max_algos));
+    CUDNN_SAFE_CALL(
+        cudnnGetConvolutionBackwardFilterAlgorithmMaxCount(*m_ctx->cudnn_handle, &max_algos));
     std::vector<cudnnConvolutionBwdFilterAlgoPerf_t> results(max_algos);
-    auto cudnn_algo_search = find_algo ? cudnnFindConvolutionBackwardFilterAlgorithm : cudnnGetConvolutionBackwardFilterAlgorithm_v7;
+    auto cudnn_algo_search = find_algo ? cudnnFindConvolutionBackwardFilterAlgorithm
+                                       : cudnnGetConvolutionBackwardFilterAlgorithm_v7;
     CUDNN_SAFE_CALL((*cudnn_algo_search)(*m_ctx->cudnn_handle,
                                          tensor_desc_0,
                                          tensor_desc_1,
@@ -1112,7 +1120,9 @@ size_t runtime::gpu::CUDNNEmitter::build_convolution_backward_filter(
                                          &num_algos,
                                          results.data()));
     results.resize(num_algos);
-    auto conv_bwd_filter_algo = select_cudnn_algo<cudnnConvolutionBwdFilterAlgoPerf_t, cudnnConvolutionBwdFilterAlgo_t>(results);
+    auto conv_bwd_filter_algo =
+        select_cudnn_algo<cudnnConvolutionBwdFilterAlgoPerf_t, cudnnConvolutionBwdFilterAlgo_t>(
+            results);
 
     size_t workspace_size_in_bytes = 0;
     CUDNN_SAFE_CALL(cudnnGetConvolutionBackwardFilterWorkspaceSize(*m_ctx->cudnn_handle,

--- a/src/ngraph/runtime/gpu/cudnn_emitter.cpp
+++ b/src/ngraph/runtime/gpu/cudnn_emitter.cpp
@@ -947,10 +947,12 @@ size_t runtime::gpu::CUDNNEmitter::build_convolution(const std::string& dtype,
     {
         int num_algos;
         int max_algos = 0;
-        CUDNN_SAFE_CALL(cudnnGetConvolutionForwardAlgorithmMaxCount(*m_ctx->cudnn_handle, &max_algos));
+        CUDNN_SAFE_CALL(
+            cudnnGetConvolutionForwardAlgorithmMaxCount(*m_ctx->cudnn_handle, &max_algos));
         std::vector<cudnnConvolutionFwdAlgoPerf_t> results(max_algos);
-        auto cudnn_algo_search =
-            find_algo == algo_search::EXPLICIT ? cudnnFindConvolutionForwardAlgorithm : cudnnGetConvolutionForwardAlgorithm_v7;
+        auto cudnn_algo_search = (find_algo == algo_search::EXPLICIT)
+                                     ? cudnnFindConvolutionForwardAlgorithm
+                                     : cudnnGetConvolutionForwardAlgorithm_v7;
         CUDNN_SAFE_CALL((*cudnn_algo_search)(*m_ctx->cudnn_handle,
                                              tensor_desc_0,
                                              filter_desc,
@@ -1034,8 +1036,9 @@ size_t runtime::gpu::CUDNNEmitter::build_convolution_backward_data(
         CUDNN_SAFE_CALL(
             cudnnGetConvolutionBackwardDataAlgorithmMaxCount(*m_ctx->cudnn_handle, &max_algos));
         std::vector<cudnnConvolutionBwdDataAlgoPerf_t> results(max_algos);
-        auto cudnn_algo_search = find_algo == algo_search::EXPLICIT ? cudnnFindConvolutionBackwardDataAlgorithm
-            : cudnnGetConvolutionBackwardDataAlgorithm_v7;
+        auto cudnn_algo_search = (find_algo == algo_search::EXPLICIT)
+                                     ? cudnnFindConvolutionBackwardDataAlgorithm
+                                     : cudnnGetConvolutionBackwardDataAlgorithm_v7;
         CUDNN_SAFE_CALL((*cudnn_algo_search)(*m_ctx->cudnn_handle,
                                              filter_desc,
                                              tensor_desc_0,
@@ -1120,8 +1123,9 @@ size_t runtime::gpu::CUDNNEmitter::build_convolution_backward_filter(
         CUDNN_SAFE_CALL(
             cudnnGetConvolutionBackwardFilterAlgorithmMaxCount(*m_ctx->cudnn_handle, &max_algos));
         std::vector<cudnnConvolutionBwdFilterAlgoPerf_t> results(max_algos);
-        auto cudnn_algo_search = find_algo == algo_search::EXPLICIT ? cudnnFindConvolutionBackwardFilterAlgorithm
-            : cudnnGetConvolutionBackwardFilterAlgorithm_v7;
+        auto cudnn_algo_search = (find_algo == algo_search::EXPLICIT)
+                                     ? cudnnFindConvolutionBackwardFilterAlgorithm
+                                     : cudnnGetConvolutionBackwardFilterAlgorithm_v7;
         CUDNN_SAFE_CALL((*cudnn_algo_search)(*m_ctx->cudnn_handle,
                                              tensor_desc_0,
                                              tensor_desc_1,

--- a/src/ngraph/runtime/gpu/cudnn_emitter.hpp
+++ b/src/ngraph/runtime/gpu/cudnn_emitter.hpp
@@ -70,7 +70,12 @@ namespace ngraph
                     Backward
                 };
 
-                enum class algo_search { HEURISTIC, EXPLICIT, NONE };
+                enum class algo_search
+                {
+                    HEURISTIC,
+                    EXPLICIT,
+                    NONE
+                };
 
                 size_t build_convolution(const std::string& dtype,
                                          const Shape& input_tensor_shape,
@@ -81,23 +86,25 @@ namespace ngraph
                                          const Shape& padding_below,
                                          const algo_search find_algo = algo_search::NONE);
 
-                size_t build_convolution_backward_data(const std::string& dtype,
-                                                       const Shape& input_filter_shape,
-                                                       const Shape& input_tensor_shape,
-                                                       const Shape& output_tensor_shape,
-                                                       const Strides& window_movement_strides,
-                                                       const Strides& window_dilation_strides,
-                                                       const Shape& padding_below,
-                                                       const algo_search find_algo = algo_search::NONE);
+                size_t build_convolution_backward_data(
+                    const std::string& dtype,
+                    const Shape& input_filter_shape,
+                    const Shape& input_tensor_shape,
+                    const Shape& output_tensor_shape,
+                    const Strides& window_movement_strides,
+                    const Strides& window_dilation_strides,
+                    const Shape& padding_below,
+                    const algo_search find_algo = algo_search::NONE);
 
-                size_t build_convolution_backward_filter(const std::string& dtype,
-                                                         const Shape& input_tensor_shape_0,
-                                                         const Shape& input_tensor_shape_1,
-                                                         const Shape& output_filter_shape,
-                                                         const Strides& window_movement_strides,
-                                                         const Strides& window_dilation_strides,
-                                                         const Shape& padding_below,
-                                                         const algo_search find_algo = algo_search::NONE);
+                size_t build_convolution_backward_filter(
+                    const std::string& dtype,
+                    const Shape& input_tensor_shape_0,
+                    const Shape& input_tensor_shape_1,
+                    const Shape& output_filter_shape,
+                    const Strides& window_movement_strides,
+                    const Strides& window_dilation_strides,
+                    const Shape& padding_below,
+                    const algo_search find_algo = algo_search::NONE);
 
                 size_t build_reduce_forward(const cudnnReduceTensorOp_t& reduce_op,
                                             const std::string& dtype,

--- a/src/ngraph/runtime/gpu/cudnn_emitter.hpp
+++ b/src/ngraph/runtime/gpu/cudnn_emitter.hpp
@@ -160,13 +160,16 @@ namespace ngraph
                                                      cudnnDataType_t data_type);
 
                 template <typename PERF_TYPE, typename ALGO_TYPE>
-                ALGO_TYPE select_cudnn_algo(const std::vector<PERF_TYPE>& perf_results,
-                                            size_t workspace_byte = std::numeric_limits<size_t>::max()) {
+                ALGO_TYPE
+                    select_cudnn_algo(const std::vector<PERF_TYPE>& perf_results,
+                                      size_t workspace_byte = std::numeric_limits<size_t>::max())
+                {
                     // Determine the fastest acceptable algo regardless of mathType.
                     for (auto i = 0; i != perf_results.size(); ++i)
                     {
                         auto const& result = perf_results[i];
-                        if (result.status == CUDNN_STATUS_SUCCESS &&  result.memory <= workspace_byte)
+                        if (result.status == CUDNN_STATUS_SUCCESS &&
+                            result.memory <= workspace_byte)
                         {
                             return result.algo;
                         }

--- a/src/ngraph/runtime/gpu/cudnn_emitter.hpp
+++ b/src/ngraph/runtime/gpu/cudnn_emitter.hpp
@@ -70,6 +70,8 @@ namespace ngraph
                     Backward
                 };
 
+                enum class algo_search { HEURISTIC, EXPLICIT, NONE };
+
                 size_t build_convolution(const std::string& dtype,
                                          const Shape& input_tensor_shape,
                                          const Shape& input_filter_shape,
@@ -77,7 +79,7 @@ namespace ngraph
                                          const Strides& window_movement_strides,
                                          const Strides& window_dilation_strides,
                                          const Shape& padding_below,
-                                         const bool find_algo = false);
+                                         const algo_search find_algo = algo_search::NONE);
 
                 size_t build_convolution_backward_data(const std::string& dtype,
                                                        const Shape& input_filter_shape,
@@ -86,7 +88,7 @@ namespace ngraph
                                                        const Strides& window_movement_strides,
                                                        const Strides& window_dilation_strides,
                                                        const Shape& padding_below,
-                                                       const bool find_algo = false);
+                                                       const algo_search find_algo = algo_search::NONE);
 
                 size_t build_convolution_backward_filter(const std::string& dtype,
                                                          const Shape& input_tensor_shape_0,
@@ -95,7 +97,7 @@ namespace ngraph
                                                          const Strides& window_movement_strides,
                                                          const Strides& window_dilation_strides,
                                                          const Shape& padding_below,
-                                                         const bool find_algo = false);
+                                                         const algo_search find_algo = algo_search::NONE);
 
                 size_t build_reduce_forward(const cudnnReduceTensorOp_t& reduce_op,
                                             const std::string& dtype,

--- a/src/ngraph/runtime/gpu/cudnn_emitter.hpp
+++ b/src/ngraph/runtime/gpu/cudnn_emitter.hpp
@@ -159,6 +159,21 @@ namespace ngraph
                                                      cudnnConvolutionMode_t mode,
                                                      cudnnDataType_t data_type);
 
+                template <typename PERF_TYPE, typename ALGO_TYPE>
+                ALGO_TYPE select_cudnn_algo(const std::vector<PERF_TYPE>& perf_results,
+                                            size_t workspace_byte = std::numeric_limits<size_t>::max()) {
+                    // Determine the fastest acceptable algo regardless of mathType.
+                    for (auto i = 0; i != perf_results.size(); ++i)
+                    {
+                        auto const& result = perf_results[i];
+                        if (result.status == CUDNN_STATUS_SUCCESS &&  result.memory <= workspace_byte)
+                        {
+                            return result.algo;
+                        }
+                    }
+                    return perf_results.at(0).algo;
+                }
+
                 CUDNNDescriptors m_descriptors;
                 CUDNNHostParameters m_host_parameters;
 


### PR DESCRIPTION
Update to algo. search so that it is no longer binary on/off. Now it is either off, a heuristic search (cudnnGet*) or an explicit search (cudnnFind*). cudnnFind gives ~10-20% speed up when used on resnet50 (bs128) relative to using cudnnGet. The extra compile time is minimal but for now I leave the explicit search turned off and default to the heuristic search. Open to suggestions.
