### PR TITLE
Changed python setup use of multiprocessing for Docker build success

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -106,7 +106,8 @@ def parallelCCompile(
         self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
     # convert to list, imap is evaluated on-demand
-    list(multiprocessing.pool.ThreadPool().imap(_single_compile, objects))
+    pool = multiprocessing.pool.ThreadPool()
+    list(pool.imap(_single_compile, objects))
     return objects
 
 


### PR DESCRIPTION
Running the build steps as described [here](https://github.com/NervanaSystems/ngraph-onnx/blob/master/BUILDING.md) in a Docker build causes the python setup step: `python3 setup.py bdist_wheel` to hang when run inside a Docker container. The problem seems to be with the use of multirpocessing ThreadPool.

I haven't diagnosed the lowlevel reason why this occurs but hopefully the fix which doesn't change any functionality will be acceptable.

We are using this in providing a Docker image for ngraph-onnx in [Seldon Core](https://github.com/SeldonIO/seldon-core)
