### PR TITLE
Partial Shapes and Types, Part 4o: Sigmoid/SigmoidBackprop

### DIFF
--- a/src/ngraph/op/sigmoid.cpp
+++ b/src/ngraph/op/sigmoid.cpp
@@ -28,24 +28,15 @@ shared_ptr<Node> op::Sigmoid::copy_with_new_args(const NodeVector& new_args) con
 }
 
 op::Sigmoid::Sigmoid(shared_ptr<Node> arg)
-    : UnaryElementwiseArithmetic("Sigmoid", {arg})
+    : UnaryElementwiseArithmetic("Sigmoid", arg)
 {
-    set_output_type(0, arg->get_element_type(), arg->get_shape());
     constructor_validate_and_infer_types();
 }
 
 op::SigmoidBackprop::SigmoidBackprop(shared_ptr<Node> arg, shared_ptr<Node> delta)
-    : Op("SigmoidBackprop", check_single_output_args({arg, delta}))
+    : BinaryElementwiseArithmetic("SigmoidBackprop", arg, delta)
 {
-    NODE_VALIDATION_ASSERT(this, arg->get_element_type() == delta->get_element_type())
-        << "Argument and delta element types do not match (argument element type: "
-        << arg->get_element_type() << ", delta element type: " << delta->get_element_type() << ").";
-
-    NODE_VALIDATION_ASSERT(this, arg->get_shape() == delta->get_shape())
-        << "Argument and delta shapes do not match (argument shape: " << arg->get_shape()
-        << ", delta shape: " << delta->get_shape() << ").";
-
-    set_output_type(0, delta->get_element_type(), delta->get_shape());
+    constructor_validate_and_infer_types();
 }
 
 shared_ptr<Node> op::SigmoidBackprop::copy_with_new_args(const NodeVector& new_args) const

--- a/src/ngraph/op/sigmoid.hpp
+++ b/src/ngraph/op/sigmoid.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ngraph/op/op.hpp"
+#include "ngraph/op/util/binary_elementwise_arithmetic.hpp"
 #include "ngraph/op/util/unary_elementwise_arithmetic.hpp"
 #include "ngraph/util.hpp"
 
@@ -36,7 +37,7 @@ namespace ngraph
 
         /// \brief Elementwise SigmoidBackprop operation.
         ///
-        class SigmoidBackprop : public Op
+        class SigmoidBackprop : public util::BinaryElementwiseArithmetic
         {
         public:
             /// \brief Constructs a SigmoidBackprop operation.


### PR DESCRIPTION
I actually just handled this by moving `SigmoidBackprop` into `BinaryElementwiseArithmetic`, which I think is appropriate because the backprop op operates in an elementwise fashion.