### PR TITLE
[ONNX] automatically detect value types of TensorProto and AttributeProto

### DIFF
--- a/src/ngraph/frontend/onnx_import/core/attribute.hpp
+++ b/src/ngraph/frontend/onnx_import/core/attribute.hpp
@@ -29,6 +29,13 @@ namespace ngraph
         class Graph;
         class Model;
 
+        // Detecting automatically the underlying type used to store the information
+        // for data type of values an attribute is holding. A bug was discovered in
+        // protobuf which forced ONNX team to switch from `enum AttributeProto_AttributeType`
+        // to `int32` in order to workaround the bug. This line allows using both versions
+        // of ONNX generated wrappers.
+        using AttributeProto_AttributeType = decltype(onnx::AttributeProto{}.type());
+
         namespace error
         {
             namespace attribute
@@ -37,7 +44,7 @@ namespace ngraph
                 {
                     struct Attribute : ngraph_error
                     {
-                        Attribute(const std::string& msg, onnx::AttributeProto_AttributeType type)
+                        Attribute(const std::string& msg, AttributeProto_AttributeType type)
                             : ngraph_error{msg + ": " +
                                            onnx::AttributeProto_AttributeType_Name(type)}
                         {
@@ -48,7 +55,7 @@ namespace ngraph
 
                 struct InvalidData : detail::Attribute
                 {
-                    explicit InvalidData(onnx::AttributeProto_AttributeType type)
+                    explicit InvalidData(AttributeProto_AttributeType type)
                         : Attribute{"invalid attribute type", type}
                     {
                     }
@@ -56,7 +63,7 @@ namespace ngraph
 
                 struct UnsupportedType : detail::Attribute
                 {
-                    explicit UnsupportedType(onnx::AttributeProto_AttributeType type)
+                    explicit UnsupportedType(AttributeProto_AttributeType type)
                         : Attribute{"unsupported attribute type", type}
                     {
                     }

--- a/src/ngraph/frontend/onnx_import/core/value_info.hpp
+++ b/src/ngraph/frontend/onnx_import/core/value_info.hpp
@@ -43,9 +43,9 @@ namespace ngraph
                 };
                 struct unsupported_element_type : ngraph_error
                 {
-                    explicit unsupported_element_type(onnx::TensorProto_DataType type)
+                    explicit unsupported_element_type(TensorProto_DataType type)
                         : ngraph_error{"unsupported value info element type: " +
-                                       onnx::TensorProto_DataType_Name(type)}
+                                       onnx::TensorProto_DataType_Name(static_cast<onnx::TensorProto_DataType>(type))}
                     {
                     }
                 };


### PR DESCRIPTION
This PR enables compilation of ONNX importer with ONNX generated wrappers based on recent ONNX specification (Microsoft ONNX Runtime is using it). It keeps compatibility with older versions.

Rationale: due to incompatibility at protobuf serialization level the ONNX community decided to replace all occurrences of `TensorProto_DataType` and `AttributeProto_AttributeType` enumeration data types with `int32_t`. However, both enumeration data types are still available as the source of values.

Please refer to this PR for more details: https://github.com/onnx/onnx/commit/765f5ee823a67a866f4bd28a9860e81f3c811ce8

Signed-off-by: Artur Wojcik <artur.wojcik@intel.com>