### PR TITLE
[ONNX] Add support for Operator Sets

### DIFF
--- a/src/ngraph/frontend/onnx_import/CMakeLists.txt
+++ b/src/ngraph/frontend/onnx_import/CMakeLists.txt
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ******************************************************************************
 
+set(ONNX_OPSET_VERSION 9 CACHE INTERNAL "Supported version of ONNX operator set")
+
 add_library(onnx_import_interface OBJECT
         onnx.cpp
         onnx.hpp)
@@ -27,6 +29,7 @@ add_library(onnx_import STATIC
         core/model.hpp
         core/node.cpp
         core/node.hpp
+        core/operator_set.hpp
         core/tensor.hpp
         core/value_info.hpp
         exceptions.hpp
@@ -145,9 +148,13 @@ target_include_directories(onnx_import PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${NGR
     SYSTEM PRIVATE ${ONNX_INCLUDE_DIR} ${ONNX_PROTO_INCLUDE_DIR} ${Protobuf_INCLUDE_DIR})
 target_link_libraries(onnx_import PRIVATE ${Protobuf_LIBRARIES} ${ONNX_PROTO_LIBRARY})
 
+target_compile_definitions(onnx_import PRIVATE ONNX_OPSET_VERSION=${ONNX_OPSET_VERSION})
+
 set_property(TARGET onnx_import_interface PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(onnx_import_interface PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${NGRAPH_INCLUDE_PATH}
     SYSTEM PRIVATE ${ONNX_INCLUDE_DIR} ${ONNX_PROTO_INCLUDE_DIR} ${Protobuf_INCLUDE_DIR})
+
+target_compile_definitions(onnx_import_interface PRIVATE ONNX_OPSET_VERSION=${ONNX_OPSET_VERSION})
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
     target_compile_options(onnx_import PRIVATE -Wno-undef -Wno-reserved-id-macro -Wno-switch-enum

--- a/src/ngraph/frontend/onnx_import/CMakeLists.txt
+++ b/src/ngraph/frontend/onnx_import/CMakeLists.txt
@@ -18,8 +18,6 @@ add_library(onnx_import_interface OBJECT
         onnx.cpp
         onnx.hpp)
 
-target_include_directories(onnx_import_interface PRIVATE ${ONNX_PROTO_INCLUDE_DIR})
-
 add_library(onnx_import STATIC
         core/attribute.cpp
         core/attribute.hpp
@@ -143,12 +141,13 @@ if (NOT NGRAPH_USE_SYSTEM_PROTOBUF)
 endif()
 
 set_property(TARGET onnx_import PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(onnx_import PUBLIC ${CMAKE_CURRENT_BINARY_DIR} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${NGRAPH_INCLUDE_PATH} ${ONNX_PROTO_INCLUDE_DIR} ${Protobuf_INCLUDE_DIR})
+target_include_directories(onnx_import PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${NGRAPH_INCLUDE_PATH}
+    SYSTEM PRIVATE ${ONNX_INCLUDE_DIR} ${ONNX_PROTO_INCLUDE_DIR} ${Protobuf_INCLUDE_DIR})
 target_link_libraries(onnx_import PRIVATE ${Protobuf_LIBRARIES} ${ONNX_PROTO_LIBRARY})
 
 set_property(TARGET onnx_import_interface PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(onnx_import_interface PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-    ${NGRAPH_INCLUDE_PATH} ${Protobuf_INCLUDE_DIR})
+target_include_directories(onnx_import_interface PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${NGRAPH_INCLUDE_PATH}
+    SYSTEM PRIVATE ${ONNX_INCLUDE_DIR} ${ONNX_PROTO_INCLUDE_DIR} ${Protobuf_INCLUDE_DIR})
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
     target_compile_options(onnx_import PRIVATE -Wno-undef -Wno-reserved-id-macro -Wno-switch-enum

--- a/src/ngraph/frontend/onnx_import/core/attribute.cpp
+++ b/src/ngraph/frontend/onnx_import/core/attribute.cpp
@@ -16,17 +16,27 @@
 
 #include "attribute.hpp"
 #include "graph.hpp"
+#include "operator_set.hpp"
 
 namespace ngraph
 {
     namespace onnx_import
     {
-        std::vector<Graph> Attribute::get_graph_array() const
+        std::vector<Graph> Attribute::get_graph_array(const OperatorSet& opset) const
         {
-            return {std::begin(m_attribute_proto->graphs()), std::end(m_attribute_proto->graphs())};
+            std::vector<Graph> result;
+            for (const auto& graph : m_attribute_proto->graphs())
+            {
+                result.emplace_back(graph, opset);
+            }
+            return result;
         }
 
-        Graph Attribute::get_graph() const { return Graph{m_attribute_proto->g()}; }
+        Graph Attribute::get_graph(const OperatorSet& opset) const
+        {
+            return Graph{m_attribute_proto->g(), opset};
+        }
+
     } // namespace onnx_import
 
 } // namespace ngraph

--- a/src/ngraph/frontend/onnx_import/core/attribute.hpp
+++ b/src/ngraph/frontend/onnx_import/core/attribute.hpp
@@ -19,6 +19,8 @@
 #include <onnx-ml.pb.h>
 
 #include "ngraph/except.hpp"
+
+#include "operator_set.hpp"
 #include "tensor.hpp"
 
 #define likely(__x) __builtin_expect(!!(__x), 1)
@@ -273,7 +275,7 @@ namespace ngraph
             float get_float() const { return m_attribute_proto->f(); }
             int64_t get_integer() const { return m_attribute_proto->i(); }
             const std::string& get_string() const { return m_attribute_proto->s(); }
-            Graph get_graph() const;
+            Graph get_graph(const OperatorSet& opset) const;
 
             std::vector<Tensor> get_tensor_array() const
             {
@@ -298,7 +300,7 @@ namespace ngraph
                         std::end(m_attribute_proto->strings())};
             }
 
-            std::vector<Graph> get_graph_array() const;
+            std::vector<Graph> get_graph_array(const OperatorSet&) const;
 
             /* explicit */ operator onnx::AttributeProto_AttributeType() const
             {

--- a/src/ngraph/frontend/onnx_import/core/graph.cpp
+++ b/src/ngraph/frontend/onnx_import/core/graph.cpp
@@ -21,8 +21,9 @@ namespace ngraph
 {
     namespace onnx_import
     {
-        Graph::Graph(const onnx::GraphProto& graph_proto)
+        Graph::Graph(const onnx::GraphProto& graph_proto, const OperatorSet& opset)
             : m_graph_proto{&graph_proto}
+            , m_opset{&opset}
         {
             for (const auto& tensor : m_graph_proto->initializer())
             {

--- a/src/ngraph/frontend/onnx_import/core/graph.hpp
+++ b/src/ngraph/frontend/onnx_import/core/graph.hpp
@@ -23,6 +23,7 @@
 
 #include "ngraph/op/parameter_vector.hpp"
 
+#include "operator_set.hpp"
 #include "value_info.hpp"
 
 namespace ngraph
@@ -32,7 +33,7 @@ namespace ngraph
         class Graph
         {
         public:
-            explicit Graph(const onnx::GraphProto& proto);
+            explicit Graph(const onnx::GraphProto& proto, const OperatorSet& opset);
 
             const std::vector<Node>& get_nodes() const { return m_nodes; }
             const std::vector<ValueInfo>& get_inputs() const { return m_inputs; }
@@ -44,6 +45,11 @@ namespace ngraph
             }
 
             const std::string& get_name() const { return m_graph_proto->name(); }
+            NodeVector make_ng_nodes(const Node& node) const
+            {
+                return m_opset->at(node.op_type())(node);
+            }
+
         private:
             const onnx::GraphProto* m_graph_proto;
             std::vector<Node> m_nodes;
@@ -52,6 +58,7 @@ namespace ngraph
             op::ParameterVector m_parameters;
             std::map<std::string, std::shared_ptr<ngraph::Node>> m_ng_node_cache;
             std::map<std::string, Tensor> m_initializers;
+            const OperatorSet* m_opset;
         };
 
         inline std::ostream& operator<<(std::ostream& outs, const Graph& graph)

--- a/src/ngraph/frontend/onnx_import/core/model.hpp
+++ b/src/ngraph/frontend/onnx_import/core/model.hpp
@@ -44,10 +44,10 @@ namespace ngraph
                 return m_model_proto->producer_version();
             }
 
+            std::int64_t get_opset_version() const { return m_opset_version; }
         private:
             const onnx::ModelProto* m_model_proto;
-
-            void assert_all_op_types_supported();
+            std::int64_t m_opset_version{ONNX_OPSET_VERSION};
         };
 
         inline std::ostream& operator<<(std::ostream& outs, const Model& model)

--- a/src/ngraph/frontend/onnx_import/core/node.cpp
+++ b/src/ngraph/frontend/onnx_import/core/node.cpp
@@ -16,13 +16,12 @@
 
 #include "node.hpp"
 #include "graph.hpp"
-#include "ops_bridge.hpp"
 
 namespace ngraph
 {
     namespace onnx_import
     {
-        NodeVector Node::get_ng_nodes() const { return ops_bridge::make_ng_nodes(*this); }
+        NodeVector Node::get_ng_nodes() const { return m_graph->make_ng_nodes(*this); }
         NodeVector Node::get_ng_inputs() const
         {
             NodeVector result;

--- a/src/ngraph/frontend/onnx_import/core/node.hpp
+++ b/src/ngraph/frontend/onnx_import/core/node.hpp
@@ -70,6 +70,7 @@ namespace ngraph
             NodeVector get_ng_nodes() const;
             NodeVector get_ng_inputs() const;
 
+            const std::string& domain() const { return m_node_proto->domain(); }
             const std::string& op_type() const { return m_node_proto->op_type(); }
             const std::string& get_name() const { return m_node_proto->name(); }
             /// @brief Describe the ONNX Node to make debugging graphs easier

--- a/src/ngraph/frontend/onnx_import/core/operator_set.hpp
+++ b/src/ngraph/frontend/onnx_import/core/operator_set.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <functional>
+#include <string>
 #include <unordered_map>
 
 #include "ngraph/node_vector.hpp"

--- a/src/ngraph/frontend/onnx_import/core/operator_set.hpp
+++ b/src/ngraph/frontend/onnx_import/core/operator_set.hpp
@@ -14,27 +14,22 @@
 // limitations under the License.
 //*****************************************************************************
 
-#include <onnx-ml.pb.h>
+#pragma once
 
-#include "model.hpp"
+#include <functional>
+#include <unordered_map>
+
+#include "ngraph/node_vector.hpp"
 
 namespace ngraph
 {
     namespace onnx_import
     {
-        Model::Model(const onnx::ModelProto& model_proto)
-            : m_model_proto{&model_proto}
-        {
-            for (const auto& id : m_model_proto->opset_import())
-            {
-                // onnx.proto(.3): the empty string ("") or absence of this field implies
-                // the operator set that is defined as part of the ONNX specification.
-                if (id.domain().empty())
-                {
-                    m_opset_version = id.version();
-                }
-            }
-        }
+        // Forward declaration
+        class Node;
+
+        using Operator = std::function<NodeVector(const Node&)>;
+        using OperatorSet = std::unordered_map<std::string, std::reference_wrapper<const Operator>>;
 
     } // namespace onnx_import
 

--- a/src/ngraph/frontend/onnx_import/onnx.cpp
+++ b/src/ngraph/frontend/onnx_import/onnx.cpp
@@ -21,7 +21,9 @@
 #include "core/graph.hpp"
 #include "core/model.hpp"
 #include "core/node.hpp"
+
 #include "onnx.hpp"
+#include "ops_bridge.hpp"
 
 namespace ngraph
 {
@@ -59,7 +61,8 @@ namespace ngraph
             }
             std::vector<std::shared_ptr<Function>> output_functions;
             Model model{model_proto};
-            Graph graph{model_proto.graph()};
+            Graph graph{model_proto.graph(),
+                        ops_bridge::get_operator_set(model.get_opset_version())};
             for (const auto& output : graph.get_outputs())
             {
                 output_functions.emplace_back(std::make_shared<Function>(

--- a/src/ngraph/frontend/onnx_import/op/average_pool.hpp
+++ b/src/ngraph/frontend/onnx_import/op/average_pool.hpp
@@ -28,14 +28,12 @@ namespace ngraph
         {
             namespace set_1
             {
-                /**
-                 * @brief Convert ONNX AveragePool operation to an nGraph node.
-                 *
-                 * @param node   The ONNX node object representing this operation.
-                 *
-                 * @return The vector containing Ngraph nodes producing output of ONNX AveragePool
-                 *         operation.
-                 */
+                /// \brief Convert ONNX AveragePool operation to an nGraph node.
+                ///
+                /// \param node   The ONNX node object representing this operation.
+                ///
+                /// \return The vector containing Ngraph nodes producing output of ONNX AveragePool
+                ///        operation.
                 NodeVector average_pool(const Node& node);
 
             } // namespace set_1

--- a/src/ngraph/frontend/onnx_import/ops_bridge.cpp
+++ b/src/ngraph/frontend/onnx_import/ops_bridge.cpp
@@ -14,9 +14,11 @@
 // limitations under the License.
 //*****************************************************************************
 
-#include <algorithm>
 #include <functional>
+#include <iterator>
+#include <map>
 #include <string>
+#include <unordered_map>
 
 #include "core/attribute.hpp"
 #include "op/abs.hpp"
@@ -122,8 +124,8 @@ namespace ngraph
                 }
 
             private:
-                std::map<std::string,
-                         std::map<std::int64_t, std::function<NodeVector(const Node&)>>>
+                std::unordered_map<std::string,
+                                   std::map<std::int64_t, std::function<NodeVector(const Node&)>>>
                     m_map;
 
                 static const OperatorsBridge& instance()

--- a/src/ngraph/frontend/onnx_import/ops_bridge.cpp
+++ b/src/ngraph/frontend/onnx_import/ops_bridge.cpp
@@ -89,10 +89,10 @@ namespace ngraph
         {
             namespace error
             {
-                struct unknown_operation : ngraph_error
+                struct UnknownOperator : ngraph_error
                 {
-                    explicit unknown_operation(const std::string& op_type)
-                        : ngraph_error{"unknown operation: " + op_type}
+                    explicit UnknownOperator(const std::string& op_type)
+                        : ngraph_error{"unknown operator: \"" + op_type + "\""}
                     {
                     }
                 };
@@ -208,7 +208,7 @@ namespace ngraph
                     auto it = m_map.find(node.op_type());
                     if (it == m_map.end())
                     {
-                        throw detail::error::unknown_operation{node.op_type()};
+                        throw detail::error::UnknownOperator{node.op_type()};
                     }
 
                     std::function<NodeVector(const Node&)> factory{it->second};

--- a/src/ngraph/frontend/onnx_import/ops_bridge.cpp
+++ b/src/ngraph/frontend/onnx_import/ops_bridge.cpp
@@ -97,6 +97,15 @@ namespace ngraph
                     }
                 };
 
+                struct UnsupportedVersion : ngraph_error
+                {
+                    explicit UnsupportedVersion(std::int64_t version)
+                        : ngraph_error{"unsupported operator set version: " +
+                                       std::to_string(version)}
+                    {
+                    }
+                };
+
             } // namespace error
 
             class OperatorsBridge
@@ -107,14 +116,15 @@ namespace ngraph
                 OperatorsBridge(OperatorsBridge&&) = delete;
                 OperatorsBridge& operator=(OperatorsBridge&&) = delete;
 
-                static NodeVector make_ng_nodes(const Node& node) { return instance()(node); }
-                static bool is_op_type_supported(const std::string& op_type)
+                static const OperatorSet& get_operator_set(std::int64_t version)
                 {
-                    return instance().is_op_type_supported_(op_type);
+                    return instance().get_operator_set_version(version);
                 }
 
             private:
-                std::map<std::string, std::function<NodeVector(const Node&)>> m_map;
+                std::map<std::string,
+                         std::map<std::int64_t, std::function<NodeVector(const Node&)>>>
+                    m_map;
 
                 static const OperatorsBridge& instance()
                 {
@@ -122,8 +132,149 @@ namespace ngraph
                     return instance;
                 }
 
+                const Operator& get_operator(const std::string& name, std::int64_t version) const
+                {
+                    auto op = m_map.find(name);
+                    if (op == std::end(m_map))
+                    {
+                        throw error::UnknownOperator{name};
+                    }
+                    auto it = op->second.find(version);
+                    if (it == std::end(op->second))
+                    {
+                        throw error::UnsupportedVersion{version};
+                    }
+                    return it->second;
+                }
+
+                const OperatorSet& get_operator_set_version_1() const
+                {
+                    static OperatorSet operator_set;
+                    if (operator_set.empty())
+                    {
+                        for (const auto& op : m_map)
+                        {
+                            for (const auto& it : op.second)
+                            {
+                                if (it.first == 1)
+                                {
+                                    operator_set.emplace(op.first, it.second);
+                                }
+                            }
+                        }
+                    }
+                    return operator_set;
+                }
+
+                const OperatorSet& get_operator_set_version_2() const
+                {
+                    static OperatorSet operator_set;
+                    if (operator_set.empty())
+                    {
+                        operator_set = get_operator_set_version_1();
+                    }
+                    return operator_set;
+                }
+
+                const OperatorSet& get_operator_set_version_3() const
+                {
+                    static OperatorSet operator_set;
+                    if (operator_set.empty())
+                    {
+                        operator_set = get_operator_set_version_2();
+                    }
+                    return operator_set;
+                }
+
+                const OperatorSet& get_operator_set_version_4() const
+                {
+                    static OperatorSet operator_set;
+                    if (operator_set.empty())
+                    {
+                        operator_set = get_operator_set_version_3();
+                    }
+                    return operator_set;
+                }
+
+                const OperatorSet& get_operator_set_version_5() const
+                {
+                    static OperatorSet operator_set;
+                    if (operator_set.empty())
+                    {
+                        operator_set = get_operator_set_version_4();
+                    }
+                    return operator_set;
+                }
+
+                const OperatorSet& get_operator_set_version_6() const
+                {
+                    static OperatorSet operator_set;
+                    if (operator_set.empty())
+                    {
+                        operator_set = get_operator_set_version_5();
+                    }
+                    return operator_set;
+                }
+
+                const OperatorSet& get_operator_set_version_7() const
+                {
+                    static OperatorSet operator_set;
+                    if (operator_set.empty())
+                    {
+                        operator_set = get_operator_set_version_6();
+                    }
+                    return operator_set;
+                }
+
+                const OperatorSet& get_operator_set_version_8() const
+                {
+                    static OperatorSet operator_set;
+                    if (operator_set.empty())
+                    {
+                        operator_set = get_operator_set_version_7();
+                    }
+                    return operator_set;
+                }
+
+                const OperatorSet& get_operator_set_version_9() const
+                {
+                    static OperatorSet operator_set;
+                    if (operator_set.empty())
+                    {
+                        operator_set = get_operator_set_version_8();
+                    }
+                    return operator_set;
+                }
+
+#define OPERATOR_SET_NAME(version_) get_operator_set_version_##version_()
+
+#define GET_OPERATOR_SET(version_)                                                                 \
+    case version_:                                                                                 \
+        return OPERATOR_SET_NAME(version_)
+
+#define OPERATOR_SET_NAME_HELPER(version_) OPERATOR_SET_NAME(version_)
+
+#define DEFAULT_OPERATOR_SET() return OPERATOR_SET_NAME_HELPER(ONNX_OPSET_VERSION)
+
+                const OperatorSet& get_operator_set_version(std::int64_t version) const
+                {
+                    switch (version)
+                    {
+                        GET_OPERATOR_SET(1);
+                        GET_OPERATOR_SET(2);
+                        GET_OPERATOR_SET(3);
+                        GET_OPERATOR_SET(4);
+                        GET_OPERATOR_SET(5);
+                        GET_OPERATOR_SET(6);
+                        GET_OPERATOR_SET(7);
+                        GET_OPERATOR_SET(8);
+                        GET_OPERATOR_SET(9);
+                    default: DEFAULT_OPERATOR_SET();
+                    }
+                }
+
 #define REGISTER_OPERATOR(name_, version_, fn_)                                                    \
-    m_map.emplace(name_, std::bind(op::set_##version_::fn_, std::placeholders::_1))
+    m_map[name_].emplace(version_, std::bind(op::set_##version_::fn_, std::placeholders::_1))
 
                 OperatorsBridge()
                 {
@@ -198,38 +349,15 @@ namespace ngraph
                     REGISTER_OPERATOR("Unsqueeze", 1, unsqueeze);
                     REGISTER_OPERATOR("Xor", 1, logical_xor);
                 }
-
-                NodeVector operator()(const Node& node) const
-                {
-                    auto it = m_map.find(node.op_type());
-                    if (it == m_map.end())
-                    {
-                        throw detail::error::UnknownOperator{node.op_type()};
-                    }
-
-                    std::function<NodeVector(const Node&)> factory{it->second};
-                    return factory(node);
-                }
-
-                bool is_op_type_supported_(const std::string& op_type) const
-                {
-                    auto it = m_map.find(op_type);
-                    return !(it == m_map.end());
-                }
             };
 
         } // namespace detail
 
         namespace ops_bridge
         {
-            NodeVector make_ng_nodes(const Node& node)
+            const OperatorSet& get_operator_set(std::int64_t version)
             {
-                return detail::OperatorsBridge::make_ng_nodes(node);
-            }
-
-            bool is_op_type_supported(const std::string& op_type)
-            {
-                return detail::OperatorsBridge::is_op_type_supported(op_type);
+                return detail::OperatorsBridge::get_operator_set(version);
             }
 
         } // namespace ops_bridge

--- a/src/ngraph/frontend/onnx_import/ops_bridge.cpp
+++ b/src/ngraph/frontend/onnx_import/ops_bridge.cpp
@@ -99,37 +99,33 @@ namespace ngraph
 
             } // namespace error
 
-            class ops_bridge
+            class OperatorsBridge
             {
             public:
-                ops_bridge(const ops_bridge&) = delete;
-                ops_bridge& operator=(const ops_bridge&) = delete;
-                ops_bridge(ops_bridge&&) = delete;
-                ops_bridge& operator=(ops_bridge&&) = delete;
+                OperatorsBridge(const OperatorsBridge&) = delete;
+                OperatorsBridge& operator=(const OperatorsBridge&) = delete;
+                OperatorsBridge(OperatorsBridge&&) = delete;
+                OperatorsBridge& operator=(OperatorsBridge&&) = delete;
 
-                static NodeVector make_ng_nodes(const Node& node)
-                {
-                    return ops_bridge::get()(node);
-                }
-
+                static NodeVector make_ng_nodes(const Node& node) { return instance()(node); }
                 static bool is_op_type_supported(const std::string& op_type)
                 {
-                    return ops_bridge::get().is_op_type_supported_(op_type);
+                    return instance().is_op_type_supported_(op_type);
                 }
 
             private:
                 std::map<std::string, std::function<NodeVector(const Node&)>> m_map;
 
-                static const ops_bridge& get()
+                static const OperatorsBridge& instance()
                 {
-                    static ops_bridge instance;
+                    static OperatorsBridge instance;
                     return instance;
                 }
 
 #define REGISTER_OPERATOR(name_, version_, fn_)                                                    \
     m_map.emplace(name_, std::bind(op::set_##version_::fn_, std::placeholders::_1))
 
-                ops_bridge()
+                OperatorsBridge()
                 {
                     REGISTER_OPERATOR("Abs", 1, abs);
                     REGISTER_OPERATOR("Add", 1, add);
@@ -228,12 +224,12 @@ namespace ngraph
         {
             NodeVector make_ng_nodes(const Node& node)
             {
-                return detail::ops_bridge::make_ng_nodes(node);
+                return detail::OperatorsBridge::make_ng_nodes(node);
             }
 
             bool is_op_type_supported(const std::string& op_type)
             {
-                return detail::ops_bridge::is_op_type_supported(op_type);
+                return detail::OperatorsBridge::is_op_type_supported(op_type);
             }
 
         } // namespace ops_bridge

--- a/src/ngraph/frontend/onnx_import/ops_bridge.hpp
+++ b/src/ngraph/frontend/onnx_import/ops_bridge.hpp
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include "core/node.hpp"
-#include "ngraph/node_vector.hpp"
+#include <cstdint>
+
+#include "core/operator_set.hpp"
 
 namespace ngraph
 {
@@ -25,9 +26,9 @@ namespace ngraph
     {
         namespace ops_bridge
         {
-            NodeVector make_ng_nodes(const onnx_import::Node&);
-            bool is_op_type_supported(const std::string& op_type);
-        }
+            const OperatorSet& get_operator_set(std::int64_t version);
+
+        } // namespace ops_bridge
 
     } // namespace onnx_import
 


### PR DESCRIPTION
This is the initial version of the operators set. The member functions `OperatorsBridge::get_operator_set_X` will be used in later PRs to add ONNX operators specific to a version of operator set.