### PR TITLE
Fix uninitialized parameter tensor data in nbench

### DIFF
--- a/doc/sphinx/source/frameworks/validation-testing.rst
+++ b/doc/sphinx/source/frameworks/validation-testing.rst
@@ -11,7 +11,7 @@ TensorFlow
 ==========
 
 .. csv-table::
-   :header: "TensorFlow Workloads", "Type"
+   :header: "TensorFlow Workload", "Type"
    :widths: 27, 53
    :escape: ~
 
@@ -37,12 +37,12 @@ MXNet
 =====
 
 .. csv-table::
-   :header: "MXNet Workloads", "Type"
+   :header: "MXNet Workload", "Type"
    :widths: 27, 53
    :escape: ~
 
    Resnet50 v1 and v2, Image recognition
-   DenseNet (121, 161, 169, 201), Image recognition
+   DenseNet-121, Image recognition
    InceptionV3, Image recognition
    InceptionV4, Image recognition
    Inception-ResNetv2, Image recognition
@@ -66,7 +66,7 @@ Additionally, we validated the following workloads are functional through nGraph
 
 
 .. csv-table::
-   :header: "Workload", "Type"
+   :header: "ONNX Workload", "Type"
    :widths: 27, 53
    :escape: ~
 

--- a/src/tools/nbench/benchmark.cpp
+++ b/src/tools/nbench/benchmark.cpp
@@ -176,12 +176,15 @@ vector<runtime::PerformanceCounter> run_benchmark(shared_ptr<Function> f,
     vector<shared_ptr<runtime::HostTensor>> arg_data;
     vector<shared_ptr<runtime::Tensor>> args;
     vector<bool> args_cacheable;
-    for (shared_ptr<op::Parameter> param : f->get_parameters())
+    for (const shared_ptr<op::Parameter> param : f->get_parameters())
     {
         auto tensor = backend->create_tensor(param->get_element_type(), param->get_shape());
         auto tensor_data =
             make_shared<runtime::HostTensor>(param->get_element_type(), param->get_shape());
         random_init(tensor_data);
+        tensor->write(tensor_data->get_data_ptr(),
+                      0,
+                      tensor_data->get_element_count() * tensor_data->get_element_type().size());
         args.push_back(tensor);
         arg_data.push_back(tensor_data);
         args_cacheable.push_back(param->get_cacheable());

--- a/src/tools/nbench/benchmark.cpp
+++ b/src/tools/nbench/benchmark.cpp
@@ -182,13 +182,9 @@ vector<runtime::PerformanceCounter> run_benchmark(shared_ptr<Function> f,
         auto tensor_data =
             make_shared<runtime::HostTensor>(param->get_element_type(), param->get_shape());
         random_init(tensor_data);
-        if (copy_data)
-        {
-            tensor->write(tensor_data->get_data_ptr(),
-                          0,
-                          tensor_data->get_element_count() *
-                              tensor_data->get_element_type().size());
-        }
+        tensor->write(tensor_data->get_data_ptr(),
+                      0,
+                      tensor_data->get_element_count() * tensor_data->get_element_type().size());
         args.push_back(tensor);
         arg_data.push_back(tensor_data);
         args_cacheable.push_back(param->get_cacheable());

--- a/src/tools/nbench/benchmark.cpp
+++ b/src/tools/nbench/benchmark.cpp
@@ -176,7 +176,7 @@ vector<runtime::PerformanceCounter> run_benchmark(shared_ptr<Function> f,
     vector<shared_ptr<runtime::HostTensor>> arg_data;
     vector<shared_ptr<runtime::Tensor>> args;
     vector<bool> args_cacheable;
-    for (const shared_ptr<op::Parameter> param : f->get_parameters())
+    for (shared_ptr<op::Parameter> param : f->get_parameters())
     {
         auto tensor = backend->create_tensor(param->get_element_type(), param->get_shape());
         auto tensor_data =

--- a/src/tools/nbench/benchmark.cpp
+++ b/src/tools/nbench/benchmark.cpp
@@ -182,9 +182,13 @@ vector<runtime::PerformanceCounter> run_benchmark(shared_ptr<Function> f,
         auto tensor_data =
             make_shared<runtime::HostTensor>(param->get_element_type(), param->get_shape());
         random_init(tensor_data);
-        tensor->write(tensor_data->get_data_ptr(),
-                      0,
-                      tensor_data->get_element_count() * tensor_data->get_element_type().size());
+        if (copy_data)
+        {
+            tensor->write(tensor_data->get_data_ptr(),
+                          0,
+                          tensor_data->get_element_count() *
+                              tensor_data->get_element_type().size());
+        }
         args.push_back(tensor);
         arg_data.push_back(tensor_data);
         args_cacheable.push_back(param->get_cacheable());


### PR DESCRIPTION
In nbench, the parameter tensor data is not initialized, and this causes an issue in NNP_SIM backend during the warm up execution for "mxnet/bn_fprop_b2c3h2w2.json".