### PR TITLE
Fix the error in nbench for input tensor data

### DIFF
--- a/src/tools/nbench/benchmark.cpp
+++ b/src/tools/nbench/benchmark.cpp
@@ -181,7 +181,7 @@ vector<runtime::PerformanceCounter> run_benchmark(shared_ptr<Function> f,
         auto tensor = backend->create_tensor(param->get_element_type(), param->get_shape());
         auto tensor_data =
             make_shared<runtime::HostTensor>(param->get_element_type(), param->get_shape());
-        random_init(tensor);
+        random_init(tensor_data);
         args.push_back(tensor);
         arg_data.push_back(tensor_data);
         args_cacheable.push_back(param->get_cacheable());


### PR DESCRIPTION
The input tensor data is not initialized, this cause an abort issue in running serialized graph with NNP backend as some of the uninitialized data is out of range for NNP A0 hardware. 