### PR TITLE
IntelGPU backend: Change exception type for unsupported op

### DIFF
--- a/src/ngraph/runtime/intelgpu/intelgpu_backend.cpp
+++ b/src/ngraph/runtime/intelgpu/intelgpu_backend.cpp
@@ -432,10 +432,6 @@ bool runtime::intelgpu::IntelGPUBackend::compile(shared_ptr<Function> func)
             function_output_names.push_back(get_input_name(op));
             break;
         }
-        case OP_TYPEID::GenerateMask:
-        {
-            throw ngraph_error("GenerateMask isn't yet supported on integrated GPU");
-        }
         case OP_TYPEID::GetOutputElement:
         {
             if (op->get_inputs().empty() || op->get_outputs().size() != 1)
@@ -1508,6 +1504,7 @@ bool runtime::intelgpu::IntelGPUBackend::compile(shared_ptr<Function> func)
         case OP_TYPEID::Quantize:
         case OP_TYPEID::ReduceWindow:
         case OP_TYPEID::ReplaceSlice:
+        case OP_TYPEID::GenerateMask:
         case OP_TYPEID::ReverseSequence:
         case OP_TYPEID::SelectAndScatter:
         case OP_TYPEID::StopGradient:


### PR DESCRIPTION
Sorry, I missed this in my previous review of the changes.
I think we need to use same exception type for all unsupported operations.