### PR TITLE
Add missing include to benchmark.cpp

### DIFF
--- a/src/tools/nbench/benchmark.cpp
+++ b/src/tools/nbench/benchmark.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 
 #include <random>
+#include <xmmintrin.h>
 
 #include "benchmark.hpp"
 #include "ngraph/file_util.hpp"


### PR DESCRIPTION
Fixes an error when building on macOS (with CPU backend disabled, but not sure if that makes a difference):

```
/Users/amprocte/Work/ngraph/src/tools/nbench/benchmark.cpp:36:29: error: use of undeclared identifier '_MM_FLUSH_ZERO_ON'
    _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
                            ^
/Users/amprocte/Work/ngraph/src/tools/nbench/benchmark.cpp:37:33: error: use of undeclared identifier '_MM_DENORMALS_ZERO_ON'
    _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
```