### PR TITLE
Re-enable CPU.batchnorm_bprop_n4c3h2w2

### DIFF
--- a/src/ngraph/runtime/cpu/unit_test.manifest
+++ b/src/ngraph/runtime/cpu/unit_test.manifest
@@ -14,8 +14,5 @@ shape_of_matrix
 shape_of_5d
 quantize_clamp_int32
 
-# this one just started failing
-batchnorm_bprop_n4c3h2w2
-
 # failing in CI build but passing on local machine
 max_3d_to_scalar_int32


### PR DESCRIPTION
This re-enables `CPU.batchnorm_bprop_n4c3h2w2`. This test seems to have a checkered past:

* Back when it was called `cpu_fusion.bn_bprop_n4c3h2w2` we were observing some random crashes on macOS; this was before we officially supported macOS, so we didn't worry about it.
* More recently, the test was disabled in #2058 because it "just started failing" (no further details available).

I have tried to reproduce the failure with repeated gtest runs as follows, with no success:

* macOS Mojave with DEX
* Ubuntu 16.04 with gcc-5.4.0 and DEX
* Ubuntu 16.04 with gcc-5.4.0 and codegen (pre-built LLVM)
* Ubuntu 16.04 with clang-3.9 and DEX
* Ubuntu 16.04 with clang-3.9 and codegen (non-pre-built LLVM)

I think the best thing to do is to re-enable it, and fix it if the failure crops up again. (Who knows, maybe CI will trip over it!)