### PR TITLE
Fix for AllReduce partial shape/type validation

### DIFF
--- a/src/ngraph/op/allreduce.cpp
+++ b/src/ngraph/op/allreduce.cpp
@@ -27,11 +27,6 @@ op::AllReduce::AllReduce(const shared_ptr<Node>& arg)
 
 void op::AllReduce::validate_and_infer_types()
 {
-    if (validate_punt_if_dynamic())
-    {
-        return;
-    }
-
     NODE_VALIDATION_ASSERT(this,
                            get_input_element_type(0).is_dynamic() ||
                                get_input_element_type(0) == element::f32 ||
@@ -39,7 +34,7 @@ void op::AllReduce::validate_and_infer_types()
         << "Only element types f32 and f64 are supported (argument element type: "
         << get_input_element_type(0) << ").";
 
-    set_output_type(0, get_input_element_type(0), get_input_shape(0));
+    set_output_type(0, get_input_element_type(0), get_input_partial_shape(0));
 }
 
 shared_ptr<Node> op::AllReduce::copy_with_new_args(const NodeVector& new_args) const


### PR DESCRIPTION
Thought I had fully dealt with this one already but I guess not.