### PR TITLE
m_direct_execution is used but not defined when NGRAPH_DEX_ONLY=TRUE

### DIFF
--- a/src/ngraph/runtime/cpu/cpu_external_function.hpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.hpp
@@ -228,7 +228,9 @@ namespace ngraph
                 bool m_emit_timing;
 
                 bool m_use_tbb;
+#if !defined(NGRAPH_DEX_ONLY)
                 bool m_is_compiled;
+#endif
                 bool m_direct_execution;
                 EntryPoint m_compiled_function;
                 std::unordered_map<std::string, std::string> m_variable_name_map;

--- a/src/ngraph/runtime/cpu/cpu_external_function.hpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.hpp
@@ -228,10 +228,8 @@ namespace ngraph
                 bool m_emit_timing;
 
                 bool m_use_tbb;
-#if !defined(NGRAPH_DEX_ONLY)
                 bool m_is_compiled;
                 bool m_direct_execution;
-#endif
                 EntryPoint m_compiled_function;
                 std::unordered_map<std::string, std::string> m_variable_name_map;
 


### PR DESCRIPTION
Looks like the addition of this defguard in ngraph #1891 (https://github.com/NervanaSystems/ngraph/pull/1891/files#diff-c704d60511f5078913700c52bb91abb6R231) doesn’t quite work. It prevents ngraph-tf:master from compiling as these members are used but not defined when NGRAPH_DEX_ONLY. 

Please check that this results in the proper behavior.
