### PR TITLE
address klocwork issues 14714, 17248, and 18661

### DIFF
--- a/doc/examples/update/update.cpp
+++ b/doc/examples/update/update.cpp
@@ -46,4 +46,6 @@ int main()
         std::cout << std::get<0>(r);
     }
     std::cout << std::endl;
+
+    return 0;
 }

--- a/src/ngraph/placement.cpp
+++ b/src/ngraph/placement.cpp
@@ -36,6 +36,7 @@ std::string ngraph::placement_to_string(Placement placement)
     case Placement::GPU: return "GPU";
     case Placement::NNP: return "NNP";
     }
+    throw runtime_error("unhandled placement type");
 }
 
 static Node* take_independent_node_with_placement_priority(

--- a/src/ngraph/runtime/cpu/cpu_external_function.cpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.cpp
@@ -1355,6 +1355,7 @@ void runtime::cpu::CPU_ExternalFunction::build()
             case CPUTensorRole::CONSTANT: return string("CPUTensorRole::CONSTANT");
             case CPUTensorRole::OUTPUT: return string("CPUTensorRole::OUTPUT");
             }
+            throw runtime_error("unhandled CPU tensor role");
         };
 
         //dump the tensor roles to debug manifest


### PR DESCRIPTION
Issue complained about functions that expect to return a value but fail to do so. If switch statements handle all cases then it is OK, but if someone adds a case to the enum and does not add to switch then very bad things will happen. throw deals with this case.