### PR TITLE
Update external libraries to optionally not version label shared libraries

### DIFF
--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -83,6 +83,11 @@ endforeach()
 
 set(MKLDNN_GIT_REPO_URL https://github.com/intel/mkl-dnn)
 set(MKLDNN_GIT_TAG "830a100")
+if(NGRAPH_LIB_VERSIONING_ENABLE)
+    set(MKLDNN_PATCH_FILE mkldnn.patch)
+else()
+    set(MKLDNN_PATCH_FILE mkldnn_no_so_link.patch)
+endif()
 
 # The 'BUILD_BYPRODUCTS' argument was introduced in CMake 3.2.
 if(${CMAKE_VERSION} VERSION_LESS 3.2)
@@ -98,7 +103,7 @@ if(${CMAKE_VERSION} VERSION_LESS 3.2)
         #    --reject-file tells patch to not right a reject file
         #    || exit 0 changes the exit code for the PATCH_COMMAND to zero so it is not an error
         # I don't like it, but it works
-        PATCH_COMMAND patch -p1 --forward --reject-file=- -i ${CMAKE_SOURCE_DIR}/cmake/mkldnn.patch || exit 0
+        PATCH_COMMAND patch -p1 --forward --reject-file=- -i ${CMAKE_SOURCE_DIR}/cmake/${MKLDNN_PATCH_FILE} || exit 0
         # Uncomment below with any in-flight MKL-DNN patches
         # PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/third-party/patches/mkldnn-cmake-openmp.patch
         CMAKE_ARGS

--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -134,7 +134,7 @@ else()
         #    --reject-file tells patch to not right a reject file
         #    || exit 0 changes the exit code for the PATCH_COMMAND to zero so it is not an error
         # I don't like it, but it works
-        PATCH_COMMAND patch -p1 --forward --reject-file=- -i ${CMAKE_SOURCE_DIR}/cmake/mkldnn.patch || exit 0
+        PATCH_COMMAND patch -p1 --forward --reject-file=- -i ${CMAKE_SOURCE_DIR}/cmake/${MKLDNN_PATCH_FILE} || exit 0
         # Uncomment below with any in-flight MKL-DNN patches
         # PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/third-party/patches/mkldnn-cmake-openmp.patch
         CMAKE_ARGS

--- a/cmake/mkldnn_no_so_link.patch
+++ b/cmake/mkldnn_no_so_link.patch
@@ -1,0 +1,46 @@
+diff --git a/cmake/OpenMP.cmake b/cmake/OpenMP.cmake
+index f9c3620e..ed1ad6c2 100644
+--- a/cmake/OpenMP.cmake
++++ b/cmake/OpenMP.cmake
+@@ -30,14 +30,19 @@ if (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+     # But we still want to build the library.
+     set(_omp_severity "WARNING")
+ else()
+-    set(_omp_severity "FATAL_ERROR")
++    set(_omp_severity "WARNING")
+ endif()
+ 
+ 
+ macro(forbid_link_compiler_omp_rt)
+     if (NOT WIN32)
+-        set_if(OpenMP_C_FOUND CMAKE_C_CREATE_SHARED_LIBRARY_FORBIDDEN_FLAGS ${OpenMP_C_FLAGS})
+-        set_if(OpenMP_CXX_FOUND CMAKE_CXX_CREATE_SHARED_LIBRARY_FORBIDDEN_FLAGS ${OpenMP_CXX_FLAGS})
++        if (OpenMP_C_FOUND)
++            set(CMAKE_C_CREATE_SHARED_LIBRARY_FORBIDDEN_FLAGS ${OpenMP_C_FLAGS})
++        endif()
++        if (OpenMP_CXX_FOUND)
++            set(CMAKE_CXX_CREATE_SHARED_LIBRARY_FORBIDDEN_FLAGS ${OpenMP_CXX_FLAGS})
++        endif()
++
+         if (NOT APPLE)
+             set (CMAKE_SHARED_LINKER_FLAGS "-Wl,--as-needed")
+         endif()
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 83ed499..d7f4ea0 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -98,10 +98,12 @@ else()
+     set(CTESTCONFIG_PATH "${CTESTCONFIG_PATH}\;${CMAKE_CURRENT_BINARY_DIR}" PARENT_SCOPE)
+ endif()
+ target_link_libraries(${TARGET_NAME} ${${TARGET_NAME}_LINKER_LIBS} ${EXTRA_LIBS})
++if(NOT APPLE)
++    set_property(TARGET ${TARGET_NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--rpath,$ORIGIN")
++    set_target_properties(${TARGET_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN")
++endif()
+ set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 11)
+ set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
+-set_property(TARGET ${TARGET_NAME} PROPERTY VERSION "${PROJECT_VERSION}.0")
+-set_property(TARGET ${TARGET_NAME} PROPERTY SOVERSION "0")
+
+ if(MINGW)
+     # We need to install *.dll into bin/ and *.a into lib/.

--- a/src/ngraph/runtime/cpu/CMakeLists.txt
+++ b/src/ngraph/runtime/cpu/CMakeLists.txt
@@ -150,10 +150,6 @@ if (NGRAPH_TBB_ENABLE)
         DESTINATION ${NGRAPH_INSTALL_LIB}
         FILES_MATCHING REGEX "/libtbb${CMAKE_SHARED_LIBRARY_SUFFIX}(\\.[0-9]+)*$"
     )
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tbb_build/tbb_debug/
-        DESTINATION ${NGRAPH_INSTALL_LIB}
-        FILES_MATCHING REGEX "/libtbb_debug${CMAKE_SHARED_LIBRARY_SUFFIX}(\\.[0-9]+)*$"
-    )
     add_library(libtbb INTERFACE)
     target_link_libraries(libtbb INTERFACE
         ${CMAKE_CURRENT_BINARY_DIR}/tbb_build/tbb_release/libtbb${CMAKE_SHARED_LIBRARY_SUFFIX}


### PR DESCRIPTION
Updated MKLDNN to honor the `NGRAPH_LIB_VERSIONING_ENABLE` flag to optionally version label the shared libraries.
Also changed TBB to not install the debug libraries as they are never used.