### PR TITLE
Passing Parameter to Dequantization op cause segfault.

### DIFF
--- a/src/ngraph/runtime/cpu/pass/cpu_assignment.cpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_assignment.cpp
@@ -728,6 +728,7 @@ namespace ngraph
                 void CPUAssignment::ASSIGN_DECL(ngraph::op::Dequantize)
                 {
                     auto dequantize = static_cast<op::Dequantize*>(node);
+                    // offset can be a ngraph::op::Parameter
                     auto offset_const_op =
                         std::static_pointer_cast<ngraph::op::Constant>(dequantize->get_argument(2));
                     // TODO: MKLDNN only handles float / not double
@@ -737,6 +738,7 @@ namespace ngraph
                     }
                     if (node->get_input_element_type(0) == element::u8)
                     {
+                        //get_vector is trying to read m_data what is nullptr -> segfault
                         auto offset = offset_const_op->get_vector<uint8_t>();
                         if (offset[0] != 0)
                             return;
@@ -760,6 +762,7 @@ namespace ngraph
                 void CPUAssignment::ASSIGN_DECL(ngraph::op::Quantize)
                 {
                     auto quantize = static_cast<op::Quantize*>(node);
+                    // offset can be a ngraph::op::Parameter
                     auto offset_const_op =
                         std::static_pointer_cast<ngraph::op::Constant>(quantize->get_argument(2));
                     op::Quantize::RoundMode round_mode = quantize->get_round_mode();


### PR DESCRIPTION
If the `Dequantize` op `offset` is passed as `ngraph::op::Parameter` (not a `ngraph::op::Constant`) we get a segfault on CPU backend.
On INTERPRETER everything works fine.

I made some comments in file diffs pointing the main culprit.

logs:
```
$ test/unit-test --gtest_filter="INTERPRETER.dequantize_segfault"
Note: Google Test filter = INTERPRETER.dequantize_segfault
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from INTERPRETER
[ RUN      ] INTERPRETER.dequantize_segfault
[       OK ] INTERPRETER.dequantize_segfault (3 ms)
[----------] 1 test from INTERPRETER (3 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (3 ms total)
[  PASSED  ] 1 test.
$ test/unit-test --gtest_filter="CPU.dequantize_segfault"
Note: Google Test filter = CPU.dequantize_segfault
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from CPU
[ RUN      ] CPU.dequantize_segfault
Segmentation fault (core dumped)
```
