### PR TITLE
Change ngraph_test_util to a static library

### DIFF
--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -21,11 +21,10 @@ set (SRC
     test_control.cpp
 )
 
-add_library(ngraph_test_util SHARED ${SRC})
+add_library(ngraph_test_util STATIC ${SRC})
 if(NGRAPH_LIB_VERSIONING_ENABLE)
     set_target_properties(ngraph_test_util PROPERTIES
-        VERSION ${NGRAPH_VERSION}
-        SOVERSION ${NGRAPH_API_VERSION})
+        VERSION ${NGRAPH_VERSION})
 endif()
 target_include_directories(ngraph_test_util PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(ngraph_test_util ngraph libgtest)


### PR DESCRIPTION
Because this library links in gtest and is used by a library which also links in gtest we end up with two gtests. This was causing segfault on some external backends.