### PR TITLE
[ONNX]: fix compilation of ONNX Python via setup.py

### DIFF
--- a/.ci/onnx/jenkins/prepare_environment.sh
+++ b/.ci/onnx/jenkins/prepare_environment.sh
@@ -68,7 +68,7 @@ function build_ngraph() {
     make install || return 1
     cd "${ngraph_directory}/ngraph/python"
     if [ ! -d ./pybind11 ]; then
-        git clone --recursive -b allow-nonconstructible-holders https://github.com/jagerman/pybind11.git
+        git clone --recursive https://github.com/pybind/pybind11.git
     fi
     export PYBIND_HEADERS_PATH="${ngraph_directory}/ngraph/python/pybind11"
     export NGRAPH_CPP_BUILD_PATH="${ngraph_directory}/ngraph_dist"

--- a/.ci/travis/ubuntu/Dockerfile
+++ b/.ci/travis/ubuntu/Dockerfile
@@ -39,7 +39,7 @@ RUN make install
 
 # Prepare nGraph Python API
 WORKDIR /root/ngraph/python
-RUN git clone --recursive -b allow-nonconstructible-holders https://github.com/jagerman/pybind11.git
+RUN git clone --recursive https://github.com/pybind/pybind11.git
 ENV NGRAPH_CPP_BUILD_PATH /root/ngraph_dist
 ENV LD_LIBRARY_PATH /root/ngraph_dist/lib
 ENV PYBIND_HEADERS_PATH /root/ngraph/python/pybind11

--- a/src/ngraph/node.hpp
+++ b/src/ngraph/node.hpp
@@ -103,10 +103,10 @@ namespace ngraph
         void validate_and_infer_elementwise_logical();
 
         Node(const std::string& node_type, const NodeVector& arguments, size_t output_size = 1);
-        virtual ~Node();
 
         virtual void generate_adjoints(autodiff::Adjoints& adjoints, const NodeVector& deltas) {}
     public:
+        virtual ~Node();
         void revalidate_and_infer_types() { validate_and_infer_types(); }
         // Called after transition
         void delayed_validate_and_infer_types();


### PR DESCRIPTION
Unable to build the python wrapper for `ngraph::Node` due to compilation error:
```
/.../ngraph/python/pyngraph/node.cpp:31:75:   required from here
/usr/include/c++/7/bits/shared_ptr_base.h:588:8: error: ‘virtual ngraph::Node::~Node()’ is protected within this context
        delete __p;
        ^~~~~~
In file included from /.../ngraph/python/pyngraph/node.cpp:20:0:
/.../ngraph/node.hpp:105:17: note: declared protected here
         virtual ~Node();
```
The line causing the problem is:
https://github.com/NervanaSystems/ngraph/blob/b4338a52d48377de30e267dfa9c43eeed660c957/python/pyngraph/node.cpp#L31

Signed-off-by: Artur Wojcik <artur.wojcik@intel.com>