### PR TITLE
Sigmoid layout bugfix

### DIFF
--- a/src/ngraph/runtime/cpu/builder/sigmoid.cpp
+++ b/src/ngraph/runtime/cpu/builder/sigmoid.cpp
@@ -40,8 +40,6 @@ namespace ngraph
 
                 auto input_shape = args[0].get_shape();
                 auto out_shape = out[0].get_shape();
-                auto input_size = static_cast<int>(shape_size(input_shape));
-                auto out_size = static_cast<int>(shape_size(out_shape));
 
                 auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                 auto input_desc = mkldnn_utils::get_input_mkldnn_md(node, 0);
@@ -72,9 +70,6 @@ namespace ngraph
                 auto input_shape = args[0].get_shape();
                 auto delta_shape = args[1].get_shape();
                 auto out_shape = out[0].get_shape();
-                int input_size = static_cast<int>(shape_size(input_shape));
-                int delta_size = static_cast<int>(shape_size(delta_shape));
-                int out_size = static_cast<int>(shape_size(out_shape));
 
                 auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
 

--- a/src/ngraph/runtime/cpu/builder/sigmoid.cpp
+++ b/src/ngraph/runtime/cpu/builder/sigmoid.cpp
@@ -44,14 +44,8 @@ namespace ngraph
                 auto out_size = static_cast<int>(shape_size(out_shape));
 
                 auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
-                auto input_desc = mkldnn::memory::desc(
-                    {input_size},
-                    mkldnn_utils::get_mkldnn_data_type(args[0].get_element_type()),
-                    mkldnn::memory::format::x);
-                auto out_desc = mkldnn::memory::desc(
-                    {out_size},
-                    mkldnn_utils::get_mkldnn_data_type(out[0].get_element_type()),
-                    mkldnn::memory::format::x);
+                auto input_desc = mkldnn_utils::get_input_mkldnn_md(node, 0);
+                auto out_desc = mkldnn_utils::get_output_mkldnn_md(node, 0);
 
                 auto sigmoid_index = mkldnn_emitter->build_sigmoid_forward(input_desc, out_desc);
 
@@ -83,18 +77,10 @@ namespace ngraph
                 int out_size = static_cast<int>(shape_size(out_shape));
 
                 auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
-                auto input_desc = mkldnn::memory::desc(
-                    {input_size},
-                    mkldnn_utils::get_mkldnn_data_type(args[0].get_element_type()),
-                    mkldnn::memory::format::x);
-                auto delta_desc = mkldnn::memory::desc(
-                    {delta_size},
-                    mkldnn_utils::get_mkldnn_data_type(args[1].get_element_type()),
-                    mkldnn::memory::format::x);
-                auto out_desc = mkldnn::memory::desc(
-                    {out_size},
-                    mkldnn_utils::get_mkldnn_data_type(out[0].get_element_type()),
-                    mkldnn::memory::format::x);
+
+                auto input_desc = mkldnn_utils::get_input_mkldnn_md(node, 0);
+                auto delta_desc = mkldnn_utils::get_input_mkldnn_md(node, 1);
+                auto out_desc = mkldnn_utils::get_output_mkldnn_md(node, 0);
 
                 size_t sigmoid_index =
                     mkldnn_emitter->build_sigmoid_backward(input_desc, delta_desc, out_desc);

--- a/src/ngraph/runtime/cpu/cpu_emitter.cpp
+++ b/src/ngraph/runtime/cpu/cpu_emitter.cpp
@@ -4157,8 +4157,6 @@ namespace ngraph
             {
                 auto input_shape = args[0].get_shape();
                 auto result_shape = out[0].get_shape();
-                int input_1d_size = static_cast<int>(shape_size(input_shape));
-                int result_1d_size = static_cast<int>(shape_size(result_shape));
 
                 auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
 
@@ -4184,9 +4182,6 @@ namespace ngraph
                 auto input_shape = args[0].get_shape();
                 auto delta_shape = args[1].get_shape();
                 auto result_shape = out[0].get_shape();
-                int input_1d_size = static_cast<int>(shape_size(input_shape));
-                int delta_1d_size = static_cast<int>(shape_size(delta_shape));
-                int result_1d_size = static_cast<int>(shape_size(result_shape));
 
                 auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
 

--- a/src/ngraph/runtime/cpu/cpu_emitter.cpp
+++ b/src/ngraph/runtime/cpu/cpu_emitter.cpp
@@ -4161,14 +4161,9 @@ namespace ngraph
                 int result_1d_size = static_cast<int>(shape_size(result_shape));
 
                 auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
-                auto input_desc = mkldnn::memory::desc(
-                    {input_1d_size},
-                    mkldnn_utils::get_mkldnn_data_type(args[0].get_element_type()),
-                    mkldnn::memory::format::x);
-                auto result_desc = mkldnn::memory::desc(
-                    {result_1d_size},
-                    mkldnn_utils::get_mkldnn_data_type(out[0].get_element_type()),
-                    mkldnn::memory::format::x);
+
+                auto input_desc = mkldnn_utils::get_input_mkldnn_md(node, 0);
+                auto result_desc = mkldnn_utils::get_output_mkldnn_md(node, 0);
 
                 size_t sigmoid_index =
                     mkldnn_emitter->build_sigmoid_forward(input_desc, result_desc);
@@ -4194,18 +4189,10 @@ namespace ngraph
                 int result_1d_size = static_cast<int>(shape_size(result_shape));
 
                 auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
-                auto input_desc = mkldnn::memory::desc(
-                    {input_1d_size},
-                    mkldnn_utils::get_mkldnn_data_type(args[0].get_element_type()),
-                    mkldnn::memory::format::x);
-                auto delta_desc = mkldnn::memory::desc(
-                    {delta_1d_size},
-                    mkldnn_utils::get_mkldnn_data_type(args[1].get_element_type()),
-                    mkldnn::memory::format::x);
-                auto result_desc = mkldnn::memory::desc(
-                    {result_1d_size},
-                    mkldnn_utils::get_mkldnn_data_type(out[0].get_element_type()),
-                    mkldnn::memory::format::x);
+
+                auto input_desc = mkldnn_utils::get_input_mkldnn_md(node, 0);
+                auto delta_desc = mkldnn_utils::get_input_mkldnn_md(node, 1);
+                auto result_desc = mkldnn_utils::get_output_mkldnn_md(node, 0);
 
                 size_t sigmoid_index =
                     mkldnn_emitter->build_sigmoid_backward(input_desc, delta_desc, result_desc);

--- a/test/cpu_test.cpp
+++ b/test/cpu_test.cpp
@@ -581,12 +581,12 @@ TEST(cpu_test, convert_layout)
 
 TEST(cpu_test, mkldnn_layouts_eltwise)
 {
-    Shape input_shape {3, 11, 14, 14};
-    Shape conv_filter{9, 1, 2, 2};
+    Shape input_shape{3, 11, 14, 14};
+    Shape filter_shape{5, 11, 2, 2};
 
     auto make_function = [&]() {
         auto input = std::make_shared<op::Parameter>(element::f32, input_shape);
-        auto filter = std::make_shared<op::Parameter>(element::f32, conv_filter);
+        auto filter = std::make_shared<op::Parameter>(element::f32, filter_shape);
         auto conv = std::make_shared<op::Convolution>(input, filter, Strides{2, 2}, Strides{1, 1});
         auto sigmoid = std::make_shared<op::Sigmoid>(conv);
         auto f = make_shared<Function>(NodeVector{sigmoid}, ParameterVector{input, filter});
@@ -596,8 +596,8 @@ TEST(cpu_test, mkldnn_layouts_eltwise)
     auto int_f = make_function();
     auto cpu_f = make_function();
 
-    vector<float> input_vec(shape_size(input_shape));
-    vector<float> filter_vec(shape_size(filter_shape));
+    std::vector<float> input_vec(shape_size(input_shape));
+    std::vector<float> filter_vec(shape_size(filter_shape));
     test::Uniform<float> rand_gen(-1, 1);
     rand_gen.initialize(input_vec);
     rand_gen.initialize(filter_vec);

--- a/test/cpu_test.cpp
+++ b/test/cpu_test.cpp
@@ -578,3 +578,32 @@ TEST(cpu_test, convert_layout)
         EXPECT_TRUE(test::all_close(cpu_results.at(i), int_results.at(i)));
     }
 }
+
+TEST(cpu_test, mkldnn_layouts_eltwise)
+{
+    Shape input_shape {3, 11, 14, 14};
+    Shape conv_filter{9, 1, 2, 2};
+
+    auto make_function = [&]() {
+        auto input = std::make_shared<op::Parameter>(element::f32, input_shape);
+        auto filter = std::make_shared<op::Parameter>(element::f32, conv_filter);
+        auto conv = std::make_shared<op::Convolution>(input, filter, Strides{2, 2}, Strides{1, 1});
+        auto sigmoid = std::make_shared<op::Sigmoid>(conv);
+        auto f = make_shared<Function>(NodeVector{sigmoid}, ParameterVector{input, filter});
+        return f;
+    };
+
+    auto int_f = make_function();
+    auto cpu_f = make_function();
+
+    vector<float> input_vec(shape_size(input_shape));
+    vector<float> filter_vec(shape_size(filter_shape));
+    test::Uniform<float> rand_gen(-1, 1);
+    rand_gen.initialize(input_vec);
+    rand_gen.initialize(filter_vec);
+    vector<vector<float>> args{input_vec, filter_vec};
+
+    auto int_results = execute(int_f, args, "INTERPRETER");
+    auto cpu_results = execute(cpu_f, args, "CPU");
+    EXPECT_TRUE(test::all_close(cpu_results.at(0), int_results.at(0)));
+}


### PR DESCRIPTION
Allow sigmoid mkldnn op to query input and output layouts. Added unit test to verify the before (failure) and after (correct) results. Shape channel size is a non multiple of 8 or 16 to trigger mkldnn layout convert to pad with zeros.