### PR TITLE
Remove _backwards from conv backprop ops.

### DIFF
--- a/src/ngraph/op/convolution.cpp
+++ b/src/ngraph/op/convolution.cpp
@@ -270,13 +270,6 @@ void op::ConvolutionBackpropData::validate_and_infer_types()
     //
     // To _validate_, we simply need to check/infer the output shape of the forward convolution,
     // then check to make sure that the incoming delta has the same shape as the forward output.
-    //
-    // We will also compute and store the various parameters in the "backward" column above, since
-    // some backends need them. (TODO(amprocte): Is it just because of the way the reference works
-    // that this stuff is needed? If so, we can probably get rid of it and have conv_backprop
-    // reference kernels that do the calculations of the backward parameters internally, or supply
-    // utility functions to do it.)
-
     const PartialShape& filters_shape = get_input_partial_shape(0);
     element::Type filters_et = get_input_element_type(0);
     const PartialShape& delta_shape = get_input_partial_shape(1);
@@ -302,40 +295,6 @@ void op::ConvolutionBackpropData::validate_and_infer_types()
         << "delta (" << delta_shape << ").";
 
     set_output_type(0, forward_result_et, m_data_batch_shape);
-
-    //
-    // Compute parameters needed for backprop-as-convolution.
-    //
-    // TODO(amprocte): Remove these fields, compute where needed.
-    //
-    if (delta_shape.is_static() && filters_shape.is_static())
-    {
-        size_t spatial_dim_count = static_cast<size_t>(delta_shape.rank()) - 2;
-
-        m_window_movement_strides_backward = m_data_dilation_strides_forward;
-        m_window_dilation_strides_backward = m_window_dilation_strides_forward;
-        m_data_dilation_strides_backward = m_window_movement_strides_forward;
-
-        m_padding_below_backward.resize(spatial_dim_count);
-        m_padding_above_backward.resize(spatial_dim_count);
-
-        for (size_t i = 0; i < spatial_dim_count; i++)
-        {
-            m_padding_below_backward[i] = (static_cast<ptrdiff_t>(filters_shape[i + 2]) - 1) *
-                                              m_window_dilation_strides_forward[i] -
-                                          m_padding_below_forward[i];
-            m_padding_above_backward[i] =
-                (static_cast<ptrdiff_t>(filters_shape[i + 2]) - 1) *
-                    m_window_dilation_strides_forward[i] +
-                ((m_padding_below_forward[i] +
-                  (m_data_batch_shape[i + 2] - 1) * m_data_dilation_strides_forward[i] +
-                  m_padding_above_forward[i] -
-                  (static_cast<ptrdiff_t>(filters_shape[i + 2]) - 1) *
-                      m_window_dilation_strides_forward[i]) %
-                 m_window_movement_strides_forward[i]) -
-                m_padding_above_forward[i];
-        }
-    }
 }
 
 void op::ConvolutionBackpropData::generate_adjoints(autodiff::Adjoints& adjoints,
@@ -364,18 +323,32 @@ void op::ConvolutionBackpropData::generate_adjoints(autodiff::Adjoints& adjoints
     CoordinateDiff padding_below;
     CoordinateDiff padding_above;
     Strides data_dilation_strides;
+    const Shape& filters_shape = get_input_shape(0);
     for (size_t i = 0; i < f_shape.size() - 2; i++)
     {
-        window_movement_strides.push_back(m_window_dilation_strides_backward[i]);
-        window_dilation_strides.push_back(m_window_movement_strides_backward[i]);
-        padding_below.push_back(m_padding_below_backward[i]);
-        padding_above.push_back(m_padding_above_backward[i] -
-                                (m_padding_below_backward[i] +
-                                 (x_shape[i + 2] - 1) * m_data_dilation_strides_backward[i] +
-                                 m_padding_above_backward[i] -
-                                 (f_shape[i + 2] - 1) * m_window_dilation_strides_backward[i]) %
-                                    m_window_movement_strides_backward[i]);
-        data_dilation_strides.push_back(m_data_dilation_strides_backward[i]);
+        window_movement_strides.push_back(m_window_dilation_strides_forward[i]);
+        window_dilation_strides.push_back(m_window_movement_strides_forward[i]);
+        ptrdiff_t padding_below_backward =
+            (static_cast<ptrdiff_t>(filters_shape[i + 2]) - 1) * window_dilation_strides[i] -
+            m_padding_below_forward[i];
+        ptrdiff_t padding_above_backward =
+            (static_cast<ptrdiff_t>(filters_shape[i + 2]) - 1) *
+                m_window_dilation_strides_forward[i] +
+            ((m_padding_below_forward[i] +
+              ((m_data_batch_shape[i + 2]) - 1) * m_data_dilation_strides_forward[i] +
+              m_padding_above_forward[i] -
+              (static_cast<ptrdiff_t>(filters_shape[i + 2]) - 1) *
+                  m_window_dilation_strides_forward[i]) %
+             m_window_movement_strides_forward[i]) -
+            m_padding_above_forward[i];
+
+        padding_below.push_back(padding_below_backward);
+        padding_above.push_back(
+            padding_above_backward -
+            (padding_below_backward + (x_shape[i + 2] - 1) * m_window_movement_strides_forward[i] +
+             padding_above_backward - (f_shape[i + 2] - 1) * m_window_movement_strides_forward[i]) %
+                m_data_dilation_strides_forward[i]);
+        data_dilation_strides.push_back(m_window_movement_strides_forward[i]);
     }
 
     auto swap_NC = [](const shared_ptr<Node> n) {
@@ -499,35 +472,6 @@ void op::ConvolutionBackpropFilters::validate_and_infer_types()
         << "delta (" << delta_shape << ").";
 
     set_output_type(0, forward_result_et, m_filters_shape);
-
-    //
-    // Compute parameters needed for backprop-as-convolution.
-    //
-    // TODO(amprocte): Remove these fields, compute where needed.
-    //
-    if (delta_shape.is_static() && data_batch_shape.is_static())
-    {
-        size_t spatial_dim_count = static_cast<size_t>(delta_shape.rank()) - 2;
-
-        m_window_movement_strides_backward = m_window_dilation_strides_forward;
-        m_window_dilation_strides_backward = m_window_movement_strides_forward;
-        m_padding_below_backward = m_padding_below_forward;
-        m_data_dilation_strides_backward = m_data_dilation_strides_forward;
-
-        m_padding_above_backward.resize(spatial_dim_count);
-
-        for (size_t i = 0; i < spatial_dim_count; i++)
-        {
-            m_padding_above_backward[i] =
-                m_padding_above_forward[i] -
-                (m_padding_below_forward[i] +
-                 (static_cast<ptrdiff_t>(data_batch_shape[i + 2]) - 1) *
-                     m_data_dilation_strides_forward[i] +
-                 m_padding_above_forward[i] -
-                 (m_filters_shape[i + 2] - 1) * m_window_dilation_strides_forward[i]) %
-                    m_window_movement_strides_forward[i];
-        }
-    }
 }
 
 shared_ptr<Node>

--- a/src/ngraph/op/convolution.hpp
+++ b/src/ngraph/op/convolution.hpp
@@ -220,32 +220,6 @@ namespace ngraph
                 return m_data_dilation_strides_forward;
             }
 
-            /// \return The window movement strides for the backward prop.
-            const Strides& get_window_movement_strides_backward() const
-            {
-                return m_window_movement_strides_backward;
-            }
-            /// \return The window dilation strides for the backward prop.
-            const Strides& get_window_dilation_strides_backward() const
-            {
-                return m_window_dilation_strides_backward;
-            }
-            /// \return The padding-below sizes (possibly negative) for the backward prop.
-            const CoordinateDiff& get_padding_below_backward() const
-            {
-                return m_padding_below_backward;
-            }
-            /// \return The padding-above sizes (possibly negative) for the backward prop.
-            const CoordinateDiff& get_padding_above_backward() const
-            {
-                return m_padding_above_backward;
-            }
-            /// \return The input data dilation strides for the backward prop.
-            const Strides& get_data_dilation_strides_backward() const
-            {
-                return m_data_dilation_strides_backward;
-            }
-
         protected:
             Shape m_data_batch_shape;
             Strides m_window_movement_strides_forward;
@@ -253,12 +227,6 @@ namespace ngraph
             CoordinateDiff m_padding_below_forward;
             CoordinateDiff m_padding_above_forward;
             Strides m_data_dilation_strides_forward;
-
-            Strides m_window_movement_strides_backward;
-            Strides m_window_dilation_strides_backward;
-            CoordinateDiff m_padding_below_backward;
-            CoordinateDiff m_padding_above_backward;
-            Strides m_data_dilation_strides_backward;
         };
 
         /// \brief Filters backprop for batched convolution operation.
@@ -317,32 +285,6 @@ namespace ngraph
                 return m_data_dilation_strides_forward;
             }
 
-            /// \return The window movement strides for the backward prop.
-            const Strides& get_window_movement_strides_backward() const
-            {
-                return m_window_movement_strides_backward;
-            }
-            /// \return The window dilation strides for the backward prop.
-            const Strides& get_window_dilation_strides_backward() const
-            {
-                return m_window_dilation_strides_backward;
-            }
-            /// \return The padding-below sizes (possibly negative) for the backward prop.
-            const CoordinateDiff& get_padding_below_backward() const
-            {
-                return m_padding_below_backward;
-            }
-            /// \return The padding-above sizes (possibly negative) for the backward prop.
-            const CoordinateDiff& get_padding_above_backward() const
-            {
-                return m_padding_above_backward;
-            }
-            /// \return The data dilation strides for the backward prop.
-            const Strides& get_data_dilation_strides_backward() const
-            {
-                return m_data_dilation_strides_backward;
-            }
-
         protected:
             Shape m_filters_shape;
             Strides m_window_movement_strides_forward;
@@ -350,12 +292,6 @@ namespace ngraph
             CoordinateDiff m_padding_below_forward;
             CoordinateDiff m_padding_above_forward;
             Strides m_data_dilation_strides_forward;
-
-            Strides m_window_movement_strides_backward;
-            Strides m_window_dilation_strides_backward;
-            CoordinateDiff m_padding_below_backward;
-            CoordinateDiff m_padding_above_backward;
-            Strides m_data_dilation_strides_backward;
         };
 
         namespace util

--- a/src/ngraph/runtime/cpu/builder/convolution.cpp
+++ b/src/ngraph/runtime/cpu/builder/convolution.cpp
@@ -99,14 +99,7 @@ namespace ngraph
                                window_dilation_strides,
                                padding_below,
                                padding_above,
-                               data_dilation_strides,
-                               0,
-                               1,
-                               1,
-                               0,
-                               0,
-                               1,
-                               false);
+                               data_dilation_strides);
                     };
                     functors.emplace_back(functor);
                 }
@@ -278,48 +271,45 @@ namespace ngraph
                 }
                 else
                 {
-                    std::function<decltype(runtime::cpu::kernel::convolution<float>)> kernel;
+                    std::function<decltype(runtime::cpu::kernel::convolution_backprop_data<float>)>
+                        kernel;
 
-                    SELECT_KERNEL(
-                        kernel, out[0].get_element_type(), runtime::cpu::kernel::convolution);
-
-                    auto window_movement_strides =
-                        convolution->get_window_movement_strides_backward();
+                    SELECT_KERNEL(kernel,
+                                  out[0].get_element_type(),
+                                  runtime::cpu::kernel::convolution_backprop_data);
+                    auto& data_batch_shape = convolution->get_data_batch_shape();
+                    auto data_dilation_strides = convolution->get_data_dilation_strides_forward();
                     auto window_dilation_strides =
-                        convolution->get_window_dilation_strides_backward();
-                    auto padding_below = convolution->get_padding_below_backward();
-                    auto padding_above = convolution->get_padding_above_backward();
-                    auto data_dilation_strides = convolution->get_data_dilation_strides_backward();
+                        convolution->get_window_dilation_strides_forward();
+                    auto padding_below = convolution->get_padding_below_forward();
+                    auto padding_above = convolution->get_padding_above_forward();
+                    auto window_movement_strides =
+                        convolution->get_window_movement_strides_forward();
 
                     auto functor = [&,
                                     kernel,
+                                    data_batch_shape,
                                     arg0_shape,
                                     arg1_shape,
                                     result_shape,
-                                    window_movement_strides,
+                                    data_dilation_strides,
                                     window_dilation_strides,
                                     padding_below,
                                     padding_above,
-                                    data_dilation_strides](CPURuntimeContext* ctx,
-                                                           CPUExecutionContext* ectx) {
+                                    window_movement_strides](CPURuntimeContext* ctx,
+                                                             CPUExecutionContext* ectx) {
                         kernel(arg1_tensor,
                                arg0_tensor,
                                out_tensor,
+                               data_batch_shape,
                                arg1_shape,
                                arg0_shape,
                                result_shape,
-                               window_movement_strides,
+                               data_dilation_strides,
                                window_dilation_strides,
                                padding_below,
                                padding_above,
-                               data_dilation_strides,
-                               0,
-                               1,
-                               0,
-                               1,
-                               0,
-                               1,
-                               true);
+                               window_movement_strides);
                     };
                     functors.emplace_back(functor);
                 }
@@ -360,26 +350,31 @@ namespace ngraph
                 }
                 else
                 {
-                    std::function<decltype(runtime::cpu::kernel::convolution<float>)> kernel;
+                    std::function<decltype(
+                        runtime::cpu::kernel::convolution_backprop_filters<float>)>
+                        kernel;
 
-                    SELECT_KERNEL(
-                        kernel, out[0].get_element_type(), runtime::cpu::kernel::convolution);
+                    SELECT_KERNEL(kernel,
+                                  out[0].get_element_type(),
+                                  runtime::cpu::kernel::convolution_backprop_filters);
 
-                    auto window_movement_strides =
-                        convolution->get_window_movement_strides_backward();
+                    auto& filters_shape = convolution->get_filters_shape();
                     auto window_dilation_strides =
-                        convolution->get_window_dilation_strides_backward();
-                    auto padding_below = convolution->get_padding_below_backward();
-                    auto padding_above = convolution->get_padding_above_backward();
-                    auto data_dilation_strides = convolution->get_data_dilation_strides_backward();
+                        convolution->get_window_dilation_strides_forward();
+                    auto window_movement_strides =
+                        convolution->get_window_movement_strides_forward();
+                    auto padding_below = convolution->get_padding_below_forward();
+                    auto padding_above = convolution->get_padding_above_forward();
+                    auto data_dilation_strides = convolution->get_data_dilation_strides_forward();
 
                     auto functor = [&,
                                     kernel,
+                                    filters_shape,
                                     arg0_shape,
                                     arg1_shape,
                                     result_shape,
-                                    window_movement_strides,
                                     window_dilation_strides,
+                                    window_movement_strides,
                                     padding_below,
                                     padding_above,
                                     data_dilation_strides](CPURuntimeContext* ctx,
@@ -387,6 +382,7 @@ namespace ngraph
                         kernel(arg0_tensor,
                                arg1_tensor,
                                out_tensor,
+                               filters_shape,
                                arg0_shape,
                                arg1_shape,
                                result_shape,
@@ -394,14 +390,7 @@ namespace ngraph
                                window_dilation_strides,
                                padding_below,
                                padding_above,
-                               data_dilation_strides,
-                               1,
-                               0,
-                               0,
-                               1,
-                               1,
-                               0,
-                               false);
+                               data_dilation_strides);
                     };
                     functors.emplace_back(functor);
                 }

--- a/src/ngraph/runtime/cpu/cpu_emitter.cpp
+++ b/src/ngraph/runtime/cpu/cpu_emitter.cpp
@@ -3033,8 +3033,7 @@ namespace ngraph
                     writer << "                         {" << join(convolution->get_padding_above())
                            << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_data_dilation_strides()) << "},\n";
-                    writer << "                         0, 1, 1, 0, 0, 1, false);\n";
+                           << join(convolution->get_data_dilation_strides()) << "});\n";
                 }
             }
 
@@ -3068,24 +3067,25 @@ namespace ngraph
                 }
                 else
                 {
-                    writer << "reference::convolution<" << out[0].get_type() << ">("
-                           << args[0].get_name() << ",\n";
+                    writer << "reference::convolution_backprop_filters<" << out[0].get_type()
+                           << ">(" << args[0].get_name() << ",\n";
                     writer << "                         " << args[1].get_name() << ",\n";
                     writer << "                         " << out[0].get_name() << ",\n";
+                    writer << "                         {" << join(convolution->get_filters_shape())
+                           << "},\n";
                     writer << "                         {" << join(arg0_shape) << "},\n";
                     writer << "                         {" << join(arg1_shape) << "},\n";
                     writer << "                         {" << join(result_shape) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_window_movement_strides_backward()) << "},\n";
+                           << join(convolution->get_window_dilation_strides_forward()) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_window_dilation_strides_backward()) << "},\n";
+                           << join(convolution->get_window_movement_strides_forward()) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_padding_below_backward()) << "},\n";
+                           << join(convolution->get_padding_below_forward()) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_padding_above_backward()) << "},\n";
+                           << join(convolution->get_padding_above_forward()) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_data_dilation_strides_backward()) << "},\n";
-                    writer << "                         1, 0, 0, 1, 1, 0, false);\n";
+                           << join(convolution->get_data_dilation_strides_forward()) << "});\n";
                 }
             }
 
@@ -3120,24 +3120,25 @@ namespace ngraph
                 else
                 {
                     // Note that args[1] and args[0] are switched here from the usual order.
-                    writer << "reference::convolution<" << out[0].get_type() << ">("
+                    writer << "reference::convolution_backprop_data<" << out[0].get_type() << ">("
                            << args[1].get_name() << ",\n";
                     writer << "                         " << args[0].get_name() << ",\n";
                     writer << "                         " << out[0].get_name() << ",\n";
+                    writer << "                         {"
+                           << join(convolution->get_data_batch_shape()) << "},\n";
                     writer << "                         {" << join(arg1_shape) << "},\n";
                     writer << "                         {" << join(arg0_shape) << "},\n";
                     writer << "                         {" << join(result_shape) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_window_movement_strides_backward()) << "},\n";
+                           << join(convolution->get_data_dilation_strides_forward()) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_window_dilation_strides_backward()) << "},\n";
+                           << join(convolution->get_window_dilation_strides_forward()) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_padding_below_backward()) << "},\n";
+                           << join(convolution->get_padding_below_forward()) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_padding_above_backward()) << "},\n";
+                           << join(convolution->get_padding_above_forward()) << "},\n";
                     writer << "                         {"
-                           << join(convolution->get_data_dilation_strides_backward()) << "},\n";
-                    writer << "                         0, 1, 0, 1, 0, 1, true);\n";
+                           << join(convolution->get_window_movement_strides_forward()) << "});\n";
                 }
             }
 

--- a/src/ngraph/runtime/cpu/kernel/convolution.hpp
+++ b/src/ngraph/runtime/cpu/kernel/convolution.hpp
@@ -38,14 +38,7 @@ namespace ngraph
                                  const Strides& window_dilation_strides,
                                  const CoordinateDiff& padding_below,
                                  const CoordinateDiff& padding_above,
-                                 const Strides& data_dilation_strides,
-                                 size_t batch_axis_data,
-                                 size_t input_channel_axis_data,
-                                 size_t input_channel_axis_filters,
-                                 size_t output_channel_axis_filters,
-                                 size_t batch_axis_result,
-                                 size_t output_channel_axis_result,
-                                 bool rotate_filter)
+                                 const Strides& data_dilation_strides)
                 {
                     reference::convolution<ElementType>(static_cast<const ElementType*>(input0),
                                                         static_cast<const ElementType*>(input1),
@@ -57,14 +50,65 @@ namespace ngraph
                                                         window_dilation_strides,
                                                         padding_below,
                                                         padding_above,
-                                                        data_dilation_strides,
-                                                        batch_axis_data,
-                                                        input_channel_axis_data,
-                                                        input_channel_axis_filters,
-                                                        output_channel_axis_filters,
-                                                        batch_axis_result,
-                                                        output_channel_axis_result,
-                                                        rotate_filter);
+                                                        data_dilation_strides);
+                }
+
+                template <typename ElementType>
+                void convolution_backprop_filters(void* input0,
+                                                  void* input1,
+                                                  void* output,
+                                                  const Shape& filters_shape,
+                                                  const Shape& arg0_shape,
+                                                  const Shape& arg1_shape,
+                                                  const Shape& result_shape,
+                                                  const Strides& window_dilation_strides,
+                                                  const Strides& window_movement_strides,
+                                                  const CoordinateDiff& padding_below,
+                                                  const CoordinateDiff& padding_above,
+                                                  const Strides& data_dilation_strides)
+                {
+                    reference::convolution_backprop_filters<ElementType>(
+                        static_cast<const ElementType*>(input0),
+                        static_cast<const ElementType*>(input1),
+                        static_cast<ElementType*>(output),
+                        filters_shape,
+                        arg0_shape,
+                        arg1_shape,
+                        result_shape,
+                        window_dilation_strides,
+                        window_movement_strides,
+                        padding_below,
+                        padding_above,
+                        data_dilation_strides);
+                }
+
+                template <typename ElementType>
+                void convolution_backprop_data(void* input0,
+                                               void* input1,
+                                               void* output,
+                                               const Shape& data_batch_shape,
+                                               const Shape& arg0_shape,
+                                               const Shape& arg1_shape,
+                                               const Shape& result_shape,
+                                               const Strides& window_movement_strides,
+                                               const Strides& window_dilation_strides,
+                                               const CoordinateDiff& padding_below,
+                                               const CoordinateDiff& padding_above,
+                                               const Strides& data_dilation_strides)
+                {
+                    reference::convolution_backprop_data<ElementType>(
+                        static_cast<const ElementType*>(input0),
+                        static_cast<const ElementType*>(input1),
+                        static_cast<ElementType*>(output),
+                        data_batch_shape,
+                        arg0_shape,
+                        arg1_shape,
+                        result_shape,
+                        window_movement_strides,
+                        window_dilation_strides,
+                        padding_below,
+                        padding_above,
+                        data_dilation_strides);
                 }
             }
         }

--- a/src/ngraph/runtime/interpreter/int_backend.hpp
+++ b/src/ngraph/runtime/interpreter/int_backend.hpp
@@ -545,38 +545,26 @@ private:
                                       c->get_window_dilation_strides(),
                                       c->get_padding_below(),
                                       c->get_padding_above(),
-                                      c->get_data_dilation_strides(),
-                                      0,
-                                      1,
-                                      1,
-                                      0,
-                                      0,
-                                      1,
-                                      false);
+                                      c->get_data_dilation_strides());
+
             break;
         }
         case OP_TYPEID::ConvolutionBackpropFilters:
         {
             const op::ConvolutionBackpropFilters* c =
                 static_cast<const op::ConvolutionBackpropFilters*>(&node);
-            reference::convolution<T>(static_cast<const T*>(args[0]),
-                                      static_cast<const T*>(args[1]),
-                                      static_cast<T*>(out[0]),
-                                      node.get_input_shape(0),
-                                      node.get_input_shape(1),
-                                      node.get_output_shape(0),
-                                      c->get_window_movement_strides_backward(),
-                                      c->get_window_dilation_strides_backward(),
-                                      c->get_padding_below_backward(),
-                                      c->get_padding_above_backward(),
-                                      c->get_data_dilation_strides_backward(),
-                                      1,
-                                      0,
-                                      0,
-                                      1,
-                                      1,
-                                      0,
-                                      false);
+            reference::convolution_backprop_filters<T>(static_cast<const T*>(args[0]),
+                                                       static_cast<const T*>(args[1]),
+                                                       static_cast<T*>(out[0]),
+                                                       c->get_filters_shape(),
+                                                       c->get_input_shape(0),
+                                                       c->get_input_shape(1),
+                                                       c->get_output_shape(0),
+                                                       c->get_window_dilation_strides_forward(),
+                                                       c->get_window_movement_strides_forward(),
+                                                       c->get_padding_below_forward(),
+                                                       c->get_padding_above_forward(),
+                                                       c->get_data_dilation_strides_forward());
             break;
         }
         case OP_TYPEID::ConvolutionBackpropData:
@@ -584,24 +572,18 @@ private:
             // Note that args[1] and args[0] are switched here from the usual order.
             const op::ConvolutionBackpropData* c =
                 static_cast<const op::ConvolutionBackpropData*>(&node);
-            reference::convolution<T>(static_cast<const T*>(args[1]),
-                                      static_cast<const T*>(args[0]),
-                                      static_cast<T*>(out[0]),
-                                      node.get_input_shape(1),
-                                      node.get_input_shape(0),
-                                      node.get_output_shape(0),
-                                      c->get_window_movement_strides_backward(),
-                                      c->get_window_dilation_strides_backward(),
-                                      c->get_padding_below_backward(),
-                                      c->get_padding_above_backward(),
-                                      c->get_data_dilation_strides_backward(),
-                                      0,
-                                      1,
-                                      0,
-                                      1,
-                                      0,
-                                      1,
-                                      true);
+            reference::convolution_backprop_data<T>(static_cast<const T*>(args[1]),
+                                                    static_cast<const T*>(args[0]),
+                                                    static_cast<T*>(out[0]),
+                                                    c->get_data_batch_shape(),
+                                                    c->get_input_shape(1),
+                                                    c->get_input_shape(0),
+                                                    c->get_output_shape(0),
+                                                    c->get_data_dilation_strides_forward(),
+                                                    c->get_window_dilation_strides_forward(),
+                                                    c->get_padding_below_forward(),
+                                                    c->get_padding_above_forward(),
+                                                    c->get_window_movement_strides_forward());
             break;
         }
         case OP_TYPEID::Cos:


### PR DESCRIPTION
Move interpreter-specific code out of the convolution ops.