### PR TITLE
optimize operator==

### DIFF
--- a/src/ngraph/coordinate_transform.cpp
+++ b/src/ngraph/coordinate_transform.cpp
@@ -456,21 +456,21 @@ bool CoordinateTransform::Iterator::operator!=(const Iterator& it)
 
 bool CoordinateTransform::Iterator::operator==(const Iterator& it)
 {
-    if (m_target_shape != it.m_target_shape)
+    if (it.m_oob)
+    {
+        // Out-of-bounds iterators are always equal; in other words, an iterator is always equal to
+        // end() even if the internally stored coordinates are different.
+
+        // If one iterator is out of bounds and the other is not, they are unequal even if their
+        // target coordinates happen to match.
+        return m_oob;
+    }
+    else if (m_oob)
     {
         return false;
     }
 
-    // Out-of-bounds iterators are always equal; in other words, an iterator is always equal to
-    // end() even if the internally stored coordinates are different.
-    if (m_oob && it.m_oob)
-    {
-        return true;
-    }
-
-    // If one iterator is out of bounds and the other is not, they are unequal even if their target
-    // coordinates happen to match.
-    if (m_oob != it.m_oob)
+    if (m_target_shape != it.m_target_shape)
     {
         return false;
     }


### PR DESCRIPTION
Check the out of bounds condition first since it is a quick check. The common case is one compare only, if the other object's oob is true then return our oob.

running gtest `benchmark.coordinate`
before 5,769ms
after 3,685ms