### PR TITLE
all_close_f test case and error reporting clarification

### DIFF
--- a/test/util/all_close_f.cpp
+++ b/test/util/all_close_f.cpp
@@ -295,17 +295,19 @@ uint32_t test::matching_mantissa_bits(uint64_t distance)
                   << " mantissa bits.\n";
     }
 
-    msg << "passing criteria: " << (mantissa_bits - tolerance_bits) << " mantissa bits ("
-        << mantissa_bits << " mantissa bits w/ " << tolerance_bits << " tolerance bits)\n";
+    msg << "passing criteria - mismatch allowed  @ mantissa bit: "
+        << (mantissa_bits - tolerance_bits) << " or later (" << mantissa_bits
+        << " mantissa bits w/ " << tolerance_bits << " tolerance bits)\n";
     msg << std::setprecision(std::numeric_limits<long double>::digits10 + 1)
-        << "tightest match:   " << matching_mantissa_bits(min_distance) << " mantissa bits ("
-        << a[min_distance_index] << " vs " << b[min_distance_index] << " at [" << min_distance_index
-        << "])\n";
+        << "tightest match   - mismatch occurred @ mantissa bit: "
+        << matching_mantissa_bits(min_distance) << " or next bit (" << a[min_distance_index]
+        << " vs " << b[min_distance_index] << " at [" << min_distance_index << "])\n";
     msg << std::setprecision(std::numeric_limits<long double>::digits10 + 1)
-        << "loosest match:    " << matching_mantissa_bits(max_distance) << " mantissa bits ("
-        << a[max_distance_index] << " vs " << b[max_distance_index] << " at [" << max_distance_index
-        << "])\n";
-    msg << "median match:     " << matching_mantissa_bits(median_distance) << " mantissa bits\n";
+        << "loosest match    - mismatch occurred @ mantissa bit: "
+        << matching_mantissa_bits(max_distance) << " or next bit (" << a[max_distance_index]
+        << " vs " << b[max_distance_index] << " at [" << max_distance_index << "])\n";
+    msg << "median match     - mismatch occurred @ mantissa bit: "
+        << matching_mantissa_bits(median_distance) << " or next bit\n";
 
     ::testing::AssertionResult res =
         rc ? ::testing::AssertionSuccess() : ::testing::AssertionFailure();
@@ -383,17 +385,19 @@ uint32_t test::matching_mantissa_bits(uint64_t distance)
                   << " mantissa bits.\n";
     }
 
-    msg << "passing criteria: " << (mantissa_bits - tolerance_bits) << " mantissa bits ("
-        << mantissa_bits << " mantissa bits w/ " << tolerance_bits << " tolerance bits)\n";
+    msg << "passing criteria - mismatch allowed  @ mantissa bit: "
+        << (mantissa_bits - tolerance_bits) << " or later (" << mantissa_bits
+        << " mantissa bits w/ " << tolerance_bits << " tolerance bits)\n";
     msg << std::setprecision(std::numeric_limits<long double>::digits10 + 1)
-        << "tightest match:   " << matching_mantissa_bits(min_distance) << " mantissa bits ("
-        << a[min_distance_index] << " vs " << b[min_distance_index] << " at [" << min_distance_index
-        << "])\n";
+        << "tightest match   - mismatch occurred @ mantissa bit: "
+        << matching_mantissa_bits(min_distance) << " or next bit (" << a[min_distance_index]
+        << " vs " << b[min_distance_index] << " at [" << min_distance_index << "])\n";
     msg << std::setprecision(std::numeric_limits<long double>::digits10 + 1)
-        << "loosest match:    " << matching_mantissa_bits(max_distance) << " mantissa bits ("
-        << a[max_distance_index] << " vs " << b[max_distance_index] << " at [" << max_distance_index
-        << "])\n";
-    msg << "median match:     " << matching_mantissa_bits(median_distance) << " mantissa bits\n";
+        << "loosest match    - mismatch occurred @ mantissa bit: "
+        << matching_mantissa_bits(max_distance) << " or next bit (" << a[max_distance_index]
+        << " vs " << b[max_distance_index] << " at [" << max_distance_index << "])\n";
+    msg << "median match     - mismatch occurred @ mantissa bit: "
+        << matching_mantissa_bits(median_distance) << " or next bit\n";
 
     ::testing::AssertionResult res =
         rc ? ::testing::AssertionSuccess() : ::testing::AssertionFailure();


### PR DESCRIPTION
Tweaked all_close_f unit testing to (hopefully) improve clarity a bit (moved from #2226 which will be abandoned).

all_close_f error reporting now better matches reality float testing criteria.
An example from testing of doubles, previously it reported:
`passing criteria: 53 mantissa bits (53 mantissa bits w/ 0 tolerance bits)
tightest match:   53 mantissa bits (0 vs 4.940656458412465442e-324 at [0])
loosest match:    53 mantissa bits (0 vs 4.940656458412465442e-324 at [0])
median match:     53 mantissa bits`

Now it reports:
`passing criteria - mismatch allowed  @ mantissa bit: 53 or later (53 mantissa bits w/ 0 tolerance bits)
tightest match   - mismatch occurred @ mantissa bit: 53 or next bit (0 vs 4.940656458412465442e-324 at [0])
loosest match    - mismatch occurred @ mantissa bit: 53 or next bit (0 vs 4.940656458412465442e-324 at [0])
median match     - mismatch occurred @ mantissa bit: 53 or next bit`

This is wordier, but better matches reality of what's being tested. (In above test cases it's actually modifying the 53rd bit to make sure that is allowed. So saying that 53 bits "matched" was misleading.)