### PR TITLE
IntelGPU backend: Fix place for the backend library

### DIFF
--- a/src/ngraph/runtime/intelgpu/CMakeLists.txt
+++ b/src/ngraph/runtime/intelgpu/CMakeLists.txt
@@ -31,6 +31,8 @@ if (NGRAPH_INTELGPU_ENABLE)
     add_library(intelgpu_backend SHARED ${SRC})
     set_target_properties(intelgpu_backend PROPERTIES VERSION ${NGRAPH_VERSION} SOVERSION ${NGRAPH_API_VERSION})
     target_link_libraries(intelgpu_backend PUBLIC ngraph)
+    set_target_properties(intelgpu_backend PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${NGRAPH_BUILD_DIR})
+
     find_package(CLDNN REQUIRED)
     target_include_directories(intelgpu_backend SYSTEM PUBLIC ${CLDNN_INCLUDE_DIRS})
     target_link_libraries(intelgpu_backend PUBLIC ${CLDNN_LIBRARIES})


### PR DESCRIPTION
This PR fix the place of the libintelgpu_backend.so in a build tree. Currently, it allows run unit tests without LD_LIBRARY_PATH set