### PR TITLE
[Py] Add make python_wheel target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,3 +311,6 @@ if (NGRAPH_DOC_BUILD_ENABLE)
     add_subdirectory(doc)
 endif()
 
+if (NGRAPH_PYTHON_BUILD_ENABLE)
+    add_subdirectory(python)
+endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ******************************************************************************
+# Copyright 2017-2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ******************************************************************************
+
+cmake_minimum_required (VERSION 3.1)
+
+project (pyngraph)
+
+include(ExternalProject)
+
+ExternalProject_Add(
+        pybind11
+        GIT_REPOSITORY "https://github.com/pybind/pybind11.git"
+        SOURCE_DIR "${CMAKE_BINARY_DIR}/pybind11"
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+)
+
+set(BUILD_SH_IN "${CMAKE_SOURCE_DIR}/python/build_wheel.sh.in")
+set(BUILD_SH    "${CMAKE_BINARY_DIR}/python/build_wheel.sh")
+configure_file(${BUILD_SH_IN} ${BUILD_SH} @ONLY)
+
+add_custom_command(
+        OUTPUT ${CMAKE_BINARY_DIR}/python/dist/
+        POST_BUILD
+        WORKING_DIR ${CMAKE_BINARY_DIR}/python/
+        COMMAND bash build_wheel.sh
+)
+
+add_custom_target(python_wheel DEPENDS ngraph ${CMAKE_BINARY_DIR}/python/dist/)

--- a/python/build_wheel.sh.in
+++ b/python/build_wheel.sh.in
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+export PYBIND_HEADERS_PATH=@CMAKE_BINARY_DIR@/pybind11
+export NGRAPH_CPP_BUILD_PATH=@CMAKE_INSTALL_PREFIX@
+export NGRAPH_ONNX_IMPORT_ENABLE=@NGRAPH_ONNX_IMPORT_ENABLE@
+export NGRAPH_VERSION=@NGRAPH_VERSION_SHORT@
+
+SOURCE_DIR=@CMAKE_SOURCE_DIR@/python
+BUILD_DIR=@CMAKE_BINARY_DIR@/python
+
+! PYTHON2_DETECTED=$(($(python -c 'import sys; print(sys.version_info.major)' 2> /dev/null) == 2))
+! PYTHON3_DETECTED=$(($(python3 -c 'import sys; print(sys.version_info.major)' 2> /dev/null) == 3))
+
+mkdir -p build
+
+if [ "${PYTHON2_DETECTED}" == 1 ]; then
+    echo "Building wheel for Python 2"
+    python --version
+    cd ${BUILD_DIR}
+    virtualenv -p "$(command -v python)" build/venv2
+    source build/venv2/bin/activate
+    pip install --upgrade setuptools pip wheel
+    python ${SOURCE_DIR}/setup.py bdist_wheel
+    deactivate
+fi
+
+if [ "${PYTHON3_DETECTED}" == 1  ]; then
+    echo "Building wheel for Python 3"
+    python3 --version
+    cd ${BUILD_DIR}
+    virtualenv -p "$(command -v python3)" build/venv3
+    source build/venv3/bin/activate
+    pip install --upgrade setuptools pip wheel
+    python ${SOURCE_DIR}/setup.py bdist_wheel
+    deactivate
+fi

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,10 +21,10 @@ import setuptools
 import os
 import distutils.ccompiler
 
-__version__ = '0.9.0'
-
+__version__ = os.environ.get('NGRAPH_VERSION', '0.0.0-dev')
 PYNGRAPH_SOURCE_DIR = os.path.abspath(os.path.dirname(__file__))
 NGRAPH_DEFAULT_INSTALL_DIR = os.environ.get('HOME')
+NGRAPH_ONNX_IMPORT_ENABLE = os.environ.get('NGRAPH_ONNX_IMPORT_ENABLE')
 
 
 def find_ngraph_dist_dir():
@@ -289,7 +289,7 @@ ext_modules = [
     )
 ]
 
-if os.environ.get('NGRAPH_ONNX_IMPORT_ENABLE') == 'TRUE':
+if NGRAPH_ONNX_IMPORT_ENABLE == 'TRUE':
     onnx_sources = [
         'pyngraph/pyngraph_onnx_import.cpp',
         'pyngraph/onnx_import/onnx_import.cpp',
@@ -356,9 +356,9 @@ setup(
     version=__version__,
     author='Intel',
     author_email='intelnervana@intel.com',
-    url='http://www.intelnervana.com',
+    url='https://ai.intel.com/',
     license='License :: OSI Approved :: Apache Software License',
-    description='Python wrapper for ngraph',
+    description='Python API for nGraph',
     long_description='',
     ext_modules=ext_modules,
     package_dir=package_dir,


### PR DESCRIPTION
The goal of this PR is to add a new target `make python_wheel` which will build the Python binary `*.whl` files.