### PR TITLE
Add some fixes to speed up RN50 training

### DIFF
--- a/src/ngraph/autodiff/adjoints.cpp
+++ b/src/ngraph/autodiff/adjoints.cpp
@@ -45,9 +45,17 @@ std::shared_ptr<Node> make_zero(const std::shared_ptr<Node>& node)
 NodeVector make_zeros(std::shared_ptr<Node> x)
 {
     NodeVector zeros;
-    for (size_t i = 0; i < x->get_outputs().size(); ++i)
+    if (x->get_outputs().size() > 1)
     {
-        zeros.push_back(make_zero(get_output_element(x, i)));
+        auto goes = op::get_output_elements(x);
+        for (size_t i = 0; i < goes.size(); ++i)
+        {
+            zeros.push_back(make_zero(goes.at(i)));
+        }
+    }
+    else
+    {
+        zeros.push_back(make_zero(x));
     }
     return zeros;
 }

--- a/src/ngraph/op/relu.cpp
+++ b/src/ngraph/op/relu.cpp
@@ -48,6 +48,6 @@ void op::Relu::generate_adjoints(autodiff::Adjoints& adjoints, const NodeVector&
 {
     auto delta = deltas.at(0);
 
-    auto backprop = make_shared<op::ReluBackprop>(get_argument(0), delta);
+    auto backprop = make_shared<op::ReluBackprop>(shared_from_this(), delta);
     adjoints.add_delta(get_argument(0), backprop);
 }


### PR DESCRIPTION
make_zeros was adding an extra OutputElement to Batchnorm that broke fprop_cache performance a little, and the Relu change enables BN+relu and Conv+relu fusion for training