### PR TITLE
runtime::Backend API change

### DIFF
--- a/python/pyngraph/runtime/backend.cpp
+++ b/python/pyngraph/runtime/backend.cpp
@@ -35,22 +35,22 @@ void regclass_pyngraph_runtime_Backend(py::module m)
                     const ngraph::element::Type&, const ngraph::Shape&)) &
                     ngraph::runtime::Backend::create_tensor);
     backend.def("compile",
-                (void (ngraph::runtime::Backend::*)(std::shared_ptr<ngraph::Function>)) &
+                (ngraph::runtime::Handle(ngraph::runtime::Backend::*)(
+                    const std::shared_ptr<ngraph::Function>&)) &
                     ngraph::runtime::Backend::compile);
     backend.def("call",
                 (void (ngraph::runtime::Backend::*)(
-                    std::shared_ptr<ngraph::Function>,
+                    void*,
                     const std::vector<std::shared_ptr<ngraph::runtime::Tensor>>&,
                     const std::vector<std::shared_ptr<ngraph::runtime::Tensor>>&)) &
                     ngraph::runtime::Backend::call);
     backend.def("remove_compiled_function",
-                (void (ngraph::runtime::Backend::*)(std::shared_ptr<ngraph::Function>)) &
+                (void (ngraph::runtime::Backend::*)(void*)) &
                     ngraph::runtime::Backend::remove_compiled_function);
     backend.def("enable_performance_data",
-                (void (ngraph::runtime::Backend::*)(std::shared_ptr<ngraph::Function>, bool)) &
-                    ngraph::runtime::Backend::enable_performance_data);
-    backend.def("get_performance_data",
-                (std::vector<ngraph::runtime::PerformanceCounter>(ngraph::runtime::Backend::*)(
-                    std::shared_ptr<ngraph::Function>)) &
-                    ngraph::runtime::Backend::get_performance_data);
+                (void(bool)) & ngraph::runtime::Backend::enable_performance_data);
+    backend.def(
+        "get_performance_data",
+        (std::vector<ngraph::runtime::PerformanceCounter>(ngraph::runtime::Backend::*)(void*)) &
+            ngraph::runtime::Backend::get_performance_data);
 }

--- a/src/ngraph/runtime/backend.cpp
+++ b/src/ngraph/runtime/backend.cpp
@@ -39,17 +39,17 @@ vector<string> runtime::Backend::get_registered_devices()
     return BackendManager::get_registered_backends();
 }
 
-void runtime::Backend::remove_compiled_function(shared_ptr<Function> func)
+void runtime::Backend::remove_compiled_function(Handle handle)
 {
 }
 
 vector<ngraph::runtime::PerformanceCounter>
-    runtime::Backend::get_performance_data(shared_ptr<Function> func) const
+    runtime::Backend::get_performance_data(Handle handle) const
 {
     return vector<PerformanceCounter>();
 }
 
-void runtime::Backend::validate_call(shared_ptr<const Function> function,
+void runtime::Backend::validate_call(const std::shared_ptr<Function>& function,
                                      const vector<shared_ptr<runtime::Tensor>>& outputs,
                                      const vector<shared_ptr<runtime::Tensor>>& inputs)
 {

--- a/src/ngraph/runtime/backend.cpp
+++ b/src/ngraph/runtime/backend.cpp
@@ -49,63 +49,63 @@ vector<ngraph::runtime::PerformanceCounter>
     return vector<PerformanceCounter>();
 }
 
-void runtime::Backend::validate_call(const std::shared_ptr<Function>& function,
+void runtime::Backend::validate_call(Handle handle,
                                      const vector<shared_ptr<runtime::Tensor>>& outputs,
                                      const vector<shared_ptr<runtime::Tensor>>& inputs)
 {
-    const op::ParameterVector& input_parameters = function->get_parameters();
-    if (input_parameters.size() != inputs.size())
-    {
-        stringstream ss;
-        ss << "Call input count " << inputs.size() << " does not match Function's Parameter count "
-           << input_parameters.size();
-        throw runtime_error(ss.str());
-    }
-    if (function->get_output_size() != outputs.size())
-    {
-        stringstream ss;
-        ss << "Call output count " << outputs.size() << " does not match Function's Result count "
-           << function->get_output_size();
-        throw runtime_error(ss.str());
-    }
+    // const op::ParameterVector& input_parameters = function->get_parameters();
+    // if (input_parameters.size() != inputs.size())
+    // {
+    //     stringstream ss;
+    //     ss << "Call input count " << inputs.size() << " does not match Function's Parameter count "
+    //        << input_parameters.size();
+    //     throw runtime_error(ss.str());
+    // }
+    // if (function->get_output_size() != outputs.size())
+    // {
+    //     stringstream ss;
+    //     ss << "Call output count " << outputs.size() << " does not match Function's Result count "
+    //        << function->get_output_size();
+    //     throw runtime_error(ss.str());
+    // }
 
-    for (size_t i = 0; i < input_parameters.size(); i++)
-    {
-        if (input_parameters[i]->get_element_type() != inputs[i]->get_element_type())
-        {
-            stringstream ss;
-            ss << "Input " << i << " type '" << inputs[i]->get_element_type()
-               << "' does not match Parameter type '" << input_parameters[i]->get_element_type()
-               << "'";
-            throw runtime_error(ss.str());
-        }
-        if (input_parameters[i]->get_shape() != inputs[i]->get_shape())
-        {
-            stringstream ss;
-            ss << "Input " << i << " shape {" << join(inputs[i]->get_shape())
-               << "} does not match Parameter shape {" << join(input_parameters[i]->get_shape())
-               << "}";
-            throw runtime_error(ss.str());
-        }
-    }
+    // for (size_t i = 0; i < input_parameters.size(); i++)
+    // {
+    //     if (input_parameters[i]->get_element_type() != inputs[i]->get_element_type())
+    //     {
+    //         stringstream ss;
+    //         ss << "Input " << i << " type '" << inputs[i]->get_element_type()
+    //            << "' does not match Parameter type '" << input_parameters[i]->get_element_type()
+    //            << "'";
+    //         throw runtime_error(ss.str());
+    //     }
+    //     if (input_parameters[i]->get_shape() != inputs[i]->get_shape())
+    //     {
+    //         stringstream ss;
+    //         ss << "Input " << i << " shape {" << join(inputs[i]->get_shape())
+    //            << "} does not match Parameter shape {" << join(input_parameters[i]->get_shape())
+    //            << "}";
+    //         throw runtime_error(ss.str());
+    //     }
+    // }
 
-    for (size_t i = 0; i < function->get_output_size(); i++)
-    {
-        if (function->get_output_element_type(i) != outputs[i]->get_element_type())
-        {
-            stringstream ss;
-            ss << "Output " << i << " type '" << outputs[i]->get_element_type()
-               << "' does not match Result type '" << function->get_output_element_type(i) << "'";
-            throw runtime_error(ss.str());
-        }
-        if (function->get_output_shape(i) != outputs[i]->get_shape())
-        {
-            stringstream ss;
-            ss << "Output " << i << " shape {" << join(outputs[i]->get_shape())
-               << "} does not match Result shape {" << join(function->get_output_shape(i)) << "}";
-            throw runtime_error(ss.str());
-        }
-    }
+    // for (size_t i = 0; i < function->get_output_size(); i++)
+    // {
+    //     if (function->get_output_element_type(i) != outputs[i]->get_element_type())
+    //     {
+    //         stringstream ss;
+    //         ss << "Output " << i << " type '" << outputs[i]->get_element_type()
+    //            << "' does not match Result type '" << function->get_output_element_type(i) << "'";
+    //         throw runtime_error(ss.str());
+    //     }
+    //     if (function->get_output_shape(i) != outputs[i]->get_shape())
+    //     {
+    //         stringstream ss;
+    //         ss << "Output " << i << " shape {" << join(outputs[i]->get_shape())
+    //            << "} does not match Result shape {" << join(function->get_output_shape(i)) << "}";
+    //         throw runtime_error(ss.str());
+    //     }
+    // }
 }
 
 bool runtime::Backend::is_supported(const Node& node) const
@@ -113,4 +113,18 @@ bool runtime::Backend::is_supported(const Node& node) const
     // The default behavior is that a backend does not support any ops. If this is not the case
     // then override this method and enhance.
     return false;
+}
+
+bool runtime::Backend::save(Handle handle, const std::string& path) const
+{
+    return false;
+}
+
+runtime::Handle runtime::Backend::load(const std::string& path)
+{
+    return nullptr;
+}
+
+void runtime::Backend::enable_performance_data(bool enable)
+{
 }

--- a/src/ngraph/runtime/backend.cpp
+++ b/src/ngraph/runtime/backend.cpp
@@ -53,59 +53,61 @@ void runtime::Backend::validate_call(Handle handle,
                                      const vector<shared_ptr<runtime::Tensor>>& outputs,
                                      const vector<shared_ptr<runtime::Tensor>>& inputs)
 {
-    // const op::ParameterVector& input_parameters = function->get_parameters();
-    // if (input_parameters.size() != inputs.size())
-    // {
-    //     stringstream ss;
-    //     ss << "Call input count " << inputs.size() << " does not match Function's Parameter count "
-    //        << input_parameters.size();
-    //     throw runtime_error(ss.str());
-    // }
-    // if (function->get_output_size() != outputs.size())
-    // {
-    //     stringstream ss;
-    //     ss << "Call output count " << outputs.size() << " does not match Function's Result count "
-    //        << function->get_output_size();
-    //     throw runtime_error(ss.str());
-    // }
+    const op::ParameterVector& input_parameters = get_parameter_descriptors(handle);
+    const ResultVector& output_results = get_result_descriptors(handle);
+    if (input_parameters.size() != inputs.size())
+    {
+        stringstream ss;
+        ss << "Call input count " << inputs.size() << " does not match Function's Parameter count "
+           << input_parameters.size();
+        throw runtime_error(ss.str());
+    }
+    if (output_results.size() != outputs.size())
+    {
+        stringstream ss;
+        ss << "Call output count " << outputs.size() << " does not match Function's Result count "
+           << output_results.size();
+        throw runtime_error(ss.str());
+    }
 
-    // for (size_t i = 0; i < input_parameters.size(); i++)
-    // {
-    //     if (input_parameters[i]->get_element_type() != inputs[i]->get_element_type())
-    //     {
-    //         stringstream ss;
-    //         ss << "Input " << i << " type '" << inputs[i]->get_element_type()
-    //            << "' does not match Parameter type '" << input_parameters[i]->get_element_type()
-    //            << "'";
-    //         throw runtime_error(ss.str());
-    //     }
-    //     if (input_parameters[i]->get_shape() != inputs[i]->get_shape())
-    //     {
-    //         stringstream ss;
-    //         ss << "Input " << i << " shape {" << join(inputs[i]->get_shape())
-    //            << "} does not match Parameter shape {" << join(input_parameters[i]->get_shape())
-    //            << "}";
-    //         throw runtime_error(ss.str());
-    //     }
-    // }
+    for (size_t i = 0; i < input_parameters.size(); i++)
+    {
+        if (input_parameters[i]->get_element_type() != inputs[i]->get_element_type())
+        {
+            stringstream ss;
+            ss << "Input " << i << " type '" << inputs[i]->get_element_type()
+               << "' does not match Parameter type '" << input_parameters[i]->get_element_type()
+               << "'";
+            throw runtime_error(ss.str());
+        }
+        if (input_parameters[i]->get_shape() != inputs[i]->get_shape())
+        {
+            stringstream ss;
+            ss << "Input " << i << " shape {" << join(inputs[i]->get_shape())
+               << "} does not match Parameter shape {" << join(input_parameters[i]->get_shape())
+               << "}";
+            throw runtime_error(ss.str());
+        }
+    }
 
-    // for (size_t i = 0; i < function->get_output_size(); i++)
-    // {
-    //     if (function->get_output_element_type(i) != outputs[i]->get_element_type())
-    //     {
-    //         stringstream ss;
-    //         ss << "Output " << i << " type '" << outputs[i]->get_element_type()
-    //            << "' does not match Result type '" << function->get_output_element_type(i) << "'";
-    //         throw runtime_error(ss.str());
-    //     }
-    //     if (function->get_output_shape(i) != outputs[i]->get_shape())
-    //     {
-    //         stringstream ss;
-    //         ss << "Output " << i << " shape {" << join(outputs[i]->get_shape())
-    //            << "} does not match Result shape {" << join(function->get_output_shape(i)) << "}";
-    //         throw runtime_error(ss.str());
-    //     }
-    // }
+    for (size_t i = 0; i < output_results.size(); i++)
+    {
+        if (output_results[i]->get_element_type() != outputs[i]->get_element_type())
+        {
+            stringstream ss;
+            ss << "Output " << i << " type '" << outputs[i]->get_element_type()
+               << "' does not match Result type '" << output_results[i]->get_element_type() << "'";
+            throw runtime_error(ss.str());
+        }
+        if (output_results[i]->get_shape() != outputs[i]->get_shape())
+        {
+            stringstream ss;
+            ss << "Output " << i << " shape {" << join(outputs[i]->get_shape())
+               << "} does not match Result shape {" << join(output_results[i]->get_output_shape(i))
+               << "}";
+            throw runtime_error(ss.str());
+        }
+    }
 }
 
 bool runtime::Backend::is_supported(const Node& node) const

--- a/src/ngraph/runtime/backend.hpp
+++ b/src/ngraph/runtime/backend.hpp
@@ -30,6 +30,7 @@ namespace ngraph
         class ExternalFunction;
         class Tensor;
         class Backend;
+        using Handle = void*;
     }
 }
 
@@ -80,43 +81,42 @@ public:
     /// \brief Compiles a Function.
     /// \param func The function to compile
     /// \returns true if compile is successful, false otherwise
-    virtual bool compile(std::shared_ptr<Function> func) = 0;
+    virtual Handle compile(const std::shared_ptr<Function>& func) = 0;
 
     /// \brief Executes a single iteration of a Function. If func is not compiled the call will
     ///     compile it.
-    /// \param func The function to execute
+    /// \param handle Handle returned from compile()
     /// \returns true if iteration is successful, false otherwise
-    virtual bool call(std::shared_ptr<Function> func,
+    virtual bool call(Handle handle,
                       const std::vector<std::shared_ptr<runtime::Tensor>>& outputs,
                       const std::vector<std::shared_ptr<runtime::Tensor>>& inputs) = 0;
 
     /// \brief Executes a single iteration of a Function. If func is not compiled the call will
     ///     compile it. Optionally validates the inputs and outputs against the function graph.
-    /// \param func The function to execute
+    /// \param handle Handle returned from compile()
     /// \returns true if iteration is successful, false otherwise
-    bool call_with_validate(std::shared_ptr<Function> func,
+    bool call_with_validate(Handle handle,
                             const std::vector<std::shared_ptr<runtime::Tensor>>& outputs,
                             const std::vector<std::shared_ptr<runtime::Tensor>>& inputs)
     {
-        validate_call(func, outputs, inputs);
-        return call(func, outputs, inputs);
+        // validate_call(handle, outputs, inputs);
+        return call(handle, outputs, inputs);
     }
 
     /// \brief Compiled functions may be cached. This function removes a compiled function
     ///     from the cache.
-    /// \param func The function to execute
-    virtual void remove_compiled_function(std::shared_ptr<Function> func);
+    /// \param handle Handle returned from compile()
+    virtual void remove_compiled_function(Handle handle);
 
     /// \brief Enable the collection of per-op performance information on a specified Function.
     ///     Data collection is via the `get_performance_data` method.
-    /// \param func The function to collect perfomance data on.
+    /// \param handle Handle returned from compile()
     /// \param enable Set to true to enable or false to disable data collection
-    virtual void enable_performance_data(std::shared_ptr<Function> func, bool enable) {}
+    virtual void enable_performance_data(Handle handle, bool enable) {}
     /// \brief Collect performance information gathered on a Function.
-    /// \param func The function to get collected data.
+    /// \param handle Handle returned from compile()
     /// \returns Vector of PerformanceCounter information.
-    virtual std::vector<PerformanceCounter>
-        get_performance_data(std::shared_ptr<Function> func) const;
+    virtual std::vector<PerformanceCounter> get_performance_data(Handle handle) const;
 
     /// \brief Test if a backend is capable of supporting an op
     /// \param node is the op to test.
@@ -124,7 +124,7 @@ public:
     virtual bool is_supported(const Node& node) const;
 
 protected:
-    void validate_call(std::shared_ptr<const Function> func,
+    void validate_call(const std::shared_ptr<Function>& function,
                        const std::vector<std::shared_ptr<runtime::Tensor>>& outputs,
                        const std::vector<std::shared_ptr<runtime::Tensor>>& inputs);
 };

--- a/src/ngraph/runtime/backend.hpp
+++ b/src/ngraph/runtime/backend.hpp
@@ -85,7 +85,7 @@ public:
 
     /// \brief Executes a single iteration of a Function. If func is not compiled the call will
     ///     compile it.
-    /// \param handle Handle returned from compile()
+    /// \param handle Handle returned from compile() or load()
     /// \returns true if iteration is successful, false otherwise
     virtual bool call(Handle handle,
                       const std::vector<std::shared_ptr<runtime::Tensor>>& outputs,
@@ -93,29 +93,29 @@ public:
 
     /// \brief Executes a single iteration of a Function. If func is not compiled the call will
     ///     compile it. Optionally validates the inputs and outputs against the function graph.
-    /// \param handle Handle returned from compile()
+    /// \param handle Handle returned from compile() or load()
     /// \returns true if iteration is successful, false otherwise
     bool call_with_validate(Handle handle,
                             const std::vector<std::shared_ptr<runtime::Tensor>>& outputs,
                             const std::vector<std::shared_ptr<runtime::Tensor>>& inputs)
     {
-        // validate_call(handle, outputs, inputs);
+        validate_call(handle, outputs, inputs);
         return call(handle, outputs, inputs);
     }
 
     /// \brief Compiled functions may be cached. This function removes a compiled function
     ///     from the cache.
-    /// \param handle Handle returned from compile()
+    /// \param handle Handle returned from compile() or load()
     virtual void remove_compiled_function(Handle handle);
 
     /// \brief Save the function's state.
-    /// \param handle Handle returned from compile()
+    /// \param handle Handle returned from compile() or load()
     /// \param path File system path to the output file.
     /// \returns true if save is successful.
     virtual bool save(Handle handle, const std::string& path) const;
 
     /// \brief Load a function's saved state.
-    /// \param handle Handle returned from compile()
+    /// \param path File system path to the input file.
     /// \returns non-nullptr Handle if successful, nullptr otherwise.
     virtual Handle load(const std::string& path);
 
@@ -125,7 +125,7 @@ public:
     virtual void enable_performance_data(bool enable);
 
     /// \brief Collect performance information gathered on a Function.
-    /// \param handle Handle returned from compile()
+    /// \param handle Handle returned from compile() or load()
     /// \returns Vector of PerformanceCounter information.
     virtual std::vector<PerformanceCounter> get_performance_data(Handle handle) const;
 
@@ -133,6 +133,16 @@ public:
     /// \param node is the op to test.
     /// \returns true if the op is supported, false otherwise.
     virtual bool is_supported(const Node& node) const;
+
+    /// \brief Query the input Parameters for a given Handle
+    /// \param handle Handle returned from compile() or load()
+    /// \returns an ngraph::op::ParameterVector of all input parameters
+    virtual const ngraph::op::ParameterVector& get_parameter_descriptors(Handle handle) const = 0;
+
+    /// \brief Query the output Results for a given Handle
+    /// \param handle Handle returned from compile() or load()
+    /// \returns an ngraph::ResultVector of all input parameters
+    virtual const ngraph::ResultVector& get_result_descriptors(Handle handle) const = 0;
 
 protected:
     void validate_call(Handle handle,

--- a/src/ngraph/runtime/backend.hpp
+++ b/src/ngraph/runtime/backend.hpp
@@ -108,11 +108,22 @@ public:
     /// \param handle Handle returned from compile()
     virtual void remove_compiled_function(Handle handle);
 
+    /// \brief Save the function's state.
+    /// \param handle Handle returned from compile()
+    /// \param path File system path to the output file.
+    /// \returns true if save is successful.
+    virtual bool save(Handle handle, const std::string& path) const;
+
+    /// \brief Load a function's saved state.
+    /// \param handle Handle returned from compile()
+    /// \returns non-nullptr Handle if successful, nullptr otherwise.
+    virtual Handle load(const std::string& path);
+
     /// \brief Enable the collection of per-op performance information on a specified Function.
     ///     Data collection is via the `get_performance_data` method.
-    /// \param handle Handle returned from compile()
     /// \param enable Set to true to enable or false to disable data collection
-    virtual void enable_performance_data(Handle handle, bool enable) {}
+    virtual void enable_performance_data(bool enable);
+
     /// \brief Collect performance information gathered on a Function.
     /// \param handle Handle returned from compile()
     /// \returns Vector of PerformanceCounter information.
@@ -124,7 +135,7 @@ public:
     virtual bool is_supported(const Node& node) const;
 
 protected:
-    void validate_call(const std::shared_ptr<Function>& function,
+    void validate_call(Handle handle,
                        const std::vector<std::shared_ptr<runtime::Tensor>>& outputs,
                        const std::vector<std::shared_ptr<runtime::Tensor>>& inputs);
 };

--- a/src/ngraph/runtime/cpu/cpu_backend.cpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.cpp
@@ -76,6 +76,7 @@ runtime::Handle runtime::cpu::CPU_Backend::compile(const shared_ptr<Function>& f
 {
     auto instance = make_shared<FunctionInstance>();
     m_instances.push_back(instance);
+    instance->m_performance_counters_enabled = m_performance_counters_enabled;
 
     instance->m_external_function = make_shared<CPU_ExternalFunction>(func);
     instance->m_external_function->m_emit_timing = instance->m_performance_counters_enabled;
@@ -118,14 +119,9 @@ void runtime::cpu::CPU_Backend::remove_compiled_function(runtime::Handle handle)
     }
 }
 
-void runtime::cpu::CPU_Backend::enable_performance_data(runtime::Handle handle, bool enable)
+void runtime::cpu::CPU_Backend::enable_performance_data(bool enable)
 {
-    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
-    if (instance->m_external_function != nullptr)
-    {
-        throw runtime_error("Performance data collection must be enabled prior to compiling.");
-    }
-    instance->m_performance_counters_enabled = enable;
+    m_performance_counters_enabled = enable;
 }
 
 vector<runtime::PerformanceCounter>
@@ -140,4 +136,16 @@ vector<runtime::PerformanceCounter>
                   instance->m_external_function->get_perf_counters().end());
     }
     return rc;
+}
+
+const op::ParameterVector& runtime::cpu::CPU_Backend::get_parameter_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_external_function->m_function->get_parameters();
+}
+
+const ResultVector& runtime::cpu::CPU_Backend::get_result_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_external_function->m_function->get_results();
 }

--- a/src/ngraph/runtime/cpu/cpu_backend.hpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.hpp
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "ngraph/runtime/backend.hpp"
 
@@ -45,18 +46,18 @@ namespace ngraph
                     create_tensor(const ngraph::element::Type& element_type,
                                   const Shape& shape) override;
 
-                bool compile(std::shared_ptr<Function> func) override;
+                runtime::Handle compile(const std::shared_ptr<Function>& func) override;
 
-                bool call(std::shared_ptr<Function> func,
+                bool call(runtime::Handle handle,
                           const std::vector<std::shared_ptr<runtime::Tensor>>& outputs,
                           const std::vector<std::shared_ptr<runtime::Tensor>>& inputs) override;
 
-                void remove_compiled_function(std::shared_ptr<Function> func) override;
-                std::shared_ptr<CPU_CallFrame> get_call_frame(std::shared_ptr<Function> func);
+                void remove_compiled_function(runtime::Handle handle) override;
+                std::shared_ptr<CPU_CallFrame> get_call_frame(runtime::Handle handle);
 
-                void enable_performance_data(std::shared_ptr<Function> func, bool enable) override;
+                void enable_performance_data(runtime::Handle handle, bool enable) override;
                 std::vector<PerformanceCounter>
-                    get_performance_data(std::shared_ptr<Function> func) const override;
+                    get_performance_data(runtime::Handle handle) const override;
 
             private:
                 class FunctionInstance
@@ -67,7 +68,7 @@ namespace ngraph
                     bool m_performance_counters_enabled = false;
                 };
 
-                std::map<std::shared_ptr<Function>, FunctionInstance> m_function_map;
+                std::vector<std::shared_ptr<FunctionInstance>> m_instances;
             };
         }
     }

--- a/src/ngraph/runtime/cpu/cpu_backend.hpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.hpp
@@ -55,9 +55,14 @@ namespace ngraph
                 void remove_compiled_function(runtime::Handle handle) override;
                 std::shared_ptr<CPU_CallFrame> get_call_frame(runtime::Handle handle);
 
-                void enable_performance_data(runtime::Handle handle, bool enable) override;
+                void enable_performance_data(bool enable) override;
                 std::vector<PerformanceCounter>
                     get_performance_data(runtime::Handle handle) const override;
+
+                const ngraph::op::ParameterVector&
+                    get_parameter_descriptors(Handle handle) const override;
+
+                const ngraph::ResultVector& get_result_descriptors(Handle handle) const override;
 
             private:
                 class FunctionInstance
@@ -69,6 +74,7 @@ namespace ngraph
                 };
 
                 std::vector<std::shared_ptr<FunctionInstance>> m_instances;
+                bool m_performance_counters_enabled = false;
             };
         }
     }

--- a/src/ngraph/runtime/gpu/gpu_backend.hpp
+++ b/src/ngraph/runtime/gpu/gpu_backend.hpp
@@ -51,16 +51,16 @@ namespace ngraph
                     create_tensor(const ngraph::element::Type& element_type,
                                   const Shape& shape) override;
 
-                bool compile(std::shared_ptr<Function> func) override;
+                runtime::Handle compile(const std::shared_ptr<Function>& func) override;
 
-                bool call(std::shared_ptr<Function> func,
+                bool call(runtime::Handle handle,
                           const std::vector<std::shared_ptr<runtime::Tensor>>& outputs,
                           const std::vector<std::shared_ptr<runtime::Tensor>>& inputs) override;
 
-                void remove_compiled_function(std::shared_ptr<Function> func) override;
-                void enable_performance_data(std::shared_ptr<Function> func, bool enable) override;
+                void remove_compiled_function(runtime::Handle handle) override;
+                void enable_performance_data(runtime::Handle handle, bool enable) override;
                 std::vector<PerformanceCounter>
-                    get_performance_data(std::shared_ptr<Function> func) const override;
+                    get_performance_data(runtime::Handle handle) const override;
 
                 bool is_supported(const Node& node) const override;
 
@@ -98,7 +98,7 @@ namespace ngraph
                     initialize_io(void** target,
                                   const std::vector<std::shared_ptr<runtime::Tensor>>& source);
 
-                std::map<std::shared_ptr<Function>, FunctionInstance> m_function_map;
+                std::vector<std::shared_ptr<FunctionInstance>> m_instances;
                 std::shared_ptr<BackendContext> m_context;
             };
         }

--- a/src/ngraph/runtime/gpu/gpu_backend.hpp
+++ b/src/ngraph/runtime/gpu/gpu_backend.hpp
@@ -58,11 +58,16 @@ namespace ngraph
                           const std::vector<std::shared_ptr<runtime::Tensor>>& inputs) override;
 
                 void remove_compiled_function(runtime::Handle handle) override;
-                void enable_performance_data(runtime::Handle handle, bool enable) override;
+                void enable_performance_data(bool enable) override;
                 std::vector<PerformanceCounter>
                     get_performance_data(runtime::Handle handle) const override;
 
                 bool is_supported(const Node& node) const override;
+
+                const ngraph::op::ParameterVector&
+                    get_parameter_descriptors(Handle handle) const override;
+
+                const ngraph::ResultVector& get_result_descriptors(Handle handle) const override;
 
                 class BackendContext
                 {
@@ -100,6 +105,7 @@ namespace ngraph
 
                 std::vector<std::shared_ptr<FunctionInstance>> m_instances;
                 std::shared_ptr<BackendContext> m_context;
+                bool m_performance_counters_enabled = false;
             };
         }
     }

--- a/src/ngraph/runtime/hybrid/hybrid_backend.cpp
+++ b/src/ngraph/runtime/hybrid/hybrid_backend.cpp
@@ -107,7 +107,7 @@ bool runtime::hybrid::HybridBackend::call(runtime::Handle handle,
     bool rc = true;
 
     auto it = m_instances.find(handle);
-    if (it == m_function_map.end())
+    if (it == m_instances.end())
     {
         throw runtime_error("runtime::Handle supplied to call invalid");
     }

--- a/src/ngraph/runtime/hybrid/hybrid_backend.cpp
+++ b/src/ngraph/runtime/hybrid/hybrid_backend.cpp
@@ -179,3 +179,16 @@ bool runtime::hybrid::HybridBackend::is_supported(const Node& node) const
 {
     return true;
 }
+
+const op::ParameterVector&
+    runtime::hybrid::HybridBackend::get_parameter_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_function->get_parameters();
+}
+
+const ResultVector& runtime::hybrid::HybridBackend::get_result_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_function->get_results();
+}

--- a/src/ngraph/runtime/hybrid/hybrid_backend.hpp
+++ b/src/ngraph/runtime/hybrid/hybrid_backend.hpp
@@ -49,9 +49,9 @@ public:
                       const ngraph::Shape& shape,
                       void* memory_pointer) override;
 
-    bool compile(std::shared_ptr<ngraph::Function> func) override;
+    runtime::Handle compile(const std::shared_ptr<ngraph::Function>& func) override;
 
-    bool call(std::shared_ptr<ngraph::Function> func,
+    bool call(runtime::Handle,
               const std::vector<std::shared_ptr<ngraph::runtime::Tensor>>& outputs,
               const std::vector<std::shared_ptr<ngraph::runtime::Tensor>>& inputs) override;
 
@@ -68,6 +68,6 @@ private:
             m_map_parameter_to_result;
     };
 
-    std::map<std::shared_ptr<ngraph::Function>, FunctionInstance> m_function_map;
+    std::vector<std::shared_ptr<FunctionInstance>> m_instances;
     std::vector<std::pair<std::string, std::shared_ptr<runtime::Backend>>> m_backend_list;
 };

--- a/src/ngraph/runtime/hybrid/hybrid_backend.hpp
+++ b/src/ngraph/runtime/hybrid/hybrid_backend.hpp
@@ -57,6 +57,10 @@ public:
 
     bool is_supported(const ngraph::Node& node) const override;
 
+    const ngraph::op::ParameterVector& get_parameter_descriptors(Handle handle) const override;
+
+    const ngraph::ResultVector& get_result_descriptors(Handle handle) const override;
+
 private:
     class FunctionInstance
     {

--- a/src/ngraph/runtime/intelgpu/intelgpu_backend.cpp
+++ b/src/ngraph/runtime/intelgpu/intelgpu_backend.cpp
@@ -1833,3 +1833,16 @@ void runtime::intelgpu::IntelGPUBackend::print_call_performance(
 
     cout.flags(saved_stream_flags); // Restore stream configuration to leave it in original state
 }
+
+const op::ParameterVector&
+    runtime::intelgpu::IntelGPUBackend::get_parameter_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_function->get_parameters();
+}
+
+const ResultVector& runtime::intelgpu::IntelGPUBackend::get_result_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_function->get_results();
+}

--- a/src/ngraph/runtime/intelgpu/intelgpu_backend.hpp
+++ b/src/ngraph/runtime/intelgpu/intelgpu_backend.hpp
@@ -57,6 +57,10 @@ public:
     void enable_performance_data(bool enable) override;
     std::vector<PerformanceCounter> get_performance_data(runtime::Handle handle) const override;
 
+    const ngraph::op::ParameterVector& get_parameter_descriptors(Handle handle) const override;
+
+    const ngraph::ResultVector& get_result_descriptors(Handle handle) const override;
+
 private:
     class FunctionInstance
     {

--- a/src/ngraph/runtime/intelgpu/intelgpu_backend.hpp
+++ b/src/ngraph/runtime/intelgpu/intelgpu_backend.hpp
@@ -47,16 +47,15 @@ public:
     std::shared_ptr<ngraph::runtime::Tensor>
         create_tensor(const ngraph::element::Type& element_type, const Shape& shape) override;
 
-    bool compile(std::shared_ptr<Function> func) override;
+    runtime::Handle compile(const std::shared_ptr<Function>& func) override;
 
-    bool call(std::shared_ptr<Function> func,
+    bool call(runtime::Handle handle,
               const std::vector<std::shared_ptr<runtime::Tensor>>& outputs,
               const std::vector<std::shared_ptr<runtime::Tensor>>& inputs) override;
 
-    void remove_compiled_function(std::shared_ptr<Function> func) override;
-    void enable_performance_data(std::shared_ptr<Function> func, bool enable) override;
-    std::vector<PerformanceCounter>
-        get_performance_data(std::shared_ptr<Function> func) const override;
+    void remove_compiled_function(runtime::Handle handle) override;
+    void enable_performance_data(bool enable) override;
+    std::vector<PerformanceCounter> get_performance_data(runtime::Handle handle) const override;
 
 private:
     class FunctionInstance
@@ -64,12 +63,14 @@ private:
     public:
         std::shared_ptr<cldnn::network> ocl_network = nullptr;
         bool m_performance_counters_enabled = false;
+        std::shared_ptr<Function> m_function;
     };
 
-    std::map<std::shared_ptr<Function>, FunctionInstance> ocl_networks;
+    std::vector<std::shared_ptr<FunctionInstance>> m_instances;
     std::shared_ptr<cldnn::engine> ocl_engine;
 
     bool m_disable_backend_optimizations = false;
+    bool m_performance_counters_enabled = false;
 
     // Statistic related things
     void print_call_performance(const std::shared_ptr<cldnn::network> network,

--- a/src/ngraph/runtime/interpreter/int_backend.cpp
+++ b/src/ngraph/runtime/interpreter/int_backend.cpp
@@ -61,6 +61,7 @@ runtime::Handle runtime::interpreter::INTBackend::compile(const shared_ptr<Funct
     auto instance = make_shared<FunctionInstance>();
     m_instances.push_back(instance);
     instance->m_function = function;
+    instance->m_performance_counters_enabled = m_performance_counters_enabled;
     pass::Manager pass_manager;
     pass_manager.register_pass<pass::LikeReplacement>();
     pass_manager.register_pass<pass::AssignLayout<DenseTensorLayout>>();
@@ -85,7 +86,7 @@ bool runtime::interpreter::INTBackend::call(Handle handle,
 {
     FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
     shared_ptr<Function> function = instance->m_function;
-    validate_call(function, outputs, inputs);
+    validate_call(handle, outputs, inputs);
 
     // convert inputs to HostTensor
     vector<void*> func_inputs;
@@ -288,10 +289,9 @@ void runtime::interpreter::INTBackend::set_nan_check(Handle handle, bool enable)
     instance->m_nan_check_enabled = enable;
 }
 
-void runtime::interpreter::INTBackend::enable_performance_data(Handle handle, bool enable)
+void runtime::interpreter::INTBackend::enable_performance_data(bool enable)
 {
-    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
-    instance->m_performance_counters_enabled = enable;
+    m_performance_counters_enabled = enable;
 }
 
 vector<runtime::PerformanceCounter>

--- a/src/ngraph/runtime/interpreter/int_backend.cpp
+++ b/src/ngraph/runtime/interpreter/int_backend.cpp
@@ -356,3 +356,16 @@ void runtime::interpreter::INTBackend::perform_nan_check(
         arg_number++;
     }
 }
+
+const op::ParameterVector&
+    runtime::interpreter::INTBackend::get_parameter_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_function->get_parameters();
+}
+
+const ResultVector& runtime::interpreter::INTBackend::get_result_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_function->get_results();
+}

--- a/src/ngraph/runtime/interpreter/int_backend.hpp
+++ b/src/ngraph/runtime/interpreter/int_backend.hpp
@@ -165,6 +165,9 @@ public:
     std::vector<PerformanceCounter> get_performance_data(Handle) const override;
 
     bool is_supported(const Node& node) const override { return true; }
+    const ngraph::op::ParameterVector& get_parameter_descriptors(Handle handle) const override;
+    const ngraph::ResultVector& get_result_descriptors(Handle handle) const override;
+
 private:
     static const int m_alignment;
     class FunctionInstance

--- a/src/ngraph/runtime/interpreter/int_backend.hpp
+++ b/src/ngraph/runtime/interpreter/int_backend.hpp
@@ -161,7 +161,7 @@ public:
 
     void set_nan_check(Handle, bool);
 
-    void enable_performance_data(Handle, bool enable) override;
+    void enable_performance_data(bool enable) override;
     std::vector<PerformanceCounter> get_performance_data(Handle) const override;
 
     bool is_supported(const Node& node) const override { return true; }
@@ -181,6 +181,7 @@ private:
         void* get_temporary_pointer(size_t offset) { return m_temporary_memory->get_ptr(offset); }
     };
     std::vector<std::shared_ptr<FunctionInstance>> m_instances;
+    bool m_performance_counters_enabled = false;
 
     static void perform_nan_check(const std::vector<std::shared_ptr<HostTensor>>&,
                                   const Node* op = nullptr);

--- a/src/ngraph/runtime/nop/nop_backend.cpp
+++ b/src/ngraph/runtime/nop/nop_backend.cpp
@@ -56,7 +56,10 @@ shared_ptr<runtime::Tensor> runtime::nop::NOPBackend::create_tensor(const elemen
 
 runtime::Handle runtime::nop::NOPBackend::compile(const shared_ptr<Function>& function)
 {
-    return reinterpret_cast<void*>(1);
+    auto instance = make_shared<FunctionInstance>();
+    m_instances.push_back(instance);
+    instance->m_function = function;
+    return instance.get();
 }
 
 bool runtime::nop::NOPBackend::call(Handle handle,
@@ -64,4 +67,16 @@ bool runtime::nop::NOPBackend::call(Handle handle,
                                     const vector<shared_ptr<runtime::Tensor>>& inputs)
 {
     return true;
+}
+
+const op::ParameterVector& runtime::nop::NOPBackend::get_parameter_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_function->get_parameters();
+}
+
+const ResultVector& runtime::nop::NOPBackend::get_result_descriptors(Handle handle) const
+{
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
+    return instance->m_function->get_results();
 }

--- a/src/ngraph/runtime/nop/nop_backend.cpp
+++ b/src/ngraph/runtime/nop/nop_backend.cpp
@@ -54,12 +54,12 @@ shared_ptr<runtime::Tensor> runtime::nop::NOPBackend::create_tensor(const elemen
     return make_shared<runtime::HostTensor>(type, shape, memory_pointer, "external");
 }
 
-bool runtime::nop::NOPBackend::compile(shared_ptr<Function> function)
+runtime::Handle runtime::nop::NOPBackend::compile(const shared_ptr<Function>& function)
 {
-    return true;
+    return reinterpret_cast<void*>(1);
 }
 
-bool runtime::nop::NOPBackend::call(shared_ptr<Function> function,
+bool runtime::nop::NOPBackend::call(Handle handle,
                                     const vector<shared_ptr<runtime::Tensor>>& outputs,
                                     const vector<shared_ptr<runtime::Tensor>>& inputs)
 {

--- a/src/ngraph/runtime/nop/nop_backend.hpp
+++ b/src/ngraph/runtime/nop/nop_backend.hpp
@@ -49,4 +49,16 @@ public:
     bool call(Handle,
               const std::vector<std::shared_ptr<Tensor>>& outputs,
               const std::vector<std::shared_ptr<Tensor>>& intputs) override;
+
+    const ngraph::op::ParameterVector& get_parameter_descriptors(Handle handle) const override;
+
+    const ngraph::ResultVector& get_result_descriptors(Handle handle) const override;
+
+private:
+    class FunctionInstance
+    {
+    public:
+        std::shared_ptr<Function> m_function;
+    };
+    std::vector<std::shared_ptr<FunctionInstance>> m_instances;
 };

--- a/src/ngraph/runtime/nop/nop_backend.hpp
+++ b/src/ngraph/runtime/nop/nop_backend.hpp
@@ -44,9 +44,9 @@ public:
 
     std::shared_ptr<Tensor> create_tensor(const element::Type& type, const Shape& shape) override;
 
-    bool compile(std::shared_ptr<Function> function) override;
+    Handle compile(const std::shared_ptr<Function>& function) override;
 
-    bool call(std::shared_ptr<Function> function,
+    bool call(Handle,
               const std::vector<std::shared_ptr<Tensor>>& outputs,
               const std::vector<std::shared_ptr<Tensor>>& intputs) override;
 };

--- a/src/tools/nbench/benchmark.cpp
+++ b/src/tools/nbench/benchmark.cpp
@@ -167,11 +167,11 @@ vector<runtime::PerformanceCounter> run_benchmark(shared_ptr<Function> f,
     stopwatch timer;
     timer.start();
     auto backend = runtime::Backend::create(backend_name);
+    backend->enable_performance_data(timing_detail);
     auto handle = backend->compile(f);
     timer.stop();
     cout.imbue(locale(""));
     cout << "compile time: " << timer.get_milliseconds() << "ms" << endl;
-    backend->enable_performance_data(handle, timing_detail);
 
     vector<shared_ptr<runtime::HostTensor>> arg_data;
     vector<shared_ptr<runtime::Tensor>> args;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,14 +72,14 @@ if (NGRAPH_INTERPRETER_ENABLE)
     list(APPEND SRC
         backend_debug_api.cpp
         builder.cpp
-        backend_api.cpp
-        hybrid_backend.cpp
-        hybrid_utils.cpp)
+        backend_api.cpp)
     set(ACTIVE_BACKEND_LIST ${ACTIVE_BACKEND_LIST} INTERPRETER)
 endif()
 
 if (NGRAPH_HYBRID_ENABLE)
-    set(SRC ${SRC} hybrid_backend.cpp)
+    list(APPEND SRC
+        hybrid_backend.cpp
+        hybrid_utils.cpp)
 endif()
 
 if (NGRAPH_CPU_ENABLE)

--- a/test/autodiff.in.cpp
+++ b/test/autodiff.in.cpp
@@ -69,7 +69,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_maxpool_n4_c1_hw4_2x2_max)
 
     auto C = make_shared<op::Parameter>(element::i32, maxpool_shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {output}, {input, ep});
+    backend->call_with_validate(backend->compile(df), {output}, {input, ep});
     ASSERT_TRUE(read_vector<int>(output) == expected);
 }
 
@@ -107,7 +107,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_maxpool_n2_c1_hw5_3x3_str2_max)
 
     auto C = make_shared<op::Parameter>(element::i32, maxpool_shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {output}, {input, ep});
+    backend->call_with_validate(backend->compile(df), {output}, {input, ep});
     ASSERT_TRUE(read_vector<int>(output) == expected);
 }
 
@@ -148,7 +148,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_maxpool_n2_c1_hw5_3x3_str2_max_pad1x2_2x3
 
     auto C = make_shared<op::Parameter>(element::f32, maxpool_shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {output}, {input, ep});
+    backend->call_with_validate(backend->compile(df), {output}, {input, ep});
     EXPECT_EQ(expected, read_vector<float>(output));
 }
 
@@ -184,7 +184,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_avgpool_n1_c1_hw2x2)
 
     auto C = make_shared<op::Parameter>(element::i32, avgpool_shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {output}, {input, ep});
+    backend->call_with_validate(backend->compile(df), {output}, {input, ep});
     ASSERT_TRUE(read_vector<int>(output) == dataEp);
 }
 
@@ -217,7 +217,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_avgpool_n1_c1_hw4x4)
 
     auto C = make_shared<op::Parameter>(element::i32, avgpool_shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {output}, {input, ep});
+    backend->call_with_validate(backend->compile(df), {output}, {input, ep});
     ASSERT_TRUE(read_vector<int>(output) == expected);
 }
 
@@ -316,7 +316,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_avgpool_n2_c2_hw4x4)
 
     auto C = make_shared<op::Parameter>(element::i32, avgpool_shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {output}, {input, ep});
+    backend->call_with_validate(backend->compile(df), {output}, {input, ep});
     ASSERT_TRUE(read_vector<int>(output) == expected);
 }
 
@@ -1588,7 +1588,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_maxpool_n4c1h4w4_kh2kw2_sh1sw1)
 
     auto C = make_shared<op::Parameter>(element::f32, maxpool_shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {output}, {input, ep});
+    backend->call_with_validate(backend->compile(df), {output}, {input, ep});
     ASSERT_TRUE(read_vector<float>(output) == expected);
 }
 
@@ -1625,7 +1625,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_maxpool_n2c1h5w5_kh3kw3_sh2sw2)
 
     auto C = make_shared<op::Parameter>(element::f32, maxpool_shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {output}, {input, ep});
+    backend->call_with_validate(backend->compile(df), {output}, {input, ep});
     ASSERT_TRUE(read_vector<float>(output) == expected);
 }
 
@@ -1699,7 +1699,7 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_reverse_sequence_n3_c2_h3)
 
     auto C = make_shared<op::Parameter>(element::i32, shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {da, db}, {a, b, c});
+    backend->call_with_validate(backend->compile(df), {da, db}, {a, b, c});
     ASSERT_EQ(read_vector<int>(da), expected);
 }
 
@@ -1749,6 +1749,6 @@ NGRAPH_TEST(${BACKEND_NAME}, backwards_reverse_sequence_n4d2c3h2w2)
 
     auto C = make_shared<op::Parameter>(element::i32, shape);
     auto df = autodiff::backprop_function(f);
-    backend->call_with_validate(df, {da, db}, {a, b, c});
+    backend->call_with_validate(backend->compile(df), {da, db}, {a, b, c});
     ASSERT_EQ(read_vector<int>(da), expected);
 }

--- a/test/backend_arg_reduce.in.cpp
+++ b/test/backend_arg_reduce.in.cpp
@@ -51,7 +51,7 @@ NGRAPH_TEST(${BACKEND_NAME}, argmin_trivial)
     copy_data(a, vector<float>{12, 2, 10, 9, 8, 4, 6, 1, 5, 3, 11, 7});
     auto result = backend->create_tensor(element::i32, rshape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int>{3, 2, 1}), read_vector<int>(result));
 }
 
@@ -88,7 +88,7 @@ NGRAPH_TEST(${BACKEND_NAME}, argmin_4D_axis_3_i64)
                                          {1.0f, 0.0f, 0.0f, 0.0f, 2.0f}}}})
                   .get_vector());
     auto result = backend->create_tensor(element::i64, rshape);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<int64_t, 3>({{{0, 4, 1, 1, 3},   // ch0
                                            {4, 1, 3, 2, 1}},  //
                                           {{0, 1, 0, 2, 0},   // ch1
@@ -130,7 +130,7 @@ NGRAPH_TEST(${BACKEND_NAME}, argmin_4D_axis_3)
                                          {1.0f, 0.0f, 0.0f, 0.0f, 2.0f}}}})
                   .get_vector());
     auto result = backend->create_tensor(element::i32, rshape);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<int, 3>({{{0, 4, 1, 1, 3},   // ch0
                                        {4, 1, 3, 2, 1}},  //
                                       {{0, 1, 0, 2, 0},   // ch1
@@ -154,7 +154,7 @@ NGRAPH_TEST(${BACKEND_NAME}, argmax_trivial)
     copy_data(a, vector<float>{9, 2, 10, 12, 8, 4, 6, 1, 5, 3, 11, 7});
     auto result = backend->create_tensor(element::i32, rshape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int>{1, 3, 0}), read_vector<int>(result));
 }
 
@@ -189,7 +189,7 @@ NGRAPH_TEST(${BACKEND_NAME}, argmax_3D_axis_0) // Along Channels
                   .get_vector());
     auto result = backend->create_tensor(element::i32, rshape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<int, 2>({{0, 1},  //r0
                                       {0, 0},  //r1
                                       {1, 0},  //r2
@@ -228,7 +228,7 @@ NGRAPH_TEST(${BACKEND_NAME}, argmax_3D_axis_1) // Along Height
                   .get_vector());
     auto result = backend->create_tensor(element::i32, rshape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<int, 2>({{1, 1}, //
                                       {1, 3}, //
                                       {3, 3}})
@@ -266,7 +266,7 @@ NGRAPH_TEST(${BACKEND_NAME}, argmax_3D_axis_2) // Along Width
                   .get_vector());
     auto result = backend->create_tensor(element::i32, rshape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<int, 2>({{0, 0, 1, 1},  //
                                       {1, 0, 0, 1},  //
                                       {0, 0, 0, 0}}) //
@@ -313,7 +313,7 @@ NGRAPH_TEST(${BACKEND_NAME}, argmax_4D_axis_3)
                   .get_vector());
     auto result = backend->create_tensor(element::i32, rshape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<int, 3>({{{3, 1, 0, 0, 1}, {3, 2, 0, 0, 0}},  //ch0
                                       {{1, 2, 4, 3, 0}, {0, 1, 2, 0, 4}}}) //ch1
                    .get_vector()),

--- a/test/backend_binary_elementwise.in.cpp
+++ b/test/backend_binary_elementwise.in.cpp
@@ -51,7 +51,7 @@ NGRAPH_TEST(${BACKEND_NAME}, add)
     copy_data(a, test::NDArray<float, 2>({{1, 2}, {3, 4}}).get_vector());
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{6, 8}, {10, 12}})).get_vector());
 }
@@ -73,7 +73,7 @@ NGRAPH_TEST(${BACKEND_NAME}, add_overload)
     copy_data(a, test::NDArray<float, 2>({{1, 2}, {3, 4}}).get_vector());
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{6, 8}, {10, 12}})).get_vector());
 }
@@ -95,7 +95,7 @@ NGRAPH_TEST(${BACKEND_NAME}, multiply)
     copy_data(a, test::NDArray<float, 2>({{1, 2}, {3, 4}}).get_vector());
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{5, 12}, {21, 32}})).get_vector());
 }
@@ -117,7 +117,7 @@ NGRAPH_TEST(${BACKEND_NAME}, multiply_overload)
     copy_data(a, test::NDArray<float, 2>({{1, 2}, {3, 4}}).get_vector());
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{5, 12}, {21, 32}})).get_vector());
 }
@@ -139,7 +139,7 @@ NGRAPH_TEST(${BACKEND_NAME}, divide)
     copy_data(b, vector<float>{1, 2, 4, 8});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{2, 2, 2, 2}), read_vector<float>(result));
 }
 
@@ -160,7 +160,7 @@ NGRAPH_TEST(${BACKEND_NAME}, divide_overload)
     copy_data(b, vector<float>{1, 2, 4, 8});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{2, 2, 2, 2}), read_vector<float>(result));
 }
 
@@ -205,7 +205,7 @@ NGRAPH_TEST(${BACKEND_NAME}, divide_adjoint_stability)
     auto resulta = backend->create_tensor(element::f32, shape);
     auto resultb = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(bf, {resulta, resultb}, {a, b, c});
+    backend->call_with_validate(backend->compile(bf), {resulta, resultb}, {a, b, c});
     EXPECT_EQ((vector<float>{0.5, 0.5, 0.5, 0.5}), read_vector<float>(resulta));
     EXPECT_EQ((vector<float>{-0.0, -0.0, -0.25, -0.25}), read_vector<float>(resultb));
 }
@@ -227,7 +227,7 @@ NGRAPH_TEST(${BACKEND_NAME}, divide_by_zero_float32)
     copy_data(b, vector<float>{0, 0, 0, 0});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{std::numeric_limits<float>::infinity(),
                              std::numeric_limits<float>::infinity(),
                              std::numeric_limits<float>::infinity(),
@@ -261,7 +261,7 @@ NGRAPH_TEST(${BACKEND_NAME}, divide_by_zero_int32)
         {
             try
             {
-                backend->call_with_validate(f, {result}, {a, b});
+                backend->call_with_validate(backend->compile(f), {result}, {a, b});
             }
             catch (...)
             {
@@ -289,7 +289,7 @@ NGRAPH_TEST(${BACKEND_NAME}, maximum)
     copy_data(b, vector<float>{1, 2, 4, 8, 0, 0, 1, 1.5});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{1, 8, 4, 17, 0, 0.5, 2, 1.5}), read_vector<float>(result));
 }
 
@@ -309,7 +309,7 @@ NGRAPH_TEST(${BACKEND_NAME}, minimum)
     copy_data(b, vector<float>{1, 2, 4, 8, 0, 0, 1, 1.5});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{1, 2, -8, 8, -.5, 0, 1, 1}), read_vector<float>(result));
 }
 
@@ -329,7 +329,7 @@ NGRAPH_TEST(${BACKEND_NAME}, minimum_int32)
     copy_data(b, vector<int32_t>{1, 2, 4, 8, 0, 18448, 1, 6});
     auto result = backend->create_tensor(element::i32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<int32_t>{1, 2, -8, 8, -5, 18448, 1, 1}), read_vector<int32_t>(result));
 }
 
@@ -349,7 +349,7 @@ NGRAPH_TEST(${BACKEND_NAME}, minimum_int64)
     copy_data(b, vector<int64_t>{1, 2, 4, 8, 0, 18448, 1, 280592});
     auto result = backend->create_tensor(element::i64, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<int64_t>{1, 2, -8, 8, -5, 18448, 1, 280592}), read_vector<int64_t>(result));
 }
 
@@ -369,7 +369,7 @@ NGRAPH_TEST(${BACKEND_NAME}, maximum_int32)
     copy_data(b, vector<int32_t>{1, 2, 4, 8, 0, 18448, 1, 6});
     auto result = backend->create_tensor(element::i32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<int32_t>{1, 8, 4, 17, 0, 67635216, 2, 6}), read_vector<int32_t>(result));
 }
 
@@ -389,7 +389,7 @@ NGRAPH_TEST(${BACKEND_NAME}, maximum_int64)
     copy_data(b, vector<int64_t>{1, 2, 4, 8, 0, 18448, 1, 280592});
     auto result = backend->create_tensor(element::i64, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<int64_t>{1, 8, 4, 17, 0, 67635216, 2, 17179887632}),
               read_vector<int64_t>(result));
 }
@@ -410,7 +410,7 @@ NGRAPH_TEST(${BACKEND_NAME}, power)
     copy_data(b, vector<float>{2, 0, 6, 3});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_TRUE(test::all_close(vector<float>{1, 1, 729, 125}, read_vector<float>(result)));
 }
 
@@ -430,7 +430,7 @@ NGRAPH_TEST(${BACKEND_NAME}, subtract)
     copy_data(b, vector<float>{1, 2, 4, 8});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{1, 2, 4, 8}), read_vector<float>(result));
 }
 
@@ -450,6 +450,6 @@ NGRAPH_TEST(${BACKEND_NAME}, subtract_overload)
     copy_data(b, vector<float>{1, 2, 4, 8});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{1, 2, 4, 8}), read_vector<float>(result));
 }

--- a/test/backend_broadcast.in.cpp
+++ b/test/backend_broadcast.in.cpp
@@ -49,7 +49,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_scalar_vector)
     copy_data(a, vector<float>{6});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{6, 6, 6, 6}), read_vector<float>(result));
 }
 
@@ -68,7 +68,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_scalar_matrix)
     copy_data(a, vector<float>{6});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{6, 6, 6, 6}), read_vector<float>(result));
 }
 
@@ -87,7 +87,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_scalar_tensor)
     copy_data(a, vector<float>{6});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{6, 6, 6, 6, 6, 6, 6, 6}), read_vector<float>(result));
 }
 
@@ -105,7 +105,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_trivial)
     copy_data(a, vector<float>{2, 4, 6, 8, 16, 32, 64, 128});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{2, 4, 6, 8, 16, 32, 64, 128}), read_vector<float>(result));
 }
 
@@ -124,7 +124,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_vector_colwise)
     copy_data(a, vector<float>{1, 2, 3});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3}), read_vector<float>(result));
 }
 
@@ -143,7 +143,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_vector_rowwise)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -164,7 +164,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_vector_rowwise_reversed)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1}), read_vector<float>(result));
 }
 
@@ -183,7 +183,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_vector_rowwise_int64)
     copy_data(a, vector<int64_t>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::i64, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int64_t>{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}), read_vector<int64_t>(result));
 }
 
@@ -202,7 +202,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_scalar_to_matrix_int64)
     copy_data(a, vector<int64_t>{4});
     auto result = backend->create_tensor(element::i64, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int64_t>{4, 4, 4}), read_vector<int64_t>(result));
 }
 
@@ -221,7 +221,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_scalar_to_matrix_int32)
     copy_data(a, vector<int32_t>{4});
     auto result = backend->create_tensor(element::i32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int32_t>{4, 4, 4}), read_vector<int32_t>(result));
 }
 
@@ -247,8 +247,8 @@ static void broadcast_test_helper(const Shape& shape_a, const Shape& shape_r, co
     auto wrk_result = wrk_backend->create_tensor(element::f32, shape_r);
     auto ref_result = ref_backend->create_tensor(element::f32, shape_r);
 
-    wrk_backend->call_with_validate(f, {wrk_result}, {wrk_a});
-    ref_backend->call_with_validate(f, {ref_result}, {ref_a});
+    wrk_backend->call_with_validate(wrk_backend->compile(f), {wrk_result}, {wrk_a});
+    ref_backend->call_with_validate(ref_backend->compile(f), {ref_result}, {ref_a});
     EXPECT_EQ(read_vector<float>(ref_result), read_vector<float>(wrk_result));
 }
 
@@ -386,7 +386,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_matrix_0)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -405,7 +405,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_matrix_1)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 1, 2, 3, 4, 3, 4}), read_vector<float>(result));
 }
 
@@ -424,7 +424,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_matrix_2)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 1, 2, 2, 3, 3, 4, 4}), read_vector<float>(result));
 }
 

--- a/test/backend_comparison.in.cpp
+++ b/test/backend_comparison.in.cpp
@@ -54,7 +54,7 @@ NGRAPH_TEST(${BACKEND_NAME}, equal)
     copy_data(b, vector<float>{1, 8, 4, 8, 0, 0, 1, 1.5});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<char>{1, 1, 0, 0, 0, 1, 1, 0}), read_vector<char>(result));
 }
 
@@ -74,7 +74,7 @@ NGRAPH_TEST(${BACKEND_NAME}, notequal)
     copy_data(b, vector<float>{1, 8, 4, 8, 0, 0, 1, 1.5});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<char>{0, 0, 1, 1, 1, 0, 0, 1}), read_vector<char>(result));
 }
 
@@ -94,7 +94,7 @@ NGRAPH_TEST(${BACKEND_NAME}, greater)
     copy_data(b, vector<float>{1, 2, 4, 8, 0, 0, 1, 1.5});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<char>{0, 1, 0, 1, 0, 1, 1, 0}), read_vector<char>(result));
 }
 
@@ -114,7 +114,7 @@ NGRAPH_TEST(${BACKEND_NAME}, greatereq)
     copy_data(b, vector<float>{1, 2, -8, 8, 0, 0, 0.5, 1.5});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<char>{1, 1, 1, 1, 0, 1, 1, 0}), read_vector<char>(result));
 }
 
@@ -134,7 +134,7 @@ NGRAPH_TEST(${BACKEND_NAME}, less)
     copy_data(b, vector<float>{1, 2, 4, 8, 0, 0, 1, 1.5});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<char>{0, 0, 1, 0, 1, 0, 0, 1}), read_vector<char>(result));
 }
 
@@ -154,7 +154,7 @@ NGRAPH_TEST(${BACKEND_NAME}, lesseq)
     copy_data(b, vector<float>{1, 2, -8, 8, 0, 0, 0.5, 1.5});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<char>{1, 0, 1, 0, 1, 1, 0, 1}), read_vector<char>(result));
 }
 
@@ -177,6 +177,6 @@ NGRAPH_TEST(${BACKEND_NAME}, lesseq_bool)
     // Overwrite the initial result vector to make sure we're not just coincidentally getting the right value.
     copy_data(result, vector<char>{1, 1, 1, 1, 1, 1, 1, 1});
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<char>{0, 0, 0, 0, 0, 0, 0, 0}), read_vector<char>(result));
 }

--- a/test/backend_debug_api.cpp
+++ b/test/backend_debug_api.cpp
@@ -47,8 +47,9 @@ TEST(INTERPRETER, nan_check_input)
     copy_data(b, vector<float>{1, 2, 1, 8});
     auto result = backend->create_tensor(element::f32, shape);
 
-    ibackend->set_nan_check(f, true);
-    EXPECT_ANY_THROW(ibackend->call_with_validate(f, {result}, {a, b}));
+    auto handle = backend->compile(f);
+    ibackend->set_nan_check(handle, true);
+    EXPECT_ANY_THROW(ibackend->call_with_validate(handle, {result}, {a, b}));
 }
 
 TEST(INTERPRETER, nan_check_output)
@@ -70,6 +71,7 @@ TEST(INTERPRETER, nan_check_output)
     copy_data(b, vector<float>{1, 2, 0, 8});
     auto result = backend->create_tensor(element::f32, shape);
 
-    ibackend->set_nan_check(f, true);
-    EXPECT_ANY_THROW(ibackend->call_with_validate(f, {result}, {a, b}));
+    auto handle = backend->compile(f);
+    ibackend->set_nan_check(handle, true);
+    EXPECT_ANY_THROW(ibackend->call_with_validate(handle, {result}, {a, b}));
 }

--- a/test/backend_dot.in.cpp
+++ b/test/backend_dot.in.cpp
@@ -91,7 +91,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_4d_5d_multi_axis)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(
         (vector<float>{6942.,  7020.,  7098.,  7176.,  7254.,  7332.,  7410.,  7488.,  7566.,
                        7644.,  7722.,  7800.,  16590., 16812., 17034., 17256., 17478., 17700.,
@@ -150,7 +150,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_4d_5d_multi_axis_more)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{251412., 254040.}), read_vector<float>(result));
 }
 
@@ -212,7 +212,7 @@ NGRAPH_TEST(DISABLED_${BACKEND_NAME}, dot_4d_5d_multi_axis_big_fp64_VERY_SLOW)
 
     auto result = backend->create_tensor(element::f64, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_TRUE(test::all_close(
         vector<double>{
             2.48832025919525478400e+18, 2.48832051839533977600e+18, 2.48832077759658444800e+18,
@@ -245,7 +245,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_0_0)
     // Overwrite the initial result vector to make sure we're not just coincidentally getting the right value.
     copy_data(result, vector<float>{2112});
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{0}), read_vector<float>(result));
 }
 
@@ -271,7 +271,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_matrix_2x0_0x2)
     // Overwrite the initial result vector to make sure we're not just coincidentally getting the right value.
     copy_data(result, vector<float>{2112, 2112, 2112, 2112});
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{0, 0, 0, 0}), read_vector<float>(result));
 }
 
@@ -294,7 +294,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_matrix_0x2_2x0)
     copy_data(b, vector<float>{});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{}), read_vector<float>(result));
 }
 
@@ -317,7 +317,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_matrix_3x2_2x0)
     copy_data(b, vector<float>{});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{}), read_vector<float>(result));
 }
 
@@ -339,7 +339,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_scalar_0x2)
     copy_data(b, vector<float>{});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{}), read_vector<float>(result));
 }
 
@@ -364,7 +364,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_2x0_0)
     // Overwrite the initial result vector to make sure we're not just coincidentally getting the right value.
     copy_data(result, vector<float>{2112, 2112});
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{0, 0}), read_vector<float>(result));
 }
 
@@ -385,7 +385,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot1d)
     copy_data(b, vector<float>{1, 2, 4, 8});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{170}), read_vector<float>(result));
 }
 
@@ -406,7 +406,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot2d)
     copy_data(b, vector<float>{5, 6, 7, 8});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{19, 22, 43, 50}), read_vector<float>(result));
 }
 
@@ -450,7 +450,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot3d_3d)
     copy_data(b, vector<float>{1, 2, 3, 4, 5, 6, 7, 8});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{11, 14, 17, 20, 23, 30, 37, 44, 35, 46, 57, 68, 47, 62, 77, 92}),
               read_vector<float>(result));
 }
@@ -497,7 +497,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot3d_2d)
     copy_data(b, vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{20,  23,  26,  29,  56,  68,  80,  92,  92,  113, 134,
                              155, 128, 158, 188, 218, 164, 203, 242, 281, 200, 248,
                              296, 344, 236, 293, 350, 407, 272, 338, 404, 470}),
@@ -521,7 +521,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_scalar_tensor_arg0)
     copy_data(b, vector<float>{1, 2, 3, 4, 5, 6, 7, 8});
     auto result = backend->create_tensor(element::f32, shape_b);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{6, 12, 18, 24, 30, 36, 42, 48}), read_vector<float>(result));
 }
 
@@ -542,7 +542,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_scalar_tensor_arg1)
     copy_data(b, vector<float>{6});
     auto result = backend->create_tensor(element::f32, shape_a);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{6, 12, 18, 24, 30, 36, 42, 48}), read_vector<float>(result));
 }
 
@@ -562,7 +562,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_scalar_scalar)
     copy_data(b, vector<float>{6});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{48}), read_vector<float>(result));
 }
 
@@ -584,7 +584,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_matrix_vector_4_3)
     copy_data(b, vector<float>{17, 18, 19});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{110, 272, 434, 596}), read_vector<float>(result));
 }
 
@@ -606,7 +606,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_matrix_vector)
     copy_data(b, vector<float>{17, 18, 19, 20});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{190, 486, 782, 1078}), read_vector<float>(result));
 }
 
@@ -628,7 +628,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_matrix_vector_int64)
     copy_data(b, vector<int64_t>{17, 18, 19, 20});
     auto result = backend->create_tensor(element::i64, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<int64_t>{190, 486, 782, 1078}), read_vector<int64_t>(result));
 }
 
@@ -679,7 +679,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_3d_multi_axis)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{2938., 3016., 3094., 3172., 3250., 7042., 7264., 7486., 7708., 7930.}),
               read_vector<float>(result));
 }
@@ -728,7 +728,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dot_3d_one_axis_arbitrary)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{483,  189, 331, 86,  85,  1262, 2155, 354, 83,  18,   58,   543,  77,
                              241,  325, 286, 859, 144, 438,  1025, 317, 973, 1041, 2930, 163,  69,
                              117,  50,  29,  472, 819, 62,   785,  236, 476, 235,  175,  1521, 2387,

--- a/test/backend_one_hot.in.cpp
+++ b/test/backend_one_hot.in.cpp
@@ -49,7 +49,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_scalar_2_in_3)
     copy_data(a, vector<int32_t>{2});
     auto result = backend->create_tensor(element::i32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int32_t>{0, 0, 1}), read_vector<int32_t>(result));
 }
 
@@ -68,7 +68,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_scalar_1_in_3)
     copy_data(a, vector<int32_t>{1});
     auto result = backend->create_tensor(element::i32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int32_t>{0, 1, 0}), read_vector<int32_t>(result));
 }
 
@@ -87,7 +87,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_scalar_0_in_3)
     copy_data(a, vector<int32_t>{0});
     auto result = backend->create_tensor(element::i32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int32_t>{1, 0, 0}), read_vector<int32_t>(result));
 }
 
@@ -108,7 +108,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_scalar_fp_nonint_in_3)
 
     try
     {
-        backend->call_with_validate(f, {result}, {a});
+        backend->call_with_validate(backend->compile(f), {result}, {a});
     }
     catch (const std::exception& e)
     {
@@ -137,7 +137,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_scalar_oob_in_3)
 
     try
     {
-        backend->call_with_validate(f, {result}, {a});
+        backend->call_with_validate(backend->compile(f), {result}, {a});
     }
     catch (const std::exception& e)
     {
@@ -164,7 +164,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_vector_0)
     copy_data(a, vector<int32_t>{2, 1, 0, 0, 2, 2, 1, 0});
     auto result = backend->create_tensor(element::i32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (vector<int32_t>{0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 0}),
         read_vector<int32_t>(result));
@@ -185,7 +185,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_vector_1)
     copy_data(a, vector<int32_t>{2, 1, 0, 0, 2, 2, 1, 0});
     auto result = backend->create_tensor(element::i32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (vector<int32_t>{0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0}),
         read_vector<int32_t>(result));
@@ -208,7 +208,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_vector_1_barely_oob)
 
     try
     {
-        backend->call_with_validate(f, {result}, {a});
+        backend->call_with_validate(backend->compile(f), {result}, {a});
     }
     catch (const std::exception& e)
     {
@@ -237,7 +237,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_vector_1_far_oob)
 
     try
     {
-        backend->call_with_validate(f, {result}, {a});
+        backend->call_with_validate(backend->compile(f), {result}, {a});
     }
     catch (const std::exception& e)
     {
@@ -267,7 +267,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_matrix_0)
               });
     auto result = backend->create_tensor(element::i32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int32_t>{1, 0, 0, 0, 0, 1, 1, 0, 0,
 
                                0, 1, 1, 0, 1, 0, 0, 0, 1,
@@ -291,7 +291,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_vector_1_fp)
     copy_data(a, vector<float>{2, 1, 0, 0, 2, 2, 1, 0});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (vector<float>{0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0}),
         read_vector<float>(result));
@@ -314,7 +314,7 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_vector_1_fp_nonint)
 
     try
     {
-        backend->call_with_validate(f, {result}, {a});
+        backend->call_with_validate(backend->compile(f), {result}, {a});
     }
     catch (const std::exception& e)
     {

--- a/test/backend_performance.cpp
+++ b/test/backend_performance.cpp
@@ -99,7 +99,7 @@ TEST(benchmark, concat_32x1x200_axis1_6)
         result_tvs.push_back(result_tv);
 
         std::function<void()> cb = [&]() {
-            backend->call_with_validate(f, {result_tv}, input_vals);
+            backend->call_with_validate(backend->compile(f), {result_tv}, input_vals);
         };
 
         test_callbacks.push_back(cb);

--- a/test/backend_pool.in.cpp
+++ b/test/backend_pool.in.cpp
@@ -52,7 +52,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_pool_1d_1channel_1image)
               test::NDArray<float, 3>{{{0, 1, 0, 2, 1, 0, 3, 2, 0, 0, 2, 0, 0, 0}}}.get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>({{{1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 2, 0}}}).get_vector()),
               read_vector<float>(result));
 }
@@ -76,7 +76,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_pool_1d_1channel_2image)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>(
                    {{{1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 2, 0}}, {{2, 2, 1, 1, 0, 2, 2, 2, 1, 1, 1, 2}}})
                    .get_vector()),
@@ -105,7 +105,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_pool_1d_2channel_2image)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>(
                    {{{1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 2, 0}, {0, 2, 2, 2, 2, 3, 3, 3, 2, 2, 2, 1}},
 
@@ -154,7 +154,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_pool_2d_2channel_2image)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 4>({{{{3, 3, 2}, // img 0 chan 0
                                           {3, 3, 2},
                                           {2, 1, 2},
@@ -221,7 +221,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_pool_2d_2channel_2image_asym_pad)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 4>({{{{3, 2}, // img 0 chan 0
                                           {2, 1}},
 
@@ -273,7 +273,7 @@ NGRAPH_TEST_F(${BACKEND_NAME}, MaxPool2D1ChannelTests, max_pool_2d_1channel_1ima
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     auto min = std::numeric_limits<float>::lowest();
     EXPECT_TRUE(test::all_close(test::NDArray<float, 4>({{{{min, min, min, min, min},
                                                            {1, 2, 2, 2, 1},
@@ -310,7 +310,7 @@ NGRAPH_TEST_F(${BACKEND_NAME}, MaxPool2D1ChannelTests, max_pool_2d_1channel_1ima
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 4>({{{{1, 2, 2, 2, 1},
                                           {3, 3, 2, 2, 1},
                                           {3, 3, 2, 1, 1},
@@ -351,7 +351,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_pool_2d_1channel_1image_padded_negative_values)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (test::NDArray<float, 4>({{{{-1, -1, -2, -2, -1, -1, -1, -2, -2, -2, -2, -2, -3, -4, -5}}}})
              .get_vector()),
@@ -384,7 +384,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_pool_2d_1channel_1image_strided)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 4>({{{{3, 2, 2}, {2, 2, 3}, {2, 2, 2}}}}).get_vector()),
               read_vector<float>(result));
 }
@@ -441,7 +441,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_1d_1channel_1image)
 
     float denom = 3.0;
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(test::NDArray<float, 3>({{{1 / denom,
                                                              3 / denom,
                                                              3 / denom,
@@ -479,7 +479,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_1d_1channel_2image)
 
     float denom = 3.0;
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(test::NDArray<float, 3>({{{1 / denom,
                                                              3 / denom,
                                                              3 / denom,
@@ -532,7 +532,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_1d_2channel_2image)
 
     float denom = 3.0;
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(test::NDArray<float, 3>({{{1 / denom,
                                                              3 / denom,
                                                              3 / denom,
@@ -628,7 +628,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_2channel_2image)
 
     float denom = 2 * 3;
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
 
     EXPECT_TRUE(test::all_close_f(
         test::NDArray<float, 4>({{{{6 / denom, 8 / denom, 5 / denom}, // img 0 chan 0
@@ -682,7 +682,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_1channel_1image_strided)
 
     float denom = 2 * 3;
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(test::NDArray<float, 4>({{{{6 / denom, 5 / denom, 4 / denom},
                                                              {6 / denom, 5 / denom, 8 / denom},
                                                              {6 / denom, 2 / denom, 4 / denom}}}})
@@ -711,7 +711,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_1channel_1image_padded_do_not_include_i
     copy_data(a, test::NDArray<float, 4>({{{{0, 1, 0}, {0, 3, 2}, {2, 0, 0}}}}).get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(
         test::all_close(test::NDArray<float, 4>({{{{0.0f / 1, 1.0f / 2, 1.0f / 2, 0.0f / 1},
                                                    {0.0f / 2, 4.0f / 4, 6.0f / 4, 2.0f / 2},
@@ -742,7 +742,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_1channel_1image_padded_include_in_compu
     copy_data(a, test::NDArray<float, 4>({{{{0, 1, 0}, {0, 3, 2}, {2, 0, 0}}}}).get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(
         test::all_close(test::NDArray<float, 4>({{{{0.0f / 4, 1.0f / 4, 1.0f / 4, 0.0f / 4},
                                                    {0.0f / 4, 4.0f / 4, 6.0f / 4, 2.0f / 4},
@@ -776,7 +776,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_2channel_2image_padded_do_not_include_i
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(
         test::all_close(test::NDArray<float, 4>({{{{0.0f / 1, 1.0f / 2, 1.0f / 2, 0.0f / 1},
                                                    {0.0f / 2, 4.0f / 4, 6.0f / 4, 2.0f / 2},
@@ -814,7 +814,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_2channel_2image_padded_include_in_compu
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(
         test::all_close(test::NDArray<float, 4>({{{{0.0f / 4, 1.0f / 4, 1.0f / 4, 0.0f / 4},
                                                    {0.0f / 4, 4.0f / 4, 6.0f / 4, 2.0f / 4},
@@ -853,7 +853,7 @@ NGRAPH_TEST(${BACKEND_NAME},
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close(test::NDArray<float, 4>({{{{0.0f / 1, 1.0f / 2, 1.0f / 2},
                                                            {0.0f / 2, 4.0f / 4, 6.0f / 4},
                                                            {2.0f / 2, 5.0f / 4, 5.0f / 4}},
@@ -888,7 +888,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_2channel_2image_padded_only_below_inclu
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close(test::NDArray<float, 4>({{{{0.0f / 4, 1.0f / 4, 1.0f / 4},
                                                            {0.0f / 4, 4.0f / 4, 6.0f / 4},
                                                            {2.0f / 4, 5.0f / 4, 5.0f / 4}},
@@ -924,7 +924,7 @@ NGRAPH_TEST(${BACKEND_NAME},
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close(test::NDArray<float, 4>({{{{4.0f / 4, 6.0f / 4, 2.0f / 2},
                                                            {5.0f / 4, 5.0f / 4, 2.0f / 2},
                                                            {2.0f / 2, 0.0f / 2, 0.0f / 1}},
@@ -959,7 +959,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_2channel_2image_padded_only_above_inclu
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close(test::NDArray<float, 4>({{{{4.0f / 4, 6.0f / 4, 2.0f / 4},
                                                            {5.0f / 4, 5.0f / 4, 2.0f / 4},
                                                            {2.0f / 4, 0.0f / 4, 0.0f / 4}},
@@ -994,7 +994,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_2channel_2image_3x3_padded_do_not_inclu
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(
         test::NDArray<float, 4>({{{{0.0f / 1, 1.0f / 2, 1.0f / 3, 1.0f / 2, 0.0f / 1},
                                    {0.0f / 2, 4.0f / 4, 6.0f / 6, 6.0f / 4, 2.0f / 2},
@@ -1034,7 +1034,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_2channel_2image_3x3_padded_include_in_c
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(
         test::NDArray<float, 4>({{{{0.0f / 9, 1.0f / 9, 1.0f / 9, 1.0f / 9, 0.0f / 9},
                                    {0.0f / 9, 4.0f / 9, 6.0f / 9, 6.0f / 9, 2.0f / 9},
@@ -1075,7 +1075,7 @@ NGRAPH_TEST(${BACKEND_NAME},
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(test::NDArray<float, 4>({{{{0.0f / 1, 1.0f / 3, 0.0f / 1},
                                                              {2.0f / 3, 8.0f / 9, 2.0f / 3},
                                                              {2.0f / 1, 2.0f / 3, 0.0f / 1}},
@@ -1110,7 +1110,7 @@ NGRAPH_TEST(${BACKEND_NAME}, avg_pool_2d_2channel_2image_3x3_strided_padded_incl
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(test::NDArray<float, 4>({{{{0.0f / 9, 1.0f / 9, 0.0f / 9},
                                                              {2.0f / 9, 8.0f / 9, 2.0f / 9},
                                                              {2.0f / 9, 2.0f / 9, 0.0f / 9}},
@@ -1146,7 +1146,7 @@ NGRAPH_TEST(${BACKEND_NAME},
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(
         test::NDArray<float, 4>(
             {{{{0.0f / 1, 1.0f / 2}, {2.0f / 3, 6.0f / 6}, {2.0f / 1, 0.0f / 2}},
@@ -1180,7 +1180,7 @@ NGRAPH_TEST(${BACKEND_NAME},
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(
         test::NDArray<float, 4>(
             {{{{0.0f / 9, 1.0f / 9}, {2.0f / 9, 6.0f / 9}, {2.0f / 9, 0.0f / 9}},

--- a/test/backend_reduce.in.cpp
+++ b/test/backend_reduce.in.cpp
@@ -58,7 +58,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_trivial)
     copy_data(b, vector<float>{0});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(g, {result}, {a, b});
+    backend->call_with_validate(backend->compile(g), {result}, {a, b});
     EXPECT_EQ((vector<float>{1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -85,7 +85,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_to_scalar)
     copy_data(b, vector<float>{0});
     auto result = backend->create_tensor(element::f32, Shape{});
 
-    backend->call_with_validate(g, {result}, {a, b});
+    backend->call_with_validate(backend->compile(g), {result}, {a, b});
     EXPECT_EQ((vector<float>{10}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -120,7 +120,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_matrix_columns)
     copy_data(b, vector<float>{0});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(g, {result}, {a, b});
+    backend->call_with_validate(backend->compile(g), {result}, {a, b});
     EXPECT_EQ((vector<float>{9, 12}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -154,7 +154,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_matrix_rows)
     copy_data(b, vector<float>{0});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(g, {result}, {a, b});
+    backend->call_with_validate(backend->compile(g), {result}, {a, b});
     EXPECT_EQ((vector<float>{3, 7, 11}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -187,7 +187,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_matrix_rows_zero)
     copy_data(b, vector<float>{66});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(g, {result}, {a, b});
+    backend->call_with_validate(backend->compile(g), {result}, {a, b});
     EXPECT_EQ((vector<float>{66, 66, 66}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -220,7 +220,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_matrix_cols_zero)
     copy_data(b, vector<float>{77});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(g, {result}, {a, b});
+    backend->call_with_validate(backend->compile(g), {result}, {a, b});
     EXPECT_EQ((vector<float>{77, 77}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -253,7 +253,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_vector_zero)
     copy_data(b, vector<float>{88});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(g, {result}, {a, b});
+    backend->call_with_validate(backend->compile(g), {result}, {a, b});
     EXPECT_EQ((vector<float>{88}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -286,7 +286,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_matrix_to_scalar_zero_by_zero)
     copy_data(b, vector<float>{99});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(g, {result}, {a, b});
+    backend->call_with_validate(backend->compile(g), {result}, {a, b});
     EXPECT_EQ((vector<float>{99}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -321,7 +321,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_3d_to_vector)
     copy_data(b, vector<float>{1});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(g, {result}, {a, b});
+    backend->call_with_validate(backend->compile(g), {result}, {a, b});
     EXPECT_EQ((vector<float>{1.0f * 10.0f * 19.0f * 4.0f * 13.0f * 22.0f * 7.0f * 16.0f * 25.0f,
                              2.0f * 11.0f * 20.0f * 5.0f * 14.0f * 23.0f * 8.0f * 17.0f * 26.0f,
                              3.0f * 12.0f * 21.0f * 6.0f * 15.0f * 24.0f * 9.0f * 18.0f * 27.0f}),
@@ -363,7 +363,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_window_emulating_max_pool_1d_1channel_1image
             -1}); // Really should use -inf but since we know the values in the test vector this should work
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 3>({{{1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 2, 0}}}).get_vector()),
               read_vector<float>(result));
 }
@@ -402,7 +402,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_window_emulating_max_pool_1d_1channel_2image
             -1}); // Really should use -inf but since we know the values in the test vector this should work
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 3>(
                    {{{1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 2, 0}}, {{2, 2, 1, 1, 0, 2, 2, 2, 1, 1, 1, 2}}})
                    .get_vector()),
@@ -446,7 +446,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_window_emulating_max_pool_1d_2channel_2image
             -1}); // Really should use -inf but since we know the values in the test vector this should work
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 3>(
                    {{{1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 2, 0}, {0, 2, 2, 2, 2, 3, 3, 3, 2, 2, 2, 1}},
 
@@ -510,7 +510,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_window_emulating_max_pool_2d_2channel_2image
             -1}); // Really should use -inf but since we know the values in the test vector this should work
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 4>({{{{3, 3, 2}, // img 0 chan 0
                                           {3, 3, 2},
                                           {2, 1, 2},
@@ -574,7 +574,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reduce_window_emulating_max_pool_2d_1channel_1image
             -1}); // Really should use -inf but since we know the values in the test vector this should work
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 4>({{{{3, 2, 2}, {2, 2, 3}, {2, 2, 2}}}}).get_vector()),
               read_vector<float>(result));
 }

--- a/test/backend_reshape.in.cpp
+++ b/test/backend_reshape.in.cpp
@@ -49,7 +49,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_t2v_012)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}), read_vector<float>(result));
 }
 
@@ -68,7 +68,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_t2s_012)
     copy_data(a, vector<float>{6});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{6}), read_vector<float>(result));
 }
 
@@ -87,7 +87,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_t2s_120)
     copy_data(a, vector<float>{6});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{6}), read_vector<float>(result));
 }
 
@@ -106,7 +106,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_s2t)
     copy_data(a, vector<float>{42});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{42}), read_vector<float>(result));
 }
 
@@ -125,7 +125,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_s2t1)
     copy_data(a, vector<char>{42});
     auto result = backend->create_tensor(element::boolean, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<char>{42}), read_vector<char>(result));
 }
 
@@ -144,7 +144,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_v2m_col)
     copy_data(a, vector<float>{1, 2, 3});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3}), read_vector<float>(result));
 }
 
@@ -163,7 +163,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_v2m_row)
     copy_data(a, vector<float>{1, 2, 3});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3}), read_vector<float>(result));
 }
 
@@ -182,7 +182,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_v2t_middle)
     copy_data(a, vector<float>{1, 2, 3});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3}), read_vector<float>(result));
 }
 
@@ -201,7 +201,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_m2m_same)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9}), read_vector<float>(result));
 }
 
@@ -220,7 +220,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_m2m_transpose)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 4, 7, 2, 5, 8, 3, 6, 9}), read_vector<float>(result));
 }
 
@@ -239,7 +239,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_m2m_dim_change_transpose)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 3, 5, 2, 4, 6}), read_vector<float>(result));
 }
 
@@ -264,7 +264,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_3d_transpose_021)
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1,  5,  9,  2,  6,  10, 3,  7,  11, 4,  8,  12,
                              13, 17, 21, 14, 18, 22, 15, 19, 23, 16, 20, 24}),
               read_vector<float>(result));
@@ -291,7 +291,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_3d_transpose_210)
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 13, 5, 17, 9,  21, 2, 14, 6, 18, 10, 22,
                              3, 15, 7, 19, 11, 23, 4, 16, 8, 20, 12, 24}),
               read_vector<float>(result));
@@ -318,7 +318,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_3d_transpose_201)
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 5, 9,  13, 17, 21, 2, 6, 10, 14, 18, 22,
                              3, 7, 11, 15, 19, 23, 4, 8, 12, 16, 20, 24}),
               read_vector<float>(result));
@@ -345,7 +345,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_3d_transpose_102)
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1,  2,  3,  4,  13, 14, 15, 16, 5,  6,  7,  8,
                              17, 18, 19, 20, 9,  10, 11, 12, 21, 22, 23, 24}),
               read_vector<float>(result));
@@ -372,7 +372,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_3d_transpose_120)
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 13, 2, 14, 3, 15, 4,  16, 5,  17, 6,  18,
                              7, 19, 8, 20, 9, 21, 10, 22, 11, 23, 12, 24}),
               read_vector<float>(result));
@@ -399,7 +399,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_4d_transpose)
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (vector<float>{1.,  26., 2.,  27., 3.,  28., 4.,  29., 5.,  30., 6.,  31., 7.,  32., 8.,
                        33., 9.,  34., 10., 35., 11., 36., 12., 37., 13., 38., 14., 39., 15., 40.,
@@ -432,7 +432,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_4d_no_transpose)
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(a_data, read_vector<float>(result));
 }
 
@@ -451,7 +451,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_transposed_shape_change)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 7, 2, 8, 3, 9, 4, 10, 5, 11, 6, 12}), read_vector<float>(result));
 }
 
@@ -519,7 +519,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_6d)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (vector<float>{
             1.,   73.,  9.,   81.,  17.,  89.,  2.,   74.,  10.,  82.,  18.,  90.,  3.,   75.,

--- a/test/backend_sum.in.cpp
+++ b/test/backend_sum.in.cpp
@@ -51,7 +51,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_trivial)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -70,7 +70,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_trivial_5d)
                                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                              1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),
               read_vector<float>(result));
@@ -89,7 +89,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_to_scalar)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, Shape{});
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{10}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -118,7 +118,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_large_1d_to_scalar)
     copy_data(a, v_a);
     auto result = backend->create_tensor(element::f32, Shape{});
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
 
     EXPECT_TRUE(
         test::all_close_f(vector<float>{static_cast<float>(r)}, read_vector<float>(result)));
@@ -138,7 +138,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_matrix_columns)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{9, 12}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -167,8 +167,8 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_matrix_6d)
     copy_data(a_wrk, inp_data);
     copy_data(a_ref, inp_data);
 
-    backend_wrk->call_with_validate(f, {result_wrk}, {a_wrk});
-    backend_ref->call_with_validate(f, {result_ref}, {a_ref});
+    backend_wrk->call_with_validate(backend_wrk->compile(f), {result_wrk}, {a_wrk});
+    backend_ref->call_with_validate(backend_ref->compile(f), {result_ref}, {a_ref});
 
     EXPECT_EQ(read_vector<float>(result_ref), read_vector<float>(result_wrk));
 }
@@ -187,7 +187,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_matrix_rows)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{3, 7, 11}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -210,7 +210,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_matrix_rows_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3, 3, 3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{0, 0, 0}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -234,7 +234,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_matrix_cols_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3, 3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{0, 0}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -257,7 +257,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_vector_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{0}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -280,7 +280,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_matrix_to_scalar_zero_by_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{0}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -303,7 +303,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_3d_to_matrix_most_sig)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1 + 10 + 19,
                              2 + 11 + 20,
                              3 + 12 + 21,
@@ -331,7 +331,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_3d_to_matrix_least_sig)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1 + 2 + 3,
                              4 + 5 + 6,
                              7 + 8 + 9,
@@ -359,7 +359,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_3d_to_vector)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1 + 10 + 19 + 4 + 13 + 22 + 7 + 16 + 25,
                              2 + 11 + 20 + 5 + 14 + 23 + 8 + 17 + 26,
                              3 + 12 + 21 + 6 + 15 + 24 + 9 + 18 + 27}),
@@ -382,7 +382,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_3d_to_scalar)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1 + 10 + 19 + 4 + 13 + 22 + 7 + 16 + 25 + 2 + 11 + 20 + 5 + 14 + 23 +
                              8 + 17 + 26 + 3 + 12 + 21 + 6 + 15 + 24 + 9 + 18 + 27}),
               read_vector<float>(result));
@@ -405,7 +405,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_3d_eliminate_zero_dim)
     // Overwrite the initial result vector to make sure we're not just coincidentally getting the right value.
     copy_data(result, vector<float>{2112, 2112, 2112, 2112, 2112, 2112});
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{0, 0, 0, 0, 0, 0}), read_vector<float>(result));
 }
 
@@ -424,6 +424,6 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_5d_to_scalar)
     copy_data(a, std::vector<float>(std::pow(3, 5), 1));
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(std::vector<float>{243.}, read_vector<float>(result));
 }

--- a/test/backend_test.in.cpp
+++ b/test/backend_test.in.cpp
@@ -83,7 +83,7 @@ NGRAPH_TEST(${BACKEND_NAME}, unhandled_op)
 
     shared_ptr<runtime::Tensor> a = backend->create_tensor<float>(shape);
     shared_ptr<runtime::Tensor> result = backend->create_tensor<float>(shape);
-    ASSERT_THROW(backend->call_with_validate(f, {result}, {a}), unsupported_op);
+    ASSERT_THROW(backend->call_with_validate(backend->compile(f), {result}, {a}), unsupported_op);
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, function_name)
@@ -103,7 +103,7 @@ NGRAPH_TEST(${BACKEND_NAME}, function_name)
     copy_data(a, test::NDArray<float, 2>({{1, 2}, {3, 4}}).get_vector());
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{6, 8}, {10, 12}})).get_vector());
 }
@@ -127,7 +127,7 @@ NGRAPH_TEST(${BACKEND_NAME}, node_name)
     copy_data(a, test::NDArray<float, 2>({{1, 2}, {3, 4}}).get_vector());
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{6, 8}, {10, 12}})).get_vector());
 }
@@ -161,7 +161,8 @@ NGRAPH_TEST(${BACKEND_NAME}, aliased_output)
     vector<float> expectedD{0, 2, 6, 12};
     vector<float> expectedE{1, 2, 3, 4};
 
-    backend->call_with_validate(f, {out1, out2, out3, out4, out5, out6, out7}, {a, b});
+    backend->call_with_validate(
+        backend->compile(f), {out1, out2, out3, out4, out5, out6, out7}, {a, b});
     EXPECT_EQ(expectedC, read_vector<float>(out1));
     EXPECT_EQ(expectedC, read_vector<float>(out2));
     EXPECT_EQ(expectedD, read_vector<float>(out3));
@@ -187,7 +188,7 @@ NGRAPH_TEST(${BACKEND_NAME}, parameter_as_output)
     vector<float> zero(shape_size(shape), 0);
     copy_data(a, expected);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(read_vector<float>(result), expected);
 }
 
@@ -211,15 +212,15 @@ NGRAPH_TEST(${BACKEND_NAME}, abc)
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
     copy_data(c, test::NDArray<float, 2>({{9, 10}, {11, 12}}).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{54, 80}, {110, 144}})).get_vector());
 
-    backend->call_with_validate(f, {result}, {b, a, c});
+    backend->call_with_validate(backend->compile(f), {result}, {b, a, c});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{54, 80}, {110, 144}})).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, c, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, c, b});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{50, 72}, {98, 128}})).get_vector());
 }
@@ -243,13 +244,13 @@ NGRAPH_TEST(${BACKEND_NAME}, abc_int64)
     copy_data(c, vector<int64_t>{9, 10, 11, 12});
     auto result = backend->create_tensor(element::i64, shape);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<int64_t>{54, 80, 110, 144}), read_vector<int64_t>(result));
 
-    backend->call_with_validate(f, {result}, {b, a, c});
+    backend->call_with_validate(backend->compile(f), {result}, {b, a, c});
     EXPECT_EQ((vector<int64_t>{54, 80, 110, 144}), read_vector<int64_t>(result));
 
-    backend->call_with_validate(f, {result}, {a, c, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, c, b});
     EXPECT_EQ((vector<int64_t>{50, 72, 98, 128}), read_vector<int64_t>(result));
 }
 
@@ -278,7 +279,7 @@ NGRAPH_TEST(${BACKEND_NAME}, multiple_result)
     auto r0 = backend->create_tensor(element::f32, shape);
     auto r1 = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {r0, r1}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {r0, r1}, {a, b, c});
 
     EXPECT_EQ((vector<float>{6, 8, 10, 12}), read_vector<float>(r0));
     EXPECT_EQ((vector<float>{54, 80, 110, 144}), read_vector<float>(r1));
@@ -314,7 +315,7 @@ NGRAPH_TEST(${BACKEND_NAME}, batch_norm_one_output)
     vector<double> expected_result{
         -0.09365749, -1.01327395, -1.04269195, 5.00118923, -0.43295258, -1.24840283};
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close(vector<double>{expected_result}, read_vector<double>(result)));
 }
 
@@ -350,19 +351,19 @@ NGRAPH_TEST(${BACKEND_NAME}, batch_norm_three_outputs)
     vector<double> expected_result0{
         0.3879149, -1.13662076, 1.34494817, 3.89632344, -0.37805778, -0.50073695};
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_TRUE(test::all_close(vector<double>{expected_result0}, read_vector<double>(result0)));
 
     auto result1 = backend->create_tensor(element::f64, shape_mean);
     vector<double> expected_result1{0.27972114, -1.14431989, 0.49731493};
 
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_TRUE(test::all_close(vector<double>{expected_result1}, read_vector<double>(result1)));
 
     auto result2 = backend->create_tensor(element::f64, shape_mean);
     vector<double> expected_result2{5.08068895e+00, 8.48043919e-01, 1.92784308e-03};
 
-    backend->call_with_validate(f2, {result2}, {a});
+    backend->call_with_validate(backend->compile(f2), {result2}, {a});
     EXPECT_TRUE(test::all_close(vector<double>{expected_result2}, read_vector<double>(result2)));
 }
 
@@ -389,7 +390,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_matrix_colwise)
     copy_data(c, vector<float>{2, 3, 5, 7, 11, 13});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<float>{2, 4, 1, 2, 4, 2, 3, 5, 8, 16, 8, 16, 32, 7, 11, 13}),
               read_vector<float>(result));
 }
@@ -417,7 +418,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_matrix_rowwise)
     copy_data(c, vector<float>{2, 3, 5, 7, 11, 13});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<float>{2, 4, 8, 16, 1, 2, 4, 8, 16, 32, 2, 3, 5, 7, 11, 13}),
               read_vector<float>(result));
 }
@@ -445,7 +446,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_matrix_int64)
     copy_data(c, vector<int64_t>{2, 3, 5, 7, 11, 13});
     auto result = backend->create_tensor(element::i64, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<int64_t>{2, 4, 8, 16, 1, 2, 4, 8, 16, 32, 2, 3, 5, 7, 11, 13}),
               read_vector<int64_t>(result));
 }
@@ -486,7 +487,7 @@ NGRAPH_TEST_P(${BACKEND_NAME}, concat_vector_params, concat_vector_large)
     }
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, inputs_value);
+    backend->call_with_validate(backend->compile(f), {result}, inputs_value);
     EXPECT_EQ(ref_result, read_vector<float>(result));
 }
 
@@ -522,7 +523,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_vector)
     copy_data(c, vector<float>{18, 19});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<float>{2, 4, 8, 16, 1, 2, 4, 8, 16, 32, 18, 19}), read_vector<float>(result));
 }
 
@@ -547,7 +548,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_4d_tensor)
     copy_data(c, vector<float>{3});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<float>{1, 2, 3}), read_vector<float>(result));
 }
 
@@ -572,7 +573,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_2d_tensor)
     copy_data(c, vector<float>{3});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<float>{1, 2, 3}), read_vector<float>(result));
 }
 
@@ -603,7 +604,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_in_place_2d_tensor)
     copy_data(d, vector<float>{4});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c, d});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c, d});
     EXPECT_EQ((vector<float>{3, 7, 2}), read_vector<float>(result));
 }
 
@@ -635,7 +636,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_in_place_propagate_2d_tensor)
     copy_data(d, vector<float>{4});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c, d});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c, d});
     EXPECT_EQ((vector<float>{3, 7, 2}), read_vector<float>(result));
 }
 
@@ -727,7 +728,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_5d)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ(
         (vector<float>{
             1.,    2.,    3.,    4.,    5.,    6.,    7.,    8.,    9.,    10.,   11.,   12.,
@@ -784,7 +785,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_zero_length_1d_last)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -817,7 +818,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_zero_length_1d_middle)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8}), read_vector<float>(result));
 }
 
@@ -850,7 +851,7 @@ NGRAPH_TEST(${BACKEND_NAME}, concat_zero_length_4d_middle)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<float>{1, 5, 2, 6, 3, 7, 4, 8}), read_vector<float>(result));
 }
 
@@ -868,7 +869,7 @@ NGRAPH_TEST(${BACKEND_NAME}, lrn)
     copy_data(a, args);
 
     auto result = backend->create_tensor(element::f32, shape);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
 
     vector<float> expected{0.f,
                            0.05325444f,
@@ -904,7 +905,7 @@ NGRAPH_TEST(${BACKEND_NAME}, select)
     copy_data(c, vector<float>{11, 12, 13, 14, 15, 16, 17, 18});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<float>{11, 2, 3, 14, 15, 6, 17, 8}), read_vector<float>(result));
 }
 
@@ -919,7 +920,7 @@ NGRAPH_TEST(${BACKEND_NAME}, tensor_constant)
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8}), read_vector<float>(result));
 }
 
@@ -935,7 +936,7 @@ NGRAPH_TEST(${BACKEND_NAME}, tensor_2constant)
     auto result0 = backend->create_tensor(element::f32, shape);
     auto result1 = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result0, result1}, {});
+    backend->call_with_validate(backend->compile(f), {result0, result1}, {});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8}), read_vector<float>(result0));
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8}), read_vector<float>(result1));
 }
@@ -951,7 +952,7 @@ NGRAPH_TEST(${BACKEND_NAME}, tensor_constant_with_op)
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8}), read_vector<float>(result));
 }
 
@@ -962,11 +963,13 @@ NGRAPH_TEST(${BACKEND_NAME}, constant_multi_use)
     auto backend = runtime::Backend::create("${BACKEND_NAME}");
 
     std::shared_ptr<runtime::Tensor> r1 = backend->create_tensor(element::i32, Shape{});
-    backend->call_with_validate(f, {r1}, std::vector<std::shared_ptr<runtime::Tensor>>{});
+    backend->call_with_validate(
+        backend->compile(f), {r1}, std::vector<std::shared_ptr<runtime::Tensor>>{});
     EXPECT_EQ(read_vector<int>(r1), std::vector<int>{388});
 
     std::shared_ptr<runtime::Tensor> r2 = backend->create_tensor(element::i32, Shape{});
-    backend->call_with_validate(f, {r2}, std::vector<std::shared_ptr<runtime::Tensor>>{});
+    backend->call_with_validate(
+        backend->compile(f), {r2}, std::vector<std::shared_ptr<runtime::Tensor>>{});
     EXPECT_EQ(read_vector<int>(r2), std::vector<int>{388});
 }
 
@@ -999,13 +1002,13 @@ NGRAPH_TEST(${BACKEND_NAME}, function_call)
     copy_data(z, vector<float>{9, 10, 11, 12});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(g, {result}, {x, y, z});
+    backend->call_with_validate(backend->compile(g), {result}, {x, y, z});
     EXPECT_EQ((vector<float>{254, 368, 502, 656}), read_vector<float>(result));
 
-    backend->call_with_validate(g, {result}, {y, x, z});
+    backend->call_with_validate(backend->compile(g), {result}, {y, x, z});
     EXPECT_EQ((vector<float>{278, 400, 542, 704}), read_vector<float>(result));
 
-    backend->call_with_validate(g, {result}, {x, z, y});
+    backend->call_with_validate(backend->compile(g), {result}, {x, z, y});
     EXPECT_EQ((vector<float>{194, 296, 418, 560}), read_vector<float>(result));
 }
 
@@ -1023,7 +1026,7 @@ NGRAPH_TEST(${BACKEND_NAME}, convert_int32_float32)
     copy_data(a, vector<int32_t>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -1041,7 +1044,7 @@ NGRAPH_TEST(${BACKEND_NAME}, convert_uint16_float32)
     copy_data(a, vector<uint16_t>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -1059,7 +1062,7 @@ NGRAPH_TEST(${BACKEND_NAME}, convert_int32_bool)
     copy_data(a, vector<int32_t>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<char>{1, 2, 3, 4}), read_vector<char>(result));
 }
 
@@ -1077,7 +1080,7 @@ NGRAPH_TEST(${BACKEND_NAME}, convert_float32_bool)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<char>{1, 2, 3, 4}), read_vector<char>(result));
 }
 
@@ -1096,7 +1099,7 @@ NGRAPH_TEST(${BACKEND_NAME}, slice_scalar)
     copy_data(a, vector<float>{312});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{312}), read_vector<float>(result));
 }
 
@@ -1115,7 +1118,7 @@ NGRAPH_TEST(${BACKEND_NAME}, slice_matrix)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{2, 3, 6, 7, 10, 11}), read_vector<float>(result));
 }
 
@@ -1134,7 +1137,7 @@ NGRAPH_TEST(${BACKEND_NAME}, slice_vector)
     copy_data(a, vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}), read_vector<float>(result));
 }
 
@@ -1159,7 +1162,7 @@ NGRAPH_TEST(${BACKEND_NAME}, slice_matrix_axis_0_overlap)
     copy_data(b, vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{12, 16, 20, 24, 28, 32, 36, 40}), read_vector<float>(result));
 }
 
@@ -1178,7 +1181,7 @@ NGRAPH_TEST(${BACKEND_NAME}, slice_matrix_strided)
     copy_data(a, vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{4, 7, 12, 15}), read_vector<float>(result));
 }
 
@@ -1203,7 +1206,7 @@ NGRAPH_TEST(${BACKEND_NAME}, slice_3d)
                                48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{21, 22, 25, 26, 37, 38, 41, 42}), read_vector<float>(result));
 }
 
@@ -1228,7 +1231,7 @@ NGRAPH_TEST(${BACKEND_NAME}, slice_3d_strided)
                                48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{0, 2, 8, 10, 32, 34, 40, 42}), read_vector<float>(result));
 }
 
@@ -1253,7 +1256,7 @@ NGRAPH_TEST(${BACKEND_NAME}, slice_3d_strided_different_strides)
                                48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{0, 3, 8, 11, 32, 35, 40, 43}), read_vector<float>(result));
 }
 
@@ -1267,7 +1270,7 @@ NGRAPH_TEST(${BACKEND_NAME}, scalar_constant_float32)
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::f32, Shape{});
 
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ(vector<float>{4.75f}, read_vector<float>(result));
 }
 
@@ -1281,7 +1284,7 @@ NGRAPH_TEST(${BACKEND_NAME}, scalar_constant_int64)
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::i64, Shape{});
 
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ(vector<int64_t>{2112}, read_vector<int64_t>(result));
 }
 
@@ -1296,7 +1299,7 @@ NGRAPH_TEST(${BACKEND_NAME}, tensor_constant_float32)
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ((vector<float>{4.75f, 4.5f, -5.25f, 0.0f}), read_vector<float>(result));
 }
 
@@ -1311,7 +1314,7 @@ NGRAPH_TEST(${BACKEND_NAME}, tensor_constant_int64)
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::i64, shape);
 
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ((vector<int64_t>{2112, 1848, 1776, 1964}), read_vector<int64_t>(result));
 }
 
@@ -1330,7 +1333,7 @@ NGRAPH_TEST(${BACKEND_NAME}, kahan_sum_to_scalar)
     copy_data(a, vector<float>{epsilon, -1.f, 0.f, 1.f});
     auto result = backend->create_tensor(element::f32, Shape{});
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(vector<float>{epsilon}, read_vector<float>(result)));
 }
 
@@ -1354,7 +1357,7 @@ NGRAPH_TEST(${BACKEND_NAME}, kahan_sum_3d_to_vector)
                                -1, -1, -1, -1, -1, -1, -1,        -1,        -1});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(vector<float>{epsilon_a, epsilon_b, epsilon_c},
                                   read_vector<float>(result)));
 }
@@ -1375,7 +1378,7 @@ NGRAPH_TEST(${BACKEND_NAME}, constant_equality_bool)
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ((vector<char>{true, false, true, false}), read_vector<char>(result));
 }
 
@@ -1398,7 +1401,7 @@ NGRAPH_TEST(${BACKEND_NAME}, replace_slice_scalar)
     copy_data(b, vector<float>{808});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{808}), read_vector<float>(result));
 }
 
@@ -1424,7 +1427,7 @@ NGRAPH_TEST(${BACKEND_NAME}, replace_slice_matrix_inplace)
     copy_data(b, vector<float>{102, 103, 106, 107, 110, 111});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{1, 102, 103, 4, 5, 106, 107, 8, 9, 110, 111, 12, 13, 14, 15, 16}),
               read_vector<float>(result));
 }
@@ -1448,7 +1451,7 @@ NGRAPH_TEST(${BACKEND_NAME}, replace_slice_matrix)
     copy_data(b, vector<float>{102, 103, 106, 107, 110, 111});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{1, 102, 103, 4, 5, 106, 107, 8, 9, 110, 111, 12, 13, 14, 15, 16}),
               read_vector<float>(result));
 }
@@ -1472,7 +1475,7 @@ NGRAPH_TEST(${BACKEND_NAME}, replace_slice_vector)
     copy_data(b, vector<float>{102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(
         (vector<float>{0, 1, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 14, 15}),
         read_vector<float>(result));
@@ -1503,7 +1506,7 @@ NGRAPH_TEST(${BACKEND_NAME}, replace_slice_3d)
     copy_data(b, vector<float>{921, 922, 925, 926, 937, 938, 941, 942});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{0,  1,  2,  3,  4,  5,   6,   7,  8,  9,   10,  11, 12, 13, 14, 15,
 
                              16, 17, 18, 19, 20, 921, 922, 23, 24, 925, 926, 27, 28, 29, 30, 31,
@@ -1540,7 +1543,7 @@ NGRAPH_TEST(${BACKEND_NAME}, replace_slice_3d_strided)
     copy_data(b, vector<float>{900, 902, 908, 910, 932, 934, 940, 942});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{900, 1,  902, 3,  4,  5,  6,  7,  908, 9,  910, 11, 12, 13, 14, 15,
 
                              16,  17, 18,  19, 20, 21, 22, 23, 24,  25, 26,  27, 28, 29, 30, 31,
@@ -1577,7 +1580,7 @@ NGRAPH_TEST(${BACKEND_NAME}, replace_slice_3d_strided_different_strides)
     copy_data(b, vector<float>{900, 903, 908, 911, 932, 935, 940, 943});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{900, 1,  2,  903, 4,  5,  6,  7,  908, 9,  10, 911, 12, 13, 14, 15,
 
                              16,  17, 18, 19,  20, 21, 22, 23, 24,  25, 26, 27,  28, 29, 30, 31,
@@ -1601,7 +1604,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_0d)
     copy_data(a, vector<float>{6});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{6}), read_vector<float>(result));
 }
 
@@ -1618,7 +1621,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_1d_nochange)
     copy_data(a, vector<float>{0, 1, 2, 3, 4, 5, 6, 7});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{0, 1, 2, 3, 4, 5, 6, 7}), read_vector<float>(result));
 }
 
@@ -1635,7 +1638,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_1d_0)
     copy_data(a, vector<float>{0, 1, 2, 3, 4, 5, 6, 7});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{7, 6, 5, 4, 3, 2, 1, 0}), read_vector<float>(result));
 }
 
@@ -1653,7 +1656,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_2d_nochange)
               test::NDArray<float, 2>({{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}}).get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (test::NDArray<float, 2>({{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}}).get_vector()),
         read_vector<float>(result));
@@ -1673,7 +1676,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_2d_0)
               test::NDArray<float, 2>({{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}}).get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (test::NDArray<float, 2>({{9, 10, 11}, {6, 7, 8}, {3, 4, 5}, {0, 1, 2}}).get_vector()),
         read_vector<float>(result));
@@ -1693,7 +1696,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_2d_1)
               test::NDArray<float, 2>({{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}}).get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (test::NDArray<float, 2>({{2, 1, 0}, {5, 4, 3}, {8, 7, 6}, {11, 10, 9}}).get_vector()),
         read_vector<float>(result));
@@ -1714,7 +1717,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_2d_01)
               test::NDArray<float, 2>({{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}}).get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(
         (test::NDArray<float, 2>({{11, 10, 9}, {8, 7, 6}, {5, 4, 3}, {2, 1, 0}}).get_vector()),
         read_vector<float>(result));
@@ -1736,7 +1739,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_3d_nochange)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>({{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}},
                                         {{12, 13, 14}, {15, 16, 17}, {18, 19, 20}, {21, 22, 23}}})
                    .get_vector()),
@@ -1759,7 +1762,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_3d_0)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>({{{12, 13, 14}, {15, 16, 17}, {18, 19, 20}, {21, 22, 23}},
                                         {{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}}})
                    .get_vector()),
@@ -1782,7 +1785,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_3d_1)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>({{{9, 10, 11}, {6, 7, 8}, {3, 4, 5}, {0, 1, 2}},
                                         {{21, 22, 23}, {18, 19, 20}, {15, 16, 17}, {12, 13, 14}}})
                    .get_vector()),
@@ -1805,7 +1808,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_3d_2)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>({{{2, 1, 0}, {5, 4, 3}, {8, 7, 6}, {11, 10, 9}},
                                         {{14, 13, 12}, {17, 16, 15}, {20, 19, 18}, {23, 22, 21}}})
                    .get_vector()),
@@ -1829,7 +1832,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_3d_01)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>({{{21, 22, 23}, {18, 19, 20}, {15, 16, 17}, {12, 13, 14}},
                                         {{9, 10, 11}, {6, 7, 8}, {3, 4, 5}, {0, 1, 2}}})
                    .get_vector()),
@@ -1853,7 +1856,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_3d_02)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>({{{14, 13, 12}, {17, 16, 15}, {20, 19, 18}, {23, 22, 21}},
                                         {{2, 1, 0}, {5, 4, 3}, {8, 7, 6}, {11, 10, 9}}})
                    .get_vector()),
@@ -1877,7 +1880,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_3d_12)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>({{{11, 10, 9}, {8, 7, 6}, {5, 4, 3}, {2, 1, 0}},
                                         {{23, 22, 21}, {20, 19, 18}, {17, 16, 15}, {14, 13, 12}}})
                    .get_vector()),
@@ -1901,7 +1904,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_3d_012)
                   .get_vector());
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((test::NDArray<float, 3>({{{23, 22, 21}, {20, 19, 18}, {17, 16, 15}, {14, 13, 12}},
                                         {{11, 10, 9}, {8, 7, 6}, {5, 4, 3}, {2, 1, 0}}})
                    .get_vector()),
@@ -1919,7 +1922,7 @@ NGRAPH_TEST(${BACKEND_NAME}, numeric_float_nan)
 
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::boolean, shape);
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ((vector<char>{false, false, true, false, false}), read_vector<char>(result));
 }
 
@@ -1934,7 +1937,7 @@ NGRAPH_TEST(${BACKEND_NAME}, numeric_double_nan)
 
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::boolean, shape);
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ((vector<char>{false, false, true, false, false}), read_vector<char>(result));
 }
 
@@ -1949,7 +1952,7 @@ NGRAPH_TEST(${BACKEND_NAME}, numeric_float_inf)
 
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::boolean, shape);
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ((vector<char>{false, false, true, false, false}), read_vector<char>(result));
 }
 
@@ -1964,7 +1967,7 @@ NGRAPH_TEST(${BACKEND_NAME}, numeric_double_inf)
 
     // Create some tensors for input/output
     auto result = backend->create_tensor(element::boolean, shape);
-    backend->call_with_validate(f, {result}, {});
+    backend->call_with_validate(backend->compile(f), {result}, {});
     EXPECT_EQ((vector<char>{false, false, true, false, false}), read_vector<char>(result));
 }
 
@@ -2014,7 +2017,7 @@ NGRAPH_TEST(${BACKEND_NAME}, select_and_scatter_with_overlap)
     copy_data(c, vector<float>{0});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((test::NDArray<float, 2>(
                    {{0, 0, 0, 0, 0}, {0, 0, 8, 0, 0}, {0, 0, 3, 0, 0}, {0, 0, 0, 1, 0}})
                    .get_vector()),
@@ -2067,7 +2070,7 @@ NGRAPH_TEST(${BACKEND_NAME}, select_and_scatter_without_overlap)
     copy_data(c, vector<float>{0});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((test::NDArray<float, 2>(
                    {{0, 0, 0, 0, 6, 0}, {0, 0, 2, 0, 0, 0}, {0, 0, 3, 0, 0, 0}, {0, 0, 0, 0, 0, 1}})
                    .get_vector()),
@@ -2122,7 +2125,7 @@ NGRAPH_TEST(${BACKEND_NAME}, select_and_scatter_3d_without_overlap)
     copy_data(c, vector<float>{0});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ(
         (test::NDArray<float, 3>(
              {{{0, 0, 0, 0, 6, 0}, {0, 0, 2, 0, 0, 0}, {0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 1}},
@@ -2156,7 +2159,7 @@ void make_unary_empty_test(const string& backend_name)
         outputs.push_back(backend->create_tensor(s_known_element_types[i], shape));
     }
 
-    backend->call_with_validate(f, outputs, inputs);
+    backend->call_with_validate(backend->compile(f), outputs, inputs);
 
     EXPECT_EQ(read_vector<float>(inputs[0]).size(), 0);
     EXPECT_EQ(read_vector<double>(inputs[1]).size(), 0);
@@ -2215,7 +2218,7 @@ void make_binary_empty_test(const string& backend_name, bool is_comparison = fal
         }
     }
 
-    backend->call_with_validate(f, outputs, inputs);
+    backend->call_with_validate(backend->compile(f), outputs, inputs);
 
     EXPECT_EQ(read_vector<float>(inputs[0]).size(), 0);
     EXPECT_EQ(read_vector<double>(inputs[1]).size(), 0);
@@ -2297,7 +2300,7 @@ NGRAPH_TEST(${BACKEND_NAME}, zero_sized_not)
     auto a = backend->create_tensor(element::from<char>(), shape);
     auto result = backend->create_tensor(element::from<char>(), shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
 
     auto in_vec = read_vector<char>(a);
     auto out_vec = read_vector<char>(result);
@@ -2460,7 +2463,7 @@ NGRAPH_TEST(${BACKEND_NAME}, convolution_outlining)
 
     vector<float> expected_result{4.0f, 4.0f, 4.0f, 4.0f, 4.0f, 4.0f, 4.0f, 4.0f};
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(vector<float>{expected_result}, read_vector<float>(result));
 }
 
@@ -2495,12 +2498,12 @@ NGRAPH_TEST(${BACKEND_NAME}, computation_reuse)
     auto b = backend->create_tensor(element::f32, shape_b, weights.data());
     auto result = backend->create_tensor(element::f32, shape_r, rv.data());
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
 
     vector<float> rv_saved(rv);
 
     b->set_stale(false);
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(rv_saved, rv);
 }
 
@@ -2527,7 +2530,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_interior_1d)
     copy_data(b, vector<float>{2112});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 1>(
                    {1, 2112, 2112, 2, 2112, 2112, 3, 2112, 2112, 4, 2112, 2112, 5, 2112, 2112, 6})
                    .get_vector()),
@@ -2557,7 +2560,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_exterior_1d)
     copy_data(b, vector<float>{2112});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 1>(
                    {2112, 2112, 2112, 2112, 1, 2, 3, 4, 5, 6, 2112, 2112, 2112, 2112, 2112})
                    .get_vector()),
@@ -2587,7 +2590,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_interior_exterior_1d)
     copy_data(b, vector<float>{2112});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 1>({2112, 2112, 2112, 2112, 1,    2112, 2112, 2, 2112,
                                         2112, 3,    2112, 2112, 4,    2112, 2112, 5, 2112,
                                         2112, 6,    2112, 2112, 2112, 2112, 2112})
@@ -2618,7 +2621,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_interior_exterior_2d)
     copy_data(b, vector<float>{9});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 2>({{9, 9, 9, 9, 9, 9},
                                         {1, 9, 2, 9, 3, 9},
                                         {9, 9, 9, 9, 9, 9},
@@ -2653,7 +2656,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_exterior_2d_0x0)
     copy_data(b, vector<float>{2112});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 2>({{2112, 2112, 2112, 2112, 2112},
                                         {2112, 2112, 2112, 2112, 2112},
                                         {2112, 2112, 2112, 2112, 2112},
@@ -2686,7 +2689,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_exterior_2d_0x3)
     copy_data(b, vector<float>{2112});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 2>({{2112, 2112, 2112, 2112, 2112},
                                         {2112, 2112, 2112, 2112, 2112},
                                         {2112, 2112, 2112, 2112, 2112},
@@ -2719,7 +2722,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_exterior_2d_3x0)
     copy_data(b, vector<float>{2112});
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 2>({{2112, 2112, 2112, 2112, 2112},
                                         {2112, 2112, 2112, 2112, 2112},
                                         {2112, 2112, 2112, 2112, 2112},
@@ -2768,7 +2771,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_exterior_4d_1x2x2x2)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     // clang-format off
     EXPECT_EQ((test::NDArray<float, 4>(
         {
@@ -2821,7 +2824,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_interior_exterior_4d_2x0x3x2)
 
     vector<float> expected(5 * 2 * 3 * 2, 2112);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(expected, read_vector<float>(result));
 }
 
@@ -2873,7 +2876,7 @@ NGRAPH_TEST(${BACKEND_NAME}, pad_2channel_2image_asym)
 
     auto result = backend->create_tensor(element::f32, shape_r);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((test::NDArray<float, 4>({{{{0, 1, 0, 2, 42, 42}, // img 0 chan 0
                                           {0, 3, 2, 0, 42, 42},
                                           {2, 0, 0, 0, 42, 42},
@@ -2919,7 +2922,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_trivial)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -2938,7 +2941,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_trivial_5d)
                                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                              1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),
               read_vector<float>(result));
@@ -2958,7 +2961,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_to_scalar)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, Shape{});
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{24}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -2980,7 +2983,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_matrix_columns)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{15, 48}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3002,7 +3005,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_matrix_rows)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{2, 12, 30}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3025,7 +3028,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_matrix_rows_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3, 3, 3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 1, 1}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3049,7 +3052,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_matrix_cols_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3, 3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 1}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3072,7 +3075,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_vector_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3096,7 +3099,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_matrix_to_scalar_zero_by_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3119,7 +3122,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_3d_to_matrix_most_sig)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1 * 10 * 19,
                              2 * 11 * 20,
                              3 * 12 * 21,
@@ -3147,7 +3150,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_3d_to_matrix_least_sig)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1 * 2 * 3,
                              4 * 5 * 6,
                              7 * 8 * 9,
@@ -3176,7 +3179,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_3d_to_vector)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1.0f * 10.0f * 19.0f * 4.0f * 13.0f * 22.0f * 7.0f * 16.0f * 25.0f,
                              2.0f * 11.0f * 20.0f * 5.0f * 14.0f * 23.0f * 8.0f * 17.0f * 26.0f,
                              3.0f * 12.0f * 21.0f * 6.0f * 15.0f * 24.0f * 9.0f * 18.0f * 27.0f}),
@@ -3199,7 +3202,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_3d_to_scalar)
                                13, 12, 11, 10, 9, 8, 7, 6, 5, 4,  3,  2,  1});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close(vector<float>{1.0f * 10.0f * 9.0f * 4.0f * 13.0f * 6.0f * 7.0f *
                                               12.0f * 3.0f * 2.0f * 11.0f * 8.0f * 5.0f * 14.0f *
                                               5.0f * 8.0f * 11.0f * 2.0f * 3.0f * 12.0f * 7.0f *
@@ -3224,7 +3227,7 @@ NGRAPH_TEST(${BACKEND_NAME}, product_3d_eliminate_zero_dim)
     // Overwrite the initial result vector to make sure we're not just coincidentally getting the right value.
     copy_data(result, vector<float>{2112, 2112, 2112, 2112, 2112, 2112});
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 1, 1, 1, 1, 1}), read_vector<float>(result));
 }
 
@@ -3242,7 +3245,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_trivial)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -3261,7 +3264,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_trivial_5d)
                                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                              1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),
               read_vector<float>(result));
@@ -3280,7 +3283,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_to_scalar)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, Shape{});
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{4}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3302,7 +3305,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_matrix_columns)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{5, 6}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3324,7 +3327,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_matrix_rows)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{2, 4, 6}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3347,7 +3350,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_matrix_rows_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3, 3, 3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{-std::numeric_limits<float>::infinity(),
                              -std::numeric_limits<float>::infinity(),
                              -std::numeric_limits<float>::infinity()}),
@@ -3374,7 +3377,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_matrix_cols_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3, 3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{-std::numeric_limits<float>::infinity(),
                              -std::numeric_limits<float>::infinity()}),
               read_vector<float>(result));
@@ -3399,7 +3402,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_vector_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{-std::numeric_limits<float>::infinity()}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3422,7 +3425,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_matrix_to_scalar_zero_by_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{-std::numeric_limits<float>::infinity()}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3445,7 +3448,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_3d_to_matrix_most_sig)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{19, 20, 21, 22, 23, 24, 25, 26, 27}), read_vector<float>(result));
 }
 
@@ -3464,7 +3467,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_3d_to_matrix_least_sig)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{3, 6, 9, 12, 15, 18, 21, 24, 27}), read_vector<float>(result));
 }
 
@@ -3483,7 +3486,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_3d_to_vector)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{25.0f, 26.0f, 27.0f}), read_vector<float>(result));
 }
 
@@ -3503,7 +3506,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_3d_to_scalar)
                                13, 12, 11, 10, 9, 8, 7, 6, 5, 4,  3,  2,  1});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{14.0f}), read_vector<float>(result));
 }
 
@@ -3526,7 +3529,7 @@ NGRAPH_TEST(${BACKEND_NAME}, max_3d_eliminate_zero_dim)
 
     float mi = -std::numeric_limits<float>::infinity();
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{mi, mi, mi, mi, mi, mi}), read_vector<float>(result));
 }
 
@@ -3544,7 +3547,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_trivial)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4}), read_vector<float>(result));
 }
 
@@ -3563,7 +3566,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_trivial_5d)
                                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                              1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),
               read_vector<float>(result));
@@ -3582,7 +3585,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_to_scalar)
     copy_data(a, vector<float>{1, 2, 3, 4});
     auto result = backend->create_tensor(element::f32, Shape{});
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3604,7 +3607,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_matrix_columns)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3626,7 +3629,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_matrix_rows)
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 3, 5}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3649,7 +3652,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_matrix_rows_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3, 3, 3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{std::numeric_limits<float>::infinity(),
                              std::numeric_limits<float>::infinity(),
                              std::numeric_limits<float>::infinity()}),
@@ -3676,7 +3679,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_matrix_cols_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3, 3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{std::numeric_limits<float>::infinity(),
                              std::numeric_limits<float>::infinity()}),
               read_vector<float>(result));
@@ -3701,7 +3704,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_vector_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{std::numeric_limits<float>::infinity()}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3724,7 +3727,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_matrix_to_scalar_zero_by_zero)
     auto result = backend->create_tensor(element::f32, shape_rt);
     copy_data(result, vector<float>({3}));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{std::numeric_limits<float>::infinity()}), read_vector<float>(result));
 
     // For some reason I'm feeling extra paranoid about making sure reduction doesn't clobber the
@@ -3747,7 +3750,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_3d_to_matrix_most_sig)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9}), read_vector<float>(result));
 }
 
@@ -3766,7 +3769,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_3d_to_matrix_least_sig)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 4, 7, 10, 13, 16, 19, 22, 25}), read_vector<float>(result));
 }
 
@@ -3785,7 +3788,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_3d_to_vector)
                                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3}), read_vector<float>(result));
 }
 
@@ -3805,7 +3808,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_3d_to_scalar)
                                13, 12, 11, 10, 9, 8, 7, 6, 5, 4,  3,  2,  1});
     auto result = backend->create_tensor(element::f32, shape_rt);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1}), read_vector<float>(result));
 }
 
@@ -3828,7 +3831,7 @@ NGRAPH_TEST(${BACKEND_NAME}, min_3d_eliminate_zero_dim)
 
     float inf = std::numeric_limits<float>::infinity();
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{inf, inf, inf, inf, inf, inf}), read_vector<float>(result));
 }
 
@@ -3846,7 +3849,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sigmoid_n1c1h2w2)
     vector<float> dataA{1.0f, 4.0f, 1.0f, 4.0f};
     copy_data(a, dataA);
 
-    backend->call_with_validate(func, {result}, {a});
+    backend->call_with_validate(backend->compile(func), {result}, {a});
     vector<float> expected{0.73105858f, 0.98201379f, 0.73105858f, 0.98201379f};
     ASSERT_TRUE(read_vector<float>(result) == expected);
 }
@@ -3865,7 +3868,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sigmoid_n1c1h4)
     vector<float> dataA{1.0f, 4.0f, 1.0f, 4.0f};
     copy_data(a, dataA);
 
-    backend->call_with_validate(func, {result}, {a});
+    backend->call_with_validate(backend->compile(func), {result}, {a});
     vector<float> expected{0.73105858f, 0.98201379f, 0.73105858f, 0.98201379f};
     ASSERT_TRUE(read_vector<float>(result) == expected);
 }
@@ -3887,7 +3890,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sigmoid_bprop_n1c1h4)
 
     copy_data(a, dataA);
     copy_data(b, dataB);
-    backend->call_with_validate(func, {result}, {a, b});
+    backend->call_with_validate(backend->compile(func), {result}, {a, b});
 
     vector<float> expected{0.196612f, 0.0176627f, 0.196612f, 0.0176627f};
     EXPECT_TRUE(test::all_close(expected, read_vector<float>(result)));
@@ -3908,7 +3911,7 @@ NGRAPH_TEST(${BACKEND_NAME}, relu_2Dfprop)
     auto result = backend->create_tensor(element::f32, shape_rt);
     vector<float> expected{1, 8, 0, 17, 0, 1, 8, 0, 17, 0};
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(read_vector<float>(result), expected);
 }
 
@@ -3927,7 +3930,7 @@ NGRAPH_TEST(${BACKEND_NAME}, relu_4Dfprop)
     auto result = backend->create_tensor(element::f32, shape_rt);
     vector<float> expected{1, 8, 0, 17, 0, 1, 8, 0, 17, 0, 1, 8, 0, 17, 0, 1};
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(read_vector<float>(result), expected);
 }
 
@@ -3947,7 +3950,7 @@ NGRAPH_TEST(${BACKEND_NAME}, fuse_max_with_constant_zero_input_as_relu)
     auto result = backend->create_tensor(element::f32, shape_rt);
     vector<float> expected{1, 8, 0, 17, 0, 1, 8, 0, 17, 0};
 
-    backend->call_with_validate(f, {result}, {b});
+    backend->call_with_validate(backend->compile(f), {result}, {b});
     EXPECT_EQ(read_vector<float>(result), expected);
 }
 
@@ -3969,7 +3972,7 @@ NGRAPH_TEST(${BACKEND_NAME}, relu_2Dbackprop)
     auto result = backend->create_tensor(element::f32, shape_rt);
     vector<float> expected{1, 2, 0, 4, 0, 6, 7, 0, 9, 0};
 
-    backend->call_with_validate(f, {result}, {a, delta});
+    backend->call_with_validate(backend->compile(f), {result}, {a, delta});
     EXPECT_EQ(read_vector<float>(result), expected);
 }
 
@@ -3991,7 +3994,7 @@ NGRAPH_TEST(${BACKEND_NAME}, relu_4Dbackprop)
     auto result = backend->create_tensor(element::f32, shape_rt);
     vector<float> expected{1, 8, 0, 17, 0, 1, 8, 0, 17, 0, 1, 8, 0, 17, 0, 1};
 
-    backend->call_with_validate(f, {result}, {a, delta});
+    backend->call_with_validate(backend->compile(f), {result}, {a, delta});
     EXPECT_EQ(read_vector<float>(result), expected);
 }
 
@@ -4010,7 +4013,7 @@ NGRAPH_TEST(${BACKEND_NAME}, softmax_all)
 
     auto d = expf(-3) + expf(-2) + expf(-1) + expf(0) + expf(1) + expf(2);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     vector<float> expected{
         expf(-3) / d, expf(-2) / d, expf(-1) / d, expf(0) / d, expf(1) / d, expf(2) / d};
     EXPECT_TRUE(test::all_close_f(expected, read_vector<float>(result)));
@@ -4019,7 +4022,7 @@ NGRAPH_TEST(${BACKEND_NAME}, softmax_all)
     f = make_shared<Function>(make_shared<op::Softmax>(A, AxisSet{}), op::ParameterVector{A});
     backend = runtime::Backend::create("${BACKEND_NAME}");
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(expected, read_vector<float>(result)));
 }
 
@@ -4042,7 +4045,7 @@ NGRAPH_TEST(${BACKEND_NAME}, softmax_axis_3d)
     auto d4 = expf(-50) + expf(-5);
     auto d5 = expf(-60) + expf(-6);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     vector<float> expected{expf(-10) / d0,
                            expf(-20) / d1,
                            expf(-30) / d2,
@@ -4078,7 +4081,7 @@ NGRAPH_TEST(${BACKEND_NAME}, softmax_axis_3d_double)
     auto d4 = expf(-50) + expf(-5);
     auto d5 = expf(-60) + expf(-6);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     vector<double> expected{expf(-10) / d0,
                             expf(-20) / d1,
                             expf(-30) / d2,
@@ -4110,7 +4113,7 @@ NGRAPH_TEST(${BACKEND_NAME}, softmax_axis)
     auto d0 = expf(-10) + expf(-20) + expf(-30);
     auto d1 = expf(-40) + expf(-50) + expf(-60);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     vector<float> expected{expf(-10) / d0,
                            expf(-20) / d0,
                            expf(-30) / d0,
@@ -4136,7 +4139,7 @@ NGRAPH_TEST(${BACKEND_NAME}, softmax_axis_2)
     auto d1 = expf(-20) + expf(-50);
     auto d2 = expf(-30) + expf(-60);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     vector<float> expected{expf(-10) / d0,
                            expf(-20) / d1,
                            expf(-30) / d2,
@@ -4158,7 +4161,7 @@ NGRAPH_TEST(${BACKEND_NAME}, softmax_axis_3d_trivial)
     copy_data(a, vector<float>{-10, -20, -30, -40, -50, -60});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     vector<float> expected{1, 1, 1, 1, 1, 1};
     EXPECT_TRUE(test::all_close(expected, read_vector<float>(result)));
 }
@@ -4181,7 +4184,7 @@ NGRAPH_TEST(${BACKEND_NAME}, softmax_underflow)
     auto d1 = expf(1) + expf(4);
     auto d2 = expf(2) + expf(5);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     vector<float> expected{
         expf(low) / d0, expf(1) / d1, expf(2) / d2, expf(3) / d0, expf(4) / d1, expf(5) / d2};
     EXPECT_TRUE(test::all_close(expected, read_vector<float>(result)));
@@ -4217,11 +4220,11 @@ NGRAPH_TEST(${BACKEND_NAME}, multiple_backends)
     copy_data(a2, test::NDArray<float, 2>({{1, 2}, {3, 4}}).get_vector());
     copy_data(b2, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
 
-    backend1->call_with_validate(f, {result1}, {a1, b1});
+    backend1->call_with_validate(backend1->compile(f), {result1}, {a1, b1});
     EXPECT_EQ(read_vector<float>(result1),
               (test::NDArray<float, 2>({{6, 8}, {10, 12}})).get_vector());
 
-    backend2->call_with_validate(g, {result2}, {a2, b2});
+    backend2->call_with_validate(backend2->compile(g), {result2}, {a2, b2});
     EXPECT_EQ(read_vector<float>(result2),
               (test::NDArray<float, 2>({{5, 12}, {21, 32}})).get_vector());
 }
@@ -4253,7 +4256,7 @@ NGRAPH_TEST(${BACKEND_NAME}, tensorview_custom_mem)
     auto result = backend->create_tensor(element::f32, shape, rv.data());
 
     // result should be in memory without needing explict read
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<float>{2, 2, 2, 2}), rv);
 }
 
@@ -4271,7 +4274,7 @@ NGRAPH_TEST(${BACKEND_NAME}, validate_call_input_count)
     auto b = backend->create_tensor(element::f32, shape);
     auto c = backend->create_tensor(element::f32, shape);
 
-    EXPECT_ANY_THROW(backend->call_with_validate(f, {c}, {a}));
+    EXPECT_ANY_THROW(backend->call_with_validate(backend->compile(f), {c}, {a}));
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, validate_call_input_type)
@@ -4288,7 +4291,7 @@ NGRAPH_TEST(${BACKEND_NAME}, validate_call_input_type)
     auto b = backend->create_tensor(element::f32, shape);
     auto c = backend->create_tensor(element::f32, shape);
 
-    EXPECT_ANY_THROW(backend->call_with_validate(f, {c}, {a, b}));
+    EXPECT_ANY_THROW(backend->call_with_validate(backend->compile(f), {c}, {a, b}));
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, validate_call_input_shape)
@@ -4305,7 +4308,7 @@ NGRAPH_TEST(${BACKEND_NAME}, validate_call_input_shape)
     auto b = backend->create_tensor(element::f32, shape);
     auto c = backend->create_tensor(element::f32, shape);
 
-    EXPECT_ANY_THROW(backend->call_with_validate(f, {c}, {a, b}));
+    EXPECT_ANY_THROW(backend->call_with_validate(backend->compile(f), {c}, {a, b}));
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, validate_call_output_count)
@@ -4323,7 +4326,7 @@ NGRAPH_TEST(${BACKEND_NAME}, validate_call_output_count)
     auto c = backend->create_tensor(element::f32, shape);
     auto d = backend->create_tensor(element::f32, shape);
 
-    EXPECT_ANY_THROW(backend->call_with_validate(f, {c, d}, {a, b}));
+    EXPECT_ANY_THROW(backend->call_with_validate(backend->compile(f), {c, d}, {a, b}));
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, validate_call_output_type)
@@ -4340,7 +4343,7 @@ NGRAPH_TEST(${BACKEND_NAME}, validate_call_output_type)
     auto b = backend->create_tensor(element::f32, shape);
     auto c = backend->create_tensor(element::f32, shape);
 
-    EXPECT_ANY_THROW(backend->call_with_validate(f, {a}, {b, c}));
+    EXPECT_ANY_THROW(backend->call_with_validate(backend->compile(f), {a}, {b, c}));
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, validate_call_output_shape)
@@ -4357,7 +4360,7 @@ NGRAPH_TEST(${BACKEND_NAME}, validate_call_output_shape)
     auto b = backend->create_tensor(element::f32, shape);
     auto c = backend->create_tensor(element::f32, shape);
 
-    EXPECT_ANY_THROW(backend->call_with_validate(f, {a}, {c, b}));
+    EXPECT_ANY_THROW(backend->call_with_validate(backend->compile(f), {a}, {c, b}));
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, logical_and)
@@ -4376,7 +4379,7 @@ NGRAPH_TEST(${BACKEND_NAME}, logical_and)
     copy_data(b, vector<char>{0, 0, 1, 0, 0, 1, 1, 0});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<char>{0, 0, 1, 0, 0, 0, 1, 0}), read_vector<char>(result));
 }
 
@@ -4396,7 +4399,7 @@ NGRAPH_TEST(${BACKEND_NAME}, logical_or)
     copy_data(b, vector<char>{0, 0, 1, 0, 0, 1, 1, 0});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<char>{1, 0, 1, 1, 1, 1, 1, 0}), read_vector<char>(result));
 }
 
@@ -4455,7 +4458,7 @@ NGRAPH_TEST(${BACKEND_NAME}, batchnorm_fprop_b1c2h2w2)
     vector<float> expected_variance{0.00472505f, 0.0361782f};
 
     backend->call_with_validate(
-        f, {bn_output, result_mean, result_variance}, {_input, _gamma, _beta});
+        backend->compile(f), {bn_output, result_mean, result_variance}, {_input, _gamma, _beta});
 
     EXPECT_TRUE(test::all_close(expected_result, read_vector<float>(bn_output), 1e-5f, 1e-6f));
     EXPECT_TRUE(test::all_close(expected_mean, read_vector<float>(result_mean), 1e-5f, 1e-6f));
@@ -4509,7 +4512,7 @@ NGRAPH_TEST(${BACKEND_NAME}, batchnorm_fprop_b2c2h2w1)
     vector<float> expected_mean{0.583388f, 0.619252f};
     vector<float> expected_variance{0.0119972f, 0.0282681f};
     backend->call_with_validate(
-        f, {bn_output, result_mean, result_variance}, {_input, _gamma, _beta});
+        backend->compile(f), {bn_output, result_mean, result_variance}, {_input, _gamma, _beta});
 
     EXPECT_TRUE(test::all_close(expected_result, read_vector<float>(bn_output)));
     EXPECT_TRUE(test::all_close(expected_mean, read_vector<float>(result_mean)));
@@ -4590,8 +4593,9 @@ NGRAPH_TEST(${BACKEND_NAME}, batchnorm_bprop_n4c3h2w2)
     shared_ptr<runtime::Tensor> _dgamma = backend->create_tensor(element::f32, gamma_shape);
     shared_ptr<runtime::Tensor> _dbeta = backend->create_tensor(element::f32, beta_shape);
 
-    backend->call_with_validate(
-        df, {_dinput, _dgamma, _dbeta}, {_mean, _var, _input, _gamma, _beta, _delta});
+    backend->call_with_validate(backend->compile(df),
+                                {_dinput, _dgamma, _dbeta},
+                                {_mean, _var, _input, _gamma, _beta, _delta});
 
     vector<float> expected_input{
         8.17051607e-06f,  4.77576657e-06f,  1.02257760e-05f,  1.20387525e-06f,  -1.73868522e-06f,
@@ -4655,7 +4659,8 @@ NGRAPH_TEST(${BACKEND_NAME}, batchnorm_fprop_inference_b2c2h2w1)
 
     vector<float> expected_result{
         -0.30327f, 1.1561f, -0.0963782f, -0.434702f, -1.4011f, 0.548275f, -1.06187f, 1.59295f};
-    backend->call_with_validate(f, {bn_output}, {_input, _gamma, _beta, _mean, _var});
+    backend->call_with_validate(
+        backend->compile(f), {bn_output}, {_input, _gamma, _beta, _mean, _var});
 
     ASSERT_TRUE(
         ngraph::test::all_close(expected_result, read_vector<float>(bn_output), 1e-3f, 1e-4f));
@@ -4704,7 +4709,7 @@ NGRAPH_TEST(${BACKEND_NAME}, batchnorm_fprop_globalstats_b2c2w2h1)
 
     vector<float> expected_result{
         -0.30327f, 1.1561f, -0.0963782f, -0.434702f, -1.4011f, 0.548275f, -1.06187f, 1.59295f};
-    backend->call_with_validate(f, {bn_output}, {_gamma, _beta, _input, _mean, _var});
+    backend->call_with_validate(backend->compile(f), {bn_output}, {_gamma, _beta, _input, _mean, _var});
 
     ASSERT_TRUE(
         ngraph::test::all_close(expected_result, read_vector<float>(bn_output), 1e-3f, 1e-4f));
@@ -4747,7 +4752,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_sequence_n2c3h4w2)
 
     copy_data(a, input);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<int>(result), expected);
 }
 
@@ -4786,7 +4791,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_sequence_n4c3h2w2)
 
     copy_data(a, input);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<int>(result), expected);
 }
 
@@ -4831,7 +4836,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reverse_sequence_n4d2c3h2w2)
     std::vector<int> seq_lenghts{1, 2, 1, 2};
     copy_data(b, seq_lenghts);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<int>(result), expected);
 }
 
@@ -4851,12 +4856,12 @@ NGRAPH_TEST(${BACKEND_NAME}, generate_mask)
 
     auto result_tv1 = backend->create_tensor<float>(result_shape);
     auto result_tv2 = backend->create_tensor<float>(result_shape);
-    backend->call_with_validate(f, {result_tv1, result_tv2}, {});
+    backend->call_with_validate(backend->compile(f), {result_tv1, result_tv2}, {});
     auto result1 = read_vector<float>(result_tv1);
     auto result2 = read_vector<float>(result_tv2);
     ASSERT_EQ(result1, result2);
     ASSERT_FALSE(std::any_of(result1.begin(), result1.end(), is_not_zero_or_one));
-    backend->call_with_validate(f, {result_tv1, result_tv2}, {});
+    backend->call_with_validate(backend->compile(f), {result_tv1, result_tv2}, {});
     auto result1_2 = read_vector<float>(result_tv1);
     auto result2_2 = read_vector<float>(result_tv2);
     ASSERT_NE(result1, result1_2);
@@ -4896,7 +4901,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize)
     // plus offset                    1  1  1  1  1  1  1  1  1  1  1   1
     // equals                         1  2  2  3  3  4  4  5  5  6  6   7
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7}),
               read_vector<output_c_type>(y));
 }
@@ -4929,7 +4934,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dequantize)
     // multiplied by scale            2  2  2  2  2  2  2  2  2  2  2  2
     // equals                         0  2  2  4  4  6  6  8  8 10 10 12
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12}),
               read_vector<output_c_type>(y));
 }
@@ -4961,7 +4966,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dequantize_zero_offset)
     // multiplied by scale            2  2  2  2  2  2  2  2  2  2  2  2
     // equals                         2  4  4  6  6  8  8  10 10 12 12 14
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14}),
               read_vector<output_c_type>(y));
 }
@@ -4997,7 +5002,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_axes)
     // plus offset                   10 10 10 20 20 20 30 30 30 40 40  40
     // equals                        10 11 11 21 21 22 32 32 32 42 42  42
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{10, 11, 11, 21, 21, 22, 32, 32, 32, 42, 42, 42}),
               read_vector<output_c_type>(y));
 }
@@ -5030,7 +5035,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dequantize_axes)
     // multiplied by scale             2   2   2   3   3   3   4   4   4   5   5   5
     // equals                          0   2   2   3   3   6   8   8   8  10  10  10
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{0, 2, 2, 3, 3, 6, 8, 8, 8, 10, 10, 10}),
               read_vector<output_c_type>(y));
 }
@@ -5066,7 +5071,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_int8)
     // plus offset                    1   1  1   1  1   1  1   1  1   1  1    1
     // equals                         1   0  2  -1  3  -2  4  -3  5  -4  6   -5
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{1, 0, 2, -1, 3, -2, 4, -3, 5, -4, 6, -5}),
               read_vector<output_c_type>(y));
 }
@@ -5099,7 +5104,7 @@ NGRAPH_TEST(${BACKEND_NAME}, dequantize_int8)
     // multiplied by scale            2  2  2   2  2   2  2   2  2   2  2   2
     // equals                         0 -2  2  -4  4  -6  6  -8  8 -10 10 -12
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{0, -2, 2, -4, 4, -6, 6, -8, 8, -10, 10, -12}),
               read_vector<output_c_type>(y));
 }
@@ -5131,7 +5136,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_clamp)
 
     copy_data(x, vector<input_c_type>{0, -1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11});
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ(
         (vector<output_c_type>{1, -128, 127, -128, 127, -128, 127, -128, 127, -128, 127, -128}),
         read_vector<output_c_type>(y));
@@ -5166,7 +5171,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_ROUND_NEAREST_TOWARD_ZERO)
     // divide by scale                4   4   4   4    4    4   4   4   4    4    4    4
     // equals (rounded)               2   2   3  -2   -2   -3   3   3   4   -3   -3   -4
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{2, 2, 3, -2, -2, -3, 3, 3, 4, -3, -3, -4}),
               read_vector<output_c_type>(y));
 }
@@ -5200,7 +5205,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_ROUND_NEAREST_UPWARD)
     // divide by scale                4   4   4   4    4    4   4   4   4    4    4    4
     // equals (rounded)               2   3   3  -2   -2   -3   3   4   4   -3   -3   -4
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{2, 3, 3, -2, -2, -3, 3, 4, 4, -3, -3, -4}),
               read_vector<output_c_type>(y));
 }
@@ -5234,7 +5239,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_ROUND_NEAREST_DOWNWARD)
     // divide by scale                4   4   4   4    4    4   4   4   4    4    4    4
     // equals (rounded)               2   2   3  -2   -3   -3   3   3   4   -3   -4   -4
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{2, 2, 3, -2, -3, -3, 3, 3, 4, -3, -4, -4}),
               read_vector<output_c_type>(y));
 }
@@ -5268,7 +5273,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_ROUND_NEAREST_TOWARD_EVEN)
     // divide by scale                4   4   4   4    4    4   4   4   4    4    4    4
     // equals (rounded)               2   2   3  -2   -2   -3   3   4   4   -3   -4   -4
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{2, 2, 3, -2, -2, -3, 3, 4, 4, -3, -4, -4}),
               read_vector<output_c_type>(y));
 }
@@ -5307,7 +5312,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_ROUND_TOWARD_INFINITY)
     // divide by scale                4   4   4   4    4    4   4   4   4    4    4    4
     // equals (rounded)               3   3   3  -3   -3   -3   4   4   4   -4   -4   -4
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{3, 3, 3, -3, -3, -3, 4, 4, 4, -4, -4, -4}),
               read_vector<output_c_type>(y));
 }
@@ -5346,7 +5351,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_ROUND_TOWARD_ZERO)
     // divide by scale                4   4   4   4    4    4   4   4   4    4    4    4
     // equals (rounded)               2   2   2  -2   -2   -2   3   3   3   -3   -3   -3
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{2, 2, 2, -2, -2, -2, 3, 3, 3, -3, -3, -3}),
               read_vector<output_c_type>(y));
 }
@@ -5380,7 +5385,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_ROUND_UP)
     // divide by scale                4   4   4   4    4    4   4   4   4    4    4    4
     // equals (rounded)               3   3   3  -2   -2   -2   4   4   4   -3   -3   -3
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{3, 3, 3, -2, -2, -2, 4, 4, 4, -3, -3, -3}),
               read_vector<output_c_type>(y));
 }
@@ -5414,7 +5419,7 @@ NGRAPH_TEST(${BACKEND_NAME}, quantize_ROUND_DOWN)
     // divide by scale                4   4   4   4    4    4   4   4   4    4    4    4
     // equals (rounded)               2   2   2  -3   -3   -3   3   3   3   -4   -4   -4
 
-    backend->call_with_validate(f, {y}, {x});
+    backend->call_with_validate(backend->compile(f), {y}, {x});
     EXPECT_EQ((vector<output_c_type>{2, 2, 2, -3, -3, -3, 3, 3, 3, -4, -4, -4}),
               read_vector<output_c_type>(y));
 }

--- a/test/backend_test.in.cpp
+++ b/test/backend_test.in.cpp
@@ -4851,17 +4851,18 @@ NGRAPH_TEST(${BACKEND_NAME}, generate_mask)
     auto f = make_shared<Function>(NodeVector{gen_mask, gen_mask2}, op::ParameterVector{});
 
     auto backend = runtime::Backend::create("${BACKEND_NAME}");
+    auto handle = backend->compile(f);
 
     auto is_not_zero_or_one = [](float num) { return num != 0.f && num != 1.f; };
 
     auto result_tv1 = backend->create_tensor<float>(result_shape);
     auto result_tv2 = backend->create_tensor<float>(result_shape);
-    backend->call_with_validate(backend->compile(f), {result_tv1, result_tv2}, {});
+    backend->call_with_validate(handle, {result_tv1, result_tv2}, {});
     auto result1 = read_vector<float>(result_tv1);
     auto result2 = read_vector<float>(result_tv2);
     ASSERT_EQ(result1, result2);
     ASSERT_FALSE(std::any_of(result1.begin(), result1.end(), is_not_zero_or_one));
-    backend->call_with_validate(backend->compile(f), {result_tv1, result_tv2}, {});
+    backend->call_with_validate(handle, {result_tv1, result_tv2}, {});
     auto result1_2 = read_vector<float>(result_tv1);
     auto result2_2 = read_vector<float>(result_tv2);
     ASSERT_NE(result1, result1_2);

--- a/test/backend_topk.in.cpp
+++ b/test/backend_topk.in.cpp
@@ -54,9 +54,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_1d_max_all)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{5, 4, 3, 2, 1, 0}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{6, 5, 4, 3, 2, 1}), read_vector<float>(result1));
 }
 
@@ -79,9 +79,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_1d_max_partial)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{5, 4, 3}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{6, 5, 4}), read_vector<float>(result1));
 }
 
@@ -104,9 +104,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_1d_max_one)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{5}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{6}), read_vector<float>(result1));
 }
 
@@ -129,9 +129,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_1d_min_all)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{5, 4, 3, 2, 1, 0}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3, 4, 5, 6}), read_vector<float>(result1));
 }
 
@@ -154,9 +154,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_1d_min_partial)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{5, 4, 3}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{1, 2, 3}), read_vector<float>(result1));
 }
 
@@ -179,9 +179,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_1d_min_one)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{5}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{1}), read_vector<float>(result1));
 }
 
@@ -204,9 +204,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_3d_max_all)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{1, 1, 0, 2, 2, 0, 2, 2, 0, 1, 1, 0}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{10, 12, 9, 4, 8, 2, 11, 7, 6, 3, 5, 1}), read_vector<float>(result1));
 }
 
@@ -229,9 +229,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_int64)
     auto result0 = backend->create_tensor(element::i64, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int64_t>{1, 1, 0, 2, 2, 0, 2, 2, 0, 1, 1, 0}), read_vector<int64_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{10, 12, 9, 4, 8, 2, 11, 7, 6, 3, 5, 1}), read_vector<float>(result1));
 }
 
@@ -278,7 +278,7 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_5d_max_partial)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ(
         (vector<int32_t>{5, 5, 5, 5, 5, 1, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 3, 5, 5, 5, 5,
                          3, 3, 3, 3, 3, 4, 3, 3, 3, 3, 3, 1, 3, 3, 3, 3, 1, 1, 1, 1, 3, 3, 3, 3,
@@ -286,7 +286,7 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_5d_max_partial)
                          3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 4, 1, 1, 1, 1, 1, 1, 5, 1, 3, 3}),
         read_vector<int32_t>(result0));
 
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{169, 241, 177, 249, 185, 233, 170, 242, 178, 250, 186, 258, 171, 243,
                              179, 251, 187, 259, 172, 224, 180, 252, 188, 260, 149, 221, 157, 229,
                              165, 113, 150, 222, 158, 230, 166, 234, 151, 223, 159, 231, 163, 235,
@@ -316,9 +316,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_3d_max_partial)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{1, 1, 0, 2, 2, 2, 0, 1}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{10, 12, 9, 4, 11, 7, 6, 3}), read_vector<float>(result1));
 }
 
@@ -341,9 +341,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_3d_max_one)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{1, 1, 2, 2}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{10, 12, 11, 7}), read_vector<float>(result1));
 }
 
@@ -366,9 +366,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_3d_min_all)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{2, 0, 1, 2, 0, 1, 1, 0, 0, 1, 2, 2}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{8, 2, 10, 4, 12, 9, 5, 1, 6, 3, 11, 7}), read_vector<float>(result1));
 }
 
@@ -391,9 +391,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_3d_min_partial)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{2, 0, 1, 2, 1, 0, 0, 1}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{8, 2, 10, 4, 5, 1, 6, 3}), read_vector<float>(result1));
 }
 
@@ -416,9 +416,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_3d_min_one)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{2, 0, 1, 0}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{8, 2, 5, 1}), read_vector<float>(result1));
 }
 
@@ -441,9 +441,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_2d_max_all)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{1, 3, 0, 0, 1, 3, 2, 0, 2, 3, 2, 1}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{12, 11, 10, 9, 8, 7, 6, 2, 5, 3, 1, 4}), read_vector<float>(result1));
 }
 
@@ -466,9 +466,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_2d_max_partial)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{1, 3, 0, 0, 1, 3}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{12, 11, 10, 9, 8, 7}), read_vector<float>(result1));
 }
 
@@ -491,9 +491,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_2d_max_one)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{1, 3, 0}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{12, 11, 10}), read_vector<float>(result1));
 }
 
@@ -516,9 +516,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_2d_min_all)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{3, 2, 1, 2, 0, 2, 1, 1, 3, 0, 3, 0}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{3, 1, 4, 6, 2, 5, 9, 8, 7, 12, 11, 10}), read_vector<float>(result1));
 }
 
@@ -541,9 +541,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_2d_min_partial)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{3, 2, 1, 2, 0, 2}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{3, 1, 4, 6, 2, 5}), read_vector<float>(result1));
 }
 
@@ -566,9 +566,9 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_2d_min_one)
     auto result0 = backend->create_tensor(element::i32, rshape);
     auto result1 = backend->create_tensor(element::f32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{3, 2, 1}), read_vector<int32_t>(result0));
-    backend->call_with_validate(f1, {result1}, {a});
+    backend->call_with_validate(backend->compile(f1), {result1}, {a});
     EXPECT_EQ((vector<float>{3, 1, 4}), read_vector<float>(result1));
 }
 
@@ -664,6 +664,6 @@ NGRAPH_TEST(${BACKEND_NAME}, topk_3d_single_output)
     copy_data(a, vector<float>{12, 2, 10, 9, 8, 4, 6, 1, 5, 3, 11, 7});
     auto result0 = backend->create_tensor(element::i32, rshape);
 
-    backend->call_with_validate(f0, {result0}, {a});
+    backend->call_with_validate(backend->compile(f0), {result0}, {a});
     EXPECT_EQ((vector<int32_t>{2, 0, 1, 2, 1, 0, 0, 1}), read_vector<int32_t>(result0));
 }

--- a/test/backend_unary_elementwise.in.cpp
+++ b/test/backend_unary_elementwise.in.cpp
@@ -47,7 +47,7 @@ NGRAPH_TEST(${BACKEND_NAME}, abs)
     copy_data(a, vector<float>{1, -2, 0, -4.75f});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, 2, 0, 4.75f}), read_vector<float>(result));
 }
 
@@ -64,7 +64,7 @@ NGRAPH_TEST(${BACKEND_NAME}, acos)
     vector<float> input{-1.f, -0.75f, -0.5f, -0.25f, -0.125f, 0.f, 0.125f, 0.25f, 0.5f, 0.75f, 1.f};
     copy_data(a, input);
     auto result = backend->create_tensor(element::f32, shape);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(vector<float>{3.14159265f,
                                                 2.41885841f,
                                                 2.09439510f,
@@ -92,7 +92,7 @@ NGRAPH_TEST(${BACKEND_NAME}, asin)
     vector<float> input{-1.f, -0.75f, -0.5f, -0.25f, -0.125f, 0.f, 0.125f, 0.25f, 0.5f, 0.75f, 1.f};
     copy_data(a, input);
     auto result = backend->create_tensor(element::f32, shape);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(vector<float>{-1.57079633f,
                                                 -0.84806208f,
                                                 -0.52359878f,
@@ -120,7 +120,7 @@ NGRAPH_TEST(${BACKEND_NAME}, atan)
     vector<float> input{-4.f, -2.f, -1.f, -0.5f, -0.25f, 0.f, 0.25f, 0.5f, 1.f, 2.f, 4.f};
     copy_data(a, input);
     auto result = backend->create_tensor(element::f32, shape);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(vector<float>{-1.32581766f,
                                                 -1.10714872f,
                                                 -0.78539816f,
@@ -148,7 +148,7 @@ NGRAPH_TEST(${BACKEND_NAME}, ceiling)
     copy_data(a, vector<float>{-2.5f, -2.0f, 0.3f, 4.8f});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{-2.0f, -2.0f, 1.0f, 5.0f}), read_vector<float>(result));
 }
 
@@ -165,7 +165,7 @@ NGRAPH_TEST(${BACKEND_NAME}, cos)
     vector<float> input{0.f, 0.25f, -0.25f, 0.5f, -0.5f, 1.f, -1.f, 2.f, -2.f, 4.f, -4.f};
     copy_data(a, input);
     auto result = backend->create_tensor(element::f32, shape);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(vector<float>{1.00000000f,
                                                 0.96891242f,
                                                 0.96891242f,
@@ -197,7 +197,7 @@ NGRAPH_TEST(${BACKEND_NAME}, cosh)
     std::transform(
         input.begin(), input.end(), input.begin(), [](float x) -> float { return coshf(x); });
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(input, read_vector<float>(result)));
 }
 
@@ -214,7 +214,7 @@ NGRAPH_TEST(${BACKEND_NAME}, exp)
     copy_data(a, vector<float>{-4, -3, -2, -1, 0, 1, 2, 3});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(
         vector<float>{expf(-4), expf(-3), expf(-2), expf(-1), expf(0), expf(1), expf(2), expf(3)},
         read_vector<float>(result)));
@@ -233,7 +233,7 @@ NGRAPH_TEST(${BACKEND_NAME}, floor)
     copy_data(a, vector<float>{-2.5f, -2.0f, 0.3f, 4.8f});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{-3.0f, -2.0f, 0.0f, 4.0f}), read_vector<float>(result));
 }
 
@@ -258,7 +258,7 @@ NGRAPH_TEST(${BACKEND_NAME}, log)
                        2.77258872f};
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(loga, read_vector<float>(result)));
 }
 
@@ -275,7 +275,7 @@ NGRAPH_TEST(${BACKEND_NAME}, negative)
     copy_data(a, vector<float>{1, -2, 0, -4.75f, 8.75f, -8.75f});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{-1, 2, 0, 4.75f, -8.75f, 8.75f}), read_vector<float>(result));
 }
 
@@ -292,7 +292,7 @@ NGRAPH_TEST(${BACKEND_NAME}, not)
     copy_data(a, vector<char>{1, 0, 2, 0});
     auto result = backend->create_tensor(element::boolean, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<char>{0, 1, 0, 1}), read_vector<char>(result));
 }
 
@@ -309,7 +309,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sign)
     copy_data(a, vector<float>{1, -2, 0, -4.8f, 4.8f, -0.0f});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{1, -1, 0, -1, 1, 0}), read_vector<float>(result));
 }
 
@@ -326,7 +326,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sin)
     vector<float> input{0.f, 0.25f, -0.25f, 0.5f, -0.5f, 1.f, -1.f, 2.f, -2.f, 4.f, -4.f};
     copy_data(a, input);
     auto result = backend->create_tensor(element::f32, shape);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(vector<float>{0.00000000f,
                                                 0.24740396f,
                                                 -0.24740396f,
@@ -358,7 +358,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sinh)
     std::transform(
         input.begin(), input.end(), input.begin(), [](float x) -> float { return sinhf(x); });
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(input, read_vector<float>(result)));
 }
 
@@ -375,7 +375,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sqrt)
     copy_data(a, vector<float>{16, 4, 81, 100, 10000, 0});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{4, 2, 9, 10, 100, 0}), read_vector<float>(result));
 }
 
@@ -392,7 +392,7 @@ NGRAPH_TEST(${BACKEND_NAME}, tan)
     vector<float> input{0.f, 0.25f, -0.25f, 0.5f, -0.5f, 1.f, -1.f, 2.f, -2.f, 4.f, -4.f};
     copy_data(a, input);
     auto result = backend->create_tensor(element::f32, shape);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(vector<float>{0.00000000f,
                                                 0.25534192f,
                                                 -0.25534192f,
@@ -424,6 +424,6 @@ NGRAPH_TEST(${BACKEND_NAME}, tanh)
     std::transform(
         input.begin(), input.end(), input.begin(), [](float x) -> float { return tanhf(x); });
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_TRUE(test::all_close_f(input, read_vector<float>(result)));
 }

--- a/test/builder.cpp
+++ b/test/builder.cpp
@@ -34,7 +34,7 @@ shared_ptr<runtime::Tensor>
     auto a = backend->create_tensor(element::f32, shape_a);
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
 
     return result;
 }
@@ -51,7 +51,7 @@ shared_ptr<runtime::Tensor> make_reduce_result_true(
     auto a = backend->create_tensor(element::f32, shape_a);
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
 
     return result;
 }
@@ -68,7 +68,7 @@ shared_ptr<runtime::Tensor> make_reduce_result_false(
     auto a = backend->create_tensor(element::f32, shape_a);
     copy_data(a, vector<float>{1, 2, 3, 4, 5, 6});
     auto result = backend->create_tensor(element::f32, shape_rt);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
 
     return result;
 }
@@ -148,7 +148,7 @@ TEST(builder, tensor_mask)
     copy_data(sequence_lengths_data, vector<uint32_t>{1, 3, 2});
     auto result = backend->create_tensor(element::boolean, mask_shape);
 
-    backend->call_with_validate(f, {result}, {sequence_lengths_data});
+    backend->call_with_validate(backend->compile(f), {result}, {sequence_lengths_data});
     vector<char> expected{1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0};
 
     EXPECT_EQ(expected, read_vector<char>(result));

--- a/test/builder_quantization.cpp
+++ b/test/builder_quantization.cpp
@@ -54,7 +54,7 @@ TEST(builder, scaled_QMP_unsigned)
     auto a = backend->create_tensor(element::u8, shape_a);
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::u8, shape_r);
-    backend->call(f, {result}, {a});
+    backend->call(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<uint8_t>{3, 3, 2, 3, 3, 2}), read_vector<uint8_t>(result));
 }
 

--- a/test/builder_quantization.cpp
+++ b/test/builder_quantization.cpp
@@ -78,7 +78,7 @@ TEST(builder, scaled_QMP_signed)
     auto a = backend->create_tensor(element::i8, shape_a);
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::i8, shape_r);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int8_t>{2, 2, 2, 2, 2, 2}), read_vector<int8_t>(result));
 }
 
@@ -102,7 +102,7 @@ TEST(builder, scaled_QAP_unsigned)
     auto a = backend->create_tensor(element::u8, shape_a);
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::u8, shape_r);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<uint8_t>{1, 1, 1, 1, 1, 0}), read_vector<uint8_t>(result));
 }
 
@@ -126,7 +126,7 @@ TEST(builder, scaled_QAP_signed)
     auto a = backend->create_tensor(element::i8, shape_a);
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::i8, shape_r);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int8_t>{2, 0, 0, 0, 0, 1}), read_vector<int8_t>(result));
 }
 
@@ -166,7 +166,7 @@ TEST(builder, scaled_QC)
     auto b = backend->create_tensor(element::i8, shape_b);
     copy_data(b, b_data);
     auto result = backend->create_tensor(element::i8, shape_r);
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<int8_t>{31, 48, 42, 45, 54, 102, 127, 61, 47, 74, 61, 55}),
               read_vector<int8_t>(result));
 }
@@ -207,7 +207,7 @@ TEST(builder, scaled_QC_with_relu)
     auto b = backend->create_tensor(element::i8, shape_b);
     copy_data(b, b_data);
     auto result = backend->create_tensor(element::u8, shape_r);
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ((vector<uint8_t>{0, 0, 0, 0, 0, 0, 69, 106, 90}), read_vector<uint8_t>(result));
 }
 
@@ -252,7 +252,7 @@ TEST(builder, scaled_QC_with_bias)
     auto c = backend->create_tensor(element::i32, Shape{1});
     copy_data(c, c_data);
     auto result = backend->create_tensor(element::i8, shape_r);
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<int8_t>{38, 55, 50, 52, 61, 109, 127, 68, 54, 81, 68, 62}),
               read_vector<int8_t>(result));
 }
@@ -299,7 +299,7 @@ TEST(builder, scaled_QC_with_bias_and_relu)
     auto c = backend->create_tensor(element::i32, Shape{1});
     copy_data(c, c_data);
     auto result = backend->create_tensor(element::u8, shape_r);
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ((vector<uint8_t>{0, 0, 0, 0, 0, 0, 96, 133, 117}), read_vector<uint8_t>(result));
 }
 
@@ -319,7 +319,7 @@ TEST(builder, scaled_Q_unsigned)
     auto a = backend->create_tensor(element::f32, shape_a);
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::u8, shape_a);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<uint8_t>{0, 0, 1, 1, 2, 64, 127, 255}), read_vector<uint8_t>(result));
 }
 
@@ -339,7 +339,7 @@ TEST(builder, scaled_Q_signed)
     auto a = backend->create_tensor(element::f32, shape_a);
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::i8, shape_a);
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<int8_t>{-127, 0, 1, 3, 5, 64, 127, 127}), read_vector<int8_t>(result));
 }
 
@@ -357,6 +357,6 @@ TEST(builder, scaled_DQ_signed)
     auto a = backend->create_tensor(element::i8, Shape{1});
     copy_data(a, a_data);
     auto result = backend->create_tensor(element::f32, Shape{1});
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ((vector<float>{99.212601}), read_vector<float>(result));
 }

--- a/test/cpu_debugger.cpp
+++ b/test/cpu_debugger.cpp
@@ -61,8 +61,9 @@ TEST(debugger, add_breakpoint)
     copy_data(a, dataA);
     copy_data(b, dataB);
 
-    auto cf =
-        std::dynamic_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(f);
+    auto handle = backend->compile(f);
+    auto cf = std::static_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(
+        handle);
 
     ngraph::runtime::cpu::CPU_Debugger dbg(*cf);
 
@@ -97,8 +98,9 @@ TEST(debugger, stepping)
     copy_data(a, dataA);
     copy_data(b, dataB);
 
-    auto cf =
-        std::dynamic_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(f);
+    auto handle = backend->compile(f);
+    auto cf = std::static_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(
+        handle);
 
     ngraph::runtime::cpu::CPU_Debugger dbg(*cf);
 
@@ -134,8 +136,9 @@ TEST(debugger, delete_breakpoint)
     copy_data(a, dataA);
     copy_data(b, dataB);
 
-    auto cf =
-        std::dynamic_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(f);
+    auto handle = backend->compile(f);
+    auto cf = std::static_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(
+        handle);
 
     ngraph::runtime::cpu::CPU_Debugger dbg(*cf);
 
@@ -174,8 +177,9 @@ TEST(debugger, while_stepping)
     copy_data(a, dataA);
     copy_data(b, dataB);
 
-    auto cf =
-        std::dynamic_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(f);
+    auto handle = backend->compile(f);
+    auto cf = std::static_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(
+        handle);
 
     ngraph::runtime::cpu::CPU_Debugger dbg(*cf);
 
@@ -212,8 +216,9 @@ TEST(debugger, resume)
     copy_data(a, dataA);
     copy_data(b, dataB);
 
-    auto cf =
-        std::dynamic_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(f);
+    auto handle = backend->compile(f);
+    auto cf = std::static_pointer_cast<ngraph::runtime::cpu::CPU_Backend>(backend)->get_call_frame(
+        handle);
 
     ngraph::runtime::cpu::CPU_Debugger dbg(*cf);
 

--- a/test/cpu_fusion.cpp
+++ b/test/cpu_fusion.cpp
@@ -633,8 +633,9 @@ TEST(cpu_fusion, conv_bias_fprop_n1c1h3w3)
     auto f = make_shared<Function>(
         convolution_bias, op::ParameterVector{conv_test.data, conv_test.weights, conv_test.bias});
 
-    backend->call_with_validate(
-        f, {conv_test.result_val}, {conv_test.data_val, conv_test.weights_val, conv_test.bias_val});
+    backend->call_with_validate(backend->compile(f),
+                                {conv_test.result_val},
+                                {conv_test.data_val, conv_test.weights_val, conv_test.bias_val});
     auto result_vec = read_vector<float>(conv_test.result_val);
 
     EXPECT_TRUE(
@@ -664,7 +665,7 @@ TEST(cpu_fusion, conv_bias_bprop_n1c1h3w3)
         NodeVector{d_data, d_weights, d_bias},
         op::ParameterVector{conv_test.data, conv_test.weights, conv_test.bias, conv_test.delta});
     backend->call_with_validate(
-        df,
+        backend->compile(df),
         {conv_test.d_data_val, conv_test.d_weights_val, conv_test.d_bias_val},
         {conv_test.data_val, conv_test.weights_val, conv_test.bias_val, conv_test.delta_val});
 
@@ -1248,7 +1249,8 @@ std::vector<shared_ptr<runtime::Tensor>> rnn_matrix_fusion_eval(const size_t tim
     copy_data(data_tensor, data_val);
     copy_data(weights_tensor, weights_val);
     copy_data(bias_tensor, bias_val);
-    backend->call_with_validate(func, result_tensors, {data_tensor, weights_tensor, bias_tensor});
+    backend->call_with_validate(
+        backend->compile(func), result_tensors, {data_tensor, weights_tensor, bias_tensor});
     return result_tensors;
 }
 
@@ -1442,7 +1444,7 @@ TEST(cpu_fusion, backwards_maxpool_with_indices_n4_c1_hw4_2x2_max)
         pass_manager.run_passes(df);
     }
 
-    backend->call_with_validate(df, {output}, {input, ep});
+    backend->call_with_validate(backend->compile(df), {output}, {input, ep});
     ASSERT_TRUE(read_vector<float>(output) == expected);
 }
 
@@ -1631,7 +1633,7 @@ TEST(cpu_fusion, loop_kernel_copy_with_new_args)
     copy_data(d, dataD);
 
     backend->call_with_validate(backend->compile(f), {r1, r2, r3}, {a, b, c, d});
-    backend->call_with_validate(copy_f, {copy_r1, copy_r2, copy_r3}, {a, b, c, d});
+    backend->call_with_validate(backend->compile(copy_f), {copy_r1, copy_r2, copy_r3}, {a, b, c, d});
 
     EXPECT_EQ(read_vector<int>(r1), read_vector<int>(copy_r1));
     EXPECT_EQ(read_vector<int>(r2), read_vector<int>(copy_r2));
@@ -2066,7 +2068,7 @@ TEST(cpu_fusion, group_convolution)
     auto upper_result = std::dynamic_pointer_cast<ngraph::runtime::cpu::CPUTensorView>(
         backend->create_tensor(element::f32, shape_ur, erv.data() + erv.size() / 2));
     backend->call_with_validate(
-        f, {group_result, lower_result, upper_result}, {a_, b_, c_, d_, e_, f_});
+        backend->compile(f), {group_result, lower_result, upper_result}, {a_, b_, c_, d_, e_, f_});
     ASSERT_EQ(rv, erv);
 }
 
@@ -2129,7 +2131,7 @@ TEST(cpu_fusion, rnn_fprop_1_lstm_cell)
     copy_data(biases_t, vector<float>(400, 1));
 
     backend->call_with_validate(
-        func,
+        backend->compile(func),
         {result_ht, result_ct},
         {src_layer_t, src_iter_t, weights_layer_t, weights_iter_t, biases_t});
     vector<float> expected_ht(10 * 100, 0.964028f);
@@ -2514,7 +2516,7 @@ void sigmoid_multiply_fusion_forward_compute(runtime::Backend* backend,
 
     auto mul_node = input_0_node * input_1_node;
     auto func = make_shared<Function>(mul_node, input_params);
-    backend->call_with_validate(func, {result_tensor}, input_tensors);
+    backend->call_with_validate(backend->compile(func), {result_tensor}, input_tensors);
     EXPECT_TRUE(test::all_close(read_vector<float>(result_tensor), expected));
 }
 
@@ -2708,7 +2710,8 @@ void sigmoid_multiply_fusion_backward_compute(runtime::Backend* backend,
     auto d_input_0 = adjoints.backprop_node(input_0_adjoint);
     auto d_input_1 = adjoints.backprop_node(input_1_adjoint);
     auto df = make_shared<Function>(NodeVector{d_input_0, d_input_1}, back_params);
-    backend->call_with_validate(df, {d_input_0_tensor, d_input_1_tensor}, input_tensors);
+    backend->call_with_validate(
+        backend->compile(df), {d_input_0_tensor, d_input_1_tensor}, input_tensors);
     EXPECT_TRUE(test::all_close(read_vector<float>(d_input_0_tensor), expected_0));
     EXPECT_TRUE(test::all_close(read_vector<float>(d_input_1_tensor), expected_1));
 }

--- a/test/cpu_fusion.cpp
+++ b/test/cpu_fusion.cpp
@@ -155,7 +155,7 @@ TEST(cpu_fusion, gemm_cpu_broadcast_row)
     copy_data(a, dataA);
     copy_data(b, dataB);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     vector<float> expected{11, 30, 38, 111};
     EXPECT_EQ(read_vector<float>(result), expected);
 }
@@ -186,7 +186,7 @@ TEST(cpu_fusion, gemm_cpu_broadcast_column)
     copy_data(a, dataA);
     copy_data(b, dataB);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     vector<float> expected{11, 29, 39, 111};
     EXPECT_EQ(read_vector<float>(result), expected);
 }
@@ -221,7 +221,7 @@ TEST(cpu_fusion, gemm_cpu_broadcast_matrix)
     copy_data(a, dataA);
     copy_data(b, dataB);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     vector<float> expected{10, 28, 37, 109};
     ASSERT_TRUE(read_vector<float>(result) == expected);
 }
@@ -253,7 +253,7 @@ TEST(cpu_fusion, gemm_cpu_no_bias)
     copy_data(a, dataA);
     copy_data(b, dataB);
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     vector<float> expected{9, 27, 36, 108};
     ASSERT_TRUE(read_vector<float>(result) == expected);
 }
@@ -766,7 +766,7 @@ TEST(cpu_fusion, batchnorm_fprop_relu_b1c2h2w2)
     auto result_mean_bnr = backend->create_tensor(element::f32, mean_shape);
     auto result_variance_bnr = backend->create_tensor(element::f32, var_shape);
 
-    backend->call_with_validate(f,
+    backend->call_with_validate(backend->compile(f),
                                 {bn_output,
                                  result_mean,
                                  result_variance,
@@ -1464,7 +1464,7 @@ TEST(cpu_fusion, loop_kernel_one_input_one_output)
     copy_data(a, dataA);
     vector<int> expected{-1, -4, -1, -4};
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
 
     EXPECT_EQ(read_vector<int>(result), expected);
 }
@@ -1491,7 +1491,7 @@ TEST(cpu_fusion, loop_kernel_embedded_graph)
     vector<int> dataB{1, 2, 3, 4};
     copy_data(b, dataB);
     vector<int> expected{-2, -6, -4, -8};
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
     EXPECT_EQ(read_vector<int>(result), expected);
 }
 
@@ -1516,7 +1516,7 @@ TEST(cpu_fusion, loop_kernel_two_inputs_one_output)
     copy_data(b, dataB);
     vector<int> expected{2, 6, 4, 8};
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
 
     EXPECT_EQ(read_vector<int>(result), expected);
 }
@@ -1568,7 +1568,7 @@ TEST(cpu_fusion, loop_kernel_multiple_outputs)
     copy_data(c, dataC);
     copy_data(d, dataD);
 
-    backend->call_with_validate(f, {r1, r2, r3}, {a, b, c, d});
+    backend->call_with_validate(backend->compile(f), {r1, r2, r3}, {a, b, c, d});
 
     vector<int> expected1{5, 11, 5, 17};
     vector<int> expected2{2, 7, 5, 14};
@@ -1630,7 +1630,7 @@ TEST(cpu_fusion, loop_kernel_copy_with_new_args)
     copy_data(c, dataC);
     copy_data(d, dataD);
 
-    backend->call_with_validate(f, {r1, r2, r3}, {a, b, c, d});
+    backend->call_with_validate(backend->compile(f), {r1, r2, r3}, {a, b, c, d});
     backend->call_with_validate(copy_f, {copy_r1, copy_r2, copy_r3}, {a, b, c, d});
 
     EXPECT_EQ(read_vector<int>(r1), read_vector<int>(copy_r1));

--- a/test/cpu_test.cpp
+++ b/test/cpu_test.cpp
@@ -121,15 +121,15 @@ TEST(cpu_test, abc_tbb)
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
     copy_data(c, test::NDArray<float, 2>({{9, 10}, {11, 12}}).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{54, 80}, {110, 144}})).get_vector());
 
-    backend->call_with_validate(f, {result}, {b, a, c});
+    backend->call_with_validate(backend->compile(f), {result}, {b, a, c});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{54, 80}, {110, 144}})).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, c, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, c, b});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{50, 72}, {98, 128}})).get_vector());
 
@@ -189,7 +189,7 @@ TEST(cpu_test, mkldnn_layouts)
         expected_result.push_back(16.0f);
     }
 
-    backend->call_with_validate(f, {result}, {a, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b});
 
     EXPECT_EQ(vector<float>{expected_result}, rv);
 }

--- a/test/distributed.in.cpp
+++ b/test/distributed.in.cpp
@@ -49,6 +49,6 @@ TEST(distributed_${BACKEND_NAME}, allreduce)
     std::transform(
         v.begin(), v.end(), v.begin(), std::bind1st(std::multiplies<float>(), comm_size));
 
-    backend->call_with_validate(f, {result}, {a});
+    backend->call_with_validate(backend->compile(f), {result}, {a});
     EXPECT_EQ(v, read_vector<float>(result));
 }

--- a/test/gpu_fusion.cpp
+++ b/test/gpu_fusion.cpp
@@ -271,7 +271,7 @@ TEST(gpu_fusion, lstm_analytic)
     std::shared_ptr<runtime::Tensor> result_ct =
         backend->create_tensor(element::f32, ct->get_shape());
 
-    backend->call_with_validate(f,
+    backend->call_with_validate(backend->compile(f),
                                 {result_ht, result_ct},
                                 {input_xt_t, weights_i2h_t, weights_h2h_t, bias_i2h_t, bias_h2h_t});
 
@@ -410,7 +410,7 @@ TEST(gpu_fusion, fuse_2_layer_rnn_1lstm_analytic)
     std::shared_ptr<runtime::Tensor> result_ct =
         backend->create_tensor(element::f32, ct->get_shape());
 
-    backend->call_with_validate(f, {result_ht, result_ct}, arg_tensors);
+    backend->call_with_validate(backend->compile(f), {result_ht, result_ct}, arg_tensors);
     //EXPECT_EQ(1, count_ops_of_type<op::gpu::Rnn>(f));
 
     auto sig = [](float x) { return 1.0f / (1.0f + std::exp(-x)); };

--- a/test/gpu_fusion.cpp
+++ b/test/gpu_fusion.cpp
@@ -113,8 +113,9 @@ TEST(gpu_fusion, rnn_fprop_1_lstm_cell)
     copy_data(state_iter_t, vector<float>(1000, 1));
     copy_data(params_t, vector<float>(shape_size(params->get_shape()), 1));
 
-    backend->call_with_validate(
-        func, {result_ht, result_ct}, {src_layer_t, src_iter_t, params_t, state_iter_t});
+    backend->call_with_validate(backend->compile(func),
+                                {result_ht, result_ct},
+                                {src_layer_t, src_iter_t, params_t, state_iter_t});
     vector<float> expected_ht(10 * 100, 0.964028f);
     vector<float> expected_ct;
     for (size_t i = 0; i < 10 * 100; i++)

--- a/test/gpu_test.cpp
+++ b/test/gpu_test.cpp
@@ -206,7 +206,7 @@ TEST(gpu_test, topk_fanout_graph_transform)
     auto r2 = backend->create_tensor(element::f32, out_shape);
     auto r3 = backend->create_tensor(element::f32, out_shape);
 
-    backend->call_with_validate(gpu_f, {r0, r1, r2, r3}, {a, b, c, d, e});
+    backend->call_with_validate(backend->compile(gpu_f), {r0, r1, r2, r3}, {a, b, c, d, e});
 
     EXPECT_EQ((vector<int32_t>{2, 1, 1, 2, 1, 2, 0, 1}), read_vector<int32_t>(r0));
     EXPECT_EQ((vector<int32_t>{2, 1, 1, 2, 1, 2, 0, 1}), read_vector<int32_t>(r1));

--- a/test/graph_partition.cpp
+++ b/test/graph_partition.cpp
@@ -173,7 +173,7 @@ public:
             }
 
             // Call
-            backend->call_with_validate(sub_function, result_tvs, parameter_tvs);
+            backend->call_with_validate(backend->compile(sub_function), result_tvs, parameter_tvs);
         }
         return rc;
     }
@@ -385,7 +385,7 @@ TEST(graph_partition, hybrid_abc)
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
     copy_data(c, test::NDArray<float, 2>({{9, 10}, {11, 12}}).get_vector());
 
-    backend->call_with_validate(f, {r}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {r}, {a, b, c});
     EXPECT_EQ(read_vector<float>(r),
               (test::NDArray<float, 2>({{54, 80}, {110, 144}})).get_vector());
 }
@@ -424,7 +424,7 @@ TEST(graph_partition, hybrid_abcd)
     copy_data(c, test::NDArray<float, 2>({{9, 10}, {11, 12}}).get_vector());
     copy_data(d, test::NDArray<float, 2>({{13, 14}, {15, 16}}).get_vector());
 
-    backend->call_with_validate(f, {r}, {a, b, c, d});
+    backend->call_with_validate(backend->compile(f), {r}, {a, b, c, d});
     EXPECT_EQ(read_vector<float>(r), (test::NDArray<float, 2>({{32, 48}, {68, 92}})).get_vector());
 }
 
@@ -458,7 +458,7 @@ TEST(graph_partition, hybrid_back_and_forth)
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
     copy_data(c, test::NDArray<float, 2>({{9, 10}, {11, 12}}).get_vector());
 
-    backend->call_with_validate(f, {r}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {r}, {a, b, c});
     EXPECT_EQ(read_vector<float>(r),
               (test::NDArray<float, 2>({{90, 180}, {308, 480}})).get_vector());
 }
@@ -495,7 +495,7 @@ TEST(graph_partition, hybrid_multi_middle_nodes)
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
     copy_data(c, test::NDArray<float, 2>({{9, 10}, {11, 12}}).get_vector());
 
-    backend->call_with_validate(f, {r}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {r}, {a, b, c});
     EXPECT_EQ(read_vector<float>(r),
               (test::NDArray<float, 2>({{210, 288}, {378, 480}})).get_vector());
 }
@@ -521,7 +521,7 @@ TEST(graph_partition, hybrid_no_split)
     copy_data(a, test::NDArray<float, 2>({{1, 2}, {3, 4}}).get_vector());
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
 
-    backend->call_with_validate(f, {c}, {a, b});
+    backend->call_with_validate(backend->compile(f), {c}, {a, b});
     EXPECT_EQ(read_vector<float>(c), (test::NDArray<float, 2>({{6, 8}, {10, 12}})).get_vector());
 }
 

--- a/test/halide.cpp
+++ b/test/halide.cpp
@@ -58,7 +58,7 @@ TEST(halide, halide_subgraph)
 
     vector<float> expected{1, 36, 6, 55, 3, 55, 105, 171};
 
-    backend->call_with_validate(f, {result}, {a, b, c, d});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c, d});
 
     EXPECT_TRUE(test::all_close(read_vector<float>(result), expected, 1.0e-4f, 1.0e-4f));
 }

--- a/test/hybrid_backend.cpp
+++ b/test/hybrid_backend.cpp
@@ -73,15 +73,15 @@ TEST(HYBRID, abc)
     copy_data(b, test::NDArray<float, 2>({{5, 6}, {7, 8}}).get_vector());
     copy_data(c, test::NDArray<float, 2>({{9, 10}, {11, 12}}).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, b, c});
+    backend->call_with_validate(backend->compile(f), {result}, {a, b, c});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{54, 80}, {110, 144}})).get_vector());
 
-    backend->call_with_validate(f, {result}, {b, a, c});
+    backend->call_with_validate(backend->compile(f), {result}, {b, a, c});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{54, 80}, {110, 144}})).get_vector());
 
-    backend->call_with_validate(f, {result}, {a, c, b});
+    backend->call_with_validate(backend->compile(f), {result}, {a, c, b});
     EXPECT_EQ(read_vector<float>(result),
               (test::NDArray<float, 2>({{50, 72}, {98, 128}})).get_vector());
 }

--- a/test/hybrid_utils.cpp
+++ b/test/hybrid_utils.cpp
@@ -44,69 +44,54 @@ shared_ptr<runtime::Tensor> TestBackend::create_tensor(const element::Type& elem
     return m_backend_list[0]->create_tensor(element_type, shape, memory_pointer);
 }
 
-bool TestBackend::compile(shared_ptr<Function> func)
+runtime::Handle TestBackend::compile(const shared_ptr<Function>& func)
 {
-    if (m_function_map.find(func) == m_function_map.end())
+    // Clone function
+    auto instance = make_shared<FunctionInstance>();
+    m_instances.push_back(instance);
+    instance->m_function = clone_function(*func);
+
+    // Run placement pass
+    pass::Manager pass_manager;
+    pass_manager.register_pass<pass::AssignPlacement>(m_backend_list);
+    pass_manager.run_passes(instance->m_function);
+
+    // Split function to sub_functions
+    tie(instance->m_sub_functions, instance->m_map_parameter_to_result) =
+        split_function_by_placement_size(instance->m_function);
+
+    // Compile subfunctions in corresponding backends
+    for (shared_ptr<Function>& sub_function : instance->m_sub_functions)
     {
-        // Clone function
-        FunctionInstance instance;
-        instance.m_function = clone_function(*func);
-
-        // Run placement pass
-        pass::Manager pass_manager;
-        pass_manager.register_pass<pass::AssignPlacement>(m_backend_list);
-        pass_manager.run_passes(instance.m_function);
-
-        // Split function to sub_functions
-        tie(instance.m_sub_functions, instance.m_map_parameter_to_result) =
-            split_function_by_placement_size(instance.m_function);
-        m_function_map.insert({func, instance});
-
-        // Compile subfunctions in corresponding backends
-        for (shared_ptr<Function>& sub_function : instance.m_sub_functions)
-        {
-            size_t placement = get_colocated_function_placement_size(sub_function);
-            auto backend =
-                m_backend_list[(placement - 1)]; // (placement-1) as 0 is default placement
-            backend->compile(sub_function);
-        }
+        size_t placement = get_colocated_function_placement_size(sub_function);
+        auto backend = m_backend_list[(placement - 1)]; // (placement-1) as 0 is default placement
+        backend->compile(sub_function);
     }
 
-    return true;
+    return instance.get();
 }
 
-bool TestBackend::call(shared_ptr<Function> func,
+bool TestBackend::call(runtime::Handle handle,
                        const vector<shared_ptr<runtime::Tensor>>& outputs,
                        const vector<shared_ptr<runtime::Tensor>>& inputs)
 {
     // Get FunctionInstance
     bool rc = true;
-    auto it = m_function_map.find(func);
-    if (it == m_function_map.end())
-    {
-        compile(func);
-        it = m_function_map.find(func);
-    }
-
-    if (it == m_function_map.end())
-    {
-        throw runtime_error("Error constructing backend.");
-    }
-    FunctionInstance& instance = it->second;
+    FunctionInstance* instance = static_cast<FunctionInstance*>(handle);
 
     // Parameter and result node in sub_function maps to one Tensor
     unordered_map<shared_ptr<Node>, shared_ptr<runtime::Tensor>> map_node_to_tensor_view;
     for (size_t i = 0; i < inputs.size(); ++i)
     {
-        map_node_to_tensor_view[instance.m_function->get_parameters()[i]] = inputs[i];
+        map_node_to_tensor_view[instance->m_function->get_parameters()[i]] = inputs[i];
     }
     for (size_t i = 0; i < outputs.size(); ++i)
     {
-        map_node_to_tensor_view[instance.m_function->get_results()[i]] = outputs[i];
+        map_node_to_tensor_view[instance->m_function->get_results()[i]] = outputs[i];
     }
 
     // Call subfunctions
-    for (shared_ptr<Function>& sub_function : instance.m_sub_functions)
+    for (shared_ptr<Function>& sub_function : instance->m_sub_functions)
     {
         // Init backend
         size_t placement = get_colocated_function_placement_size(sub_function);
@@ -122,7 +107,7 @@ bool TestBackend::call(shared_ptr<Function> func,
             }
             else
             {
-                auto result_node = instance.m_map_parameter_to_result.at(parameter_node);
+                auto result_node = instance->m_map_parameter_to_result.at(parameter_node);
                 auto result_tv = map_node_to_tensor_view.at(result_node);
                 auto parameter_tv = backend->create_tensor(parameter_node->get_element_type(),
                                                            parameter_node->get_shape());

--- a/test/hybrid_utils.hpp
+++ b/test/hybrid_utils.hpp
@@ -41,9 +41,9 @@ public:
                       const ngraph::Shape& shape,
                       void* memory_pointer) override;
 
-    bool compile(std::shared_ptr<ngraph::Function> func) override;
+    ngraph::runtime::Handle compile(const std::shared_ptr<ngraph::Function>& func) override;
 
-    bool call(std::shared_ptr<ngraph::Function> func,
+    bool call(ngraph::runtime::Handle,
               const std::vector<std::shared_ptr<ngraph::runtime::Tensor>>& outputs,
               const std::vector<std::shared_ptr<ngraph::runtime::Tensor>>& inputs) override;
 
@@ -63,7 +63,7 @@ protected:
             m_map_parameter_to_result;
     };
 
-    std::map<std::shared_ptr<ngraph::Function>, FunctionInstance> m_function_map;
+    std::vector<std::shared_ptr<FunctionInstance>> m_instances;
 };
 
 class BackendWrapper : public ngraph::runtime::Backend
@@ -82,9 +82,9 @@ public:
                       const ngraph::Shape& shape,
                       void* memory_pointer) override;
 
-    bool compile(std::shared_ptr<ngraph::Function> func) override;
+    ngraph::runtime::Handle compile(const std::shared_ptr<ngraph::Function>& func) override;
 
-    bool call(std::shared_ptr<ngraph::Function> func,
+    bool call(ngraph::runtime::Handle,
               const std::vector<std::shared_ptr<ngraph::runtime::Tensor>>& outputs,
               const std::vector<std::shared_ptr<ngraph::runtime::Tensor>>& inputs) override;
 

--- a/test/ref_generators/generate_convolution_ref.py
+++ b/test/ref_generators/generate_convolution_ref.py
@@ -246,7 +246,8 @@ NGRAPH_TEST (${BACKEND_NAME}, %s)
 
     vector<float> expected_result{%s};
 
-    backend->call_with_validate(function, {result}, {a, b});
+    auto handle = backend->compile(function);
+    backend->call_with_validate(handle, {result}, {a, b});
     EXPECT_TRUE(test::all_close<float>(vector<float>{expected_result}, read_vector<float>(result), 1.0e-4f, 1.0e-6f));
     // only test backprop for certain cases as it takes significant compute resources
     %sEXPECT_TRUE(autodiff_numeric_compare<float>(backend.get(), make_graph, {a, b}, .01f, .01f));

--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -82,9 +82,8 @@ TEST(serialize, main)
 
     istringstream in(js);
     shared_ptr<Function> sfunc = deserialize(in);
-
-    // Now call h on some test vectors.
     auto backend = runtime::Backend::create("INTERPRETER");
+    auto handle = backend->compile(sfunc);
 
     auto x = backend->create_tensor(element::f32, shape);
     copy_data(x, vector<float>{1, 2, 3, 4});
@@ -94,13 +93,13 @@ TEST(serialize, main)
     copy_data(z, vector<float>{9, 10, 11, 12});
     auto result = backend->create_tensor(element::f32, shape);
 
-    backend->call_with_validate(sfunc, {result}, {x, y, z});
+    backend->call_with_validate(handle, {result}, {x, y, z});
     EXPECT_EQ((vector<float>{216, 320, 440, 576}), read_vector<float>(result));
 
-    backend->call_with_validate(sfunc, {result}, {y, x, z});
+    backend->call_with_validate(handle, {result}, {y, x, z});
     EXPECT_EQ((vector<float>{216, 320, 440, 576}), read_vector<float>(result));
 
-    backend->call_with_validate(sfunc, {result}, {x, z, y});
+    backend->call_with_validate(handle, {result}, {x, z, y});
     EXPECT_EQ((vector<float>{200, 288, 392, 512}), read_vector<float>(result));
 }
 #endif

--- a/test/util/autodiff/numeric_derivative.hpp
+++ b/test/util/autodiff/numeric_derivative.hpp
@@ -58,19 +58,7 @@ namespace ngraph
             // ref_y is the function evaluated at the args
             auto ref_y = backend->create_tensor<T>(y_shape);
 
-            static std::unordered_map<std::shared_ptr<Function>, runtime::Handle>
-                s_compiled_functions;
-            auto it = s_compiled_functions.find(f);
-            runtime::Handle f_handle;
-            if (it == s_compiled_functions.end())
-            {
-                f_handle = backend->compile(f);
-                s_compiled_functions.insert({f, f_handle});
-            }
-            else
-            {
-                f_handle = it->second;
-            }
+            runtime::Handle f_handle = backend->compile(f);
 
             backend->call_with_validate(
                 f_handle, std::vector<std::shared_ptr<ngraph::runtime::Tensor>>{ref_y}, args);

--- a/test/util/test_tools.hpp
+++ b/test/util/test_tools.hpp
@@ -126,7 +126,8 @@ std::vector<std::vector<T1>> execute(const std::shared_ptr<ngraph::Function>& fu
             backend->create_tensor(results.at(i)->get_element_type(), results.at(i)->get_shape());
     }
 
-    backend->call_with_validate(function, result_tensors, arg_tensors);
+    auto handle = backend->compile(function);
+    backend->call_with_validate(handle, result_tensors, arg_tensors);
 
     std::vector<std::vector<T1>> result_vectors;
     for (auto rt : result_tensors)


### PR DESCRIPTION
Change the Backend API by adding the use of an opaque Handle instead of using shared_ptr<Function> as a handle. This allows us to add a `save()` and `load()` function to the Backend. It also means that the caller does not need to maintain a copy of shared_ptr<Function> for the lifetime of a Backend.
You must now call `compile()` or `load()` prior to calling `call()`
This is a WIP. I still need to get validate() working.