### PR TITLE
Discard debug log output in non-debug mode

### DIFF
--- a/src/ngraph/log.cpp
+++ b/src/ngraph/log.cpp
@@ -28,26 +28,6 @@
 using namespace std;
 using namespace ngraph;
 
-namespace
-{
-    class NilStreamBuf final : public streambuf
-    {
-        // N.B. We derive from the base streambuf implementation, in
-        //      which underflow() and overflow() both return
-        //      Traits::eof() -- any access returns a failure.
-    };
-}
-
-ostream& ngraph::get_nil_stream()
-{
-    // N.B. When debug logging is disabled, multiple threads may
-    //      access the nil stream simultaneously, so it's important to
-    //      return a threadsafe nil stream implementation.
-    static NilStreamBuf nil_buf;
-    static ostream nil{&nil_buf};
-    return nil;
-}
-
 void ngraph::default_logger_handler_func(const string& s)
 {
     cout << s << endl;

--- a/src/ngraph/log.hpp
+++ b/src/ngraph/log.hpp
@@ -100,8 +100,6 @@ namespace ngraph
         static std::deque<std::string> m_queue;
     };
 
-    extern std::ostream& get_nil_stream();
-
     void default_logger_handler_func(const std::string& s);
 
 #define NGRAPH_ERR                                                                                 \
@@ -133,6 +131,33 @@ namespace ngraph
                       ngraph::default_logger_handler_func)                                         \
         .stream()
 #else
-#define NGRAPH_DEBUG ngraph::get_nil_stream()
+
+    struct NullLogger
+    {
+    };
+
+    template <typename T>
+    NullLogger&& operator<<(NullLogger&& logger, T&&)
+    {
+        return std::move(logger);
+    }
+
+    template <typename T>
+    NullLogger&& operator<<(NullLogger&& logger, const T&)
+    {
+        return std::move(logger);
+    }
+
+    inline NullLogger&&
+        operator<<(NullLogger&& logger,
+                   std::basic_ostream<char, std::char_traits<char>>& (&)(std::basic_ostream<
+                                                                         char,
+                                                                         std::char_traits<char>>&))
+    {
+        return std::move(logger);
+    }
+
+#define NGRAPH_DEBUG                                                                               \
+    ::ngraph::NullLogger {}
 #endif
 }


### PR DESCRIPTION
It seems wasteful to be generating debug output a character at a time
all the time, only to discard it on non-debug builds.  This change
replaces that behavior by introducing a no-op operator<< for the debug
log on non-debug builds.