### PR TITLE
Grep "<replacement " to detect clang-format error

### DIFF
--- a/cmake/Modules/style_check.cmake
+++ b/cmake/Modules/style_check.cmake
@@ -19,11 +19,11 @@ find_program(CLANG_FORMAT ${CLANG_FORMAT_FILENAME} PATHS ENV PATH)
 
 macro(STYLE_CHECK_FILE PATH)
     execute_process(COMMAND ${CLANG_FORMAT} -style=file -output-replacements-xml ${PATH}
-        OUTPUT_VARIABLE STYLE_CHECK_RESULT)
-        list(LENGTH STYLE_CHECK_RESULT RESULT_LENGTH)
-        if (RESULT_LENGTH GREATER 1)
-            list(APPEND ERROR_LIST ${PATH})
-        endif()
+        OUTPUT_VARIABLE STYLE_CHECK_RESULT
+    )
+    if("${STYLE_CHECK_RESULT}" MATCHES ".*<replacement .*")
+        list(APPEND ERROR_LIST ${PATH})
+    endif()
 endmacro()
 
 set(DIRECTORIES_OF_INTEREST


### PR DESCRIPTION
The fix is based on https://stackoverflow.com/questions/22866609/can-clang-format-tell-me-if-formatting-changes-are-necessary. It greps for `"<replacement "` to detect if there is a style error.

### Before
Here `axis_vector.cpp` is explicitly changed, however `make style-check` didn't catch the style error.
```
➜  ~/repo/ngraph/build (master) git --no-pager diff
diff --git a/src/ngraph/axis_vector.cpp b/src/ngraph/axis_vector.cpp
index e1a981b..6aadf8c 100644
--- a/src/ngraph/axis_vector.cpp
+++ b/src/ngraph/axis_vector.cpp
@@ -17,7 +17,7 @@
 #include "ngraph/axis_vector.hpp"
 #include "ngraph/util.hpp"
 
-std::ostream& ngraph::operator<<(std::ostream& s, const AxisVector& axis_vector)
+std::ostream&      ngraph::operator<<(std::ostream& s, const AxisVector& axis_vector)
 {
     s << "AxisVector{";
     s << ngraph::join(axis_vector);

➜  ~/repo/ngraph/build (master) make style-check
Built target style-check
```

### After
After the fix, the style error is detected.
```
➜  ~/repo/ngraph/build (yixing/style-check) make style-check
-- style error: /home/yixing/repo/ngraph/src/ngraph/axis_vector.cpp
CMake Error at /home/yixing/repo/ngraph/cmake/Modules/style_check.cmake:48 (message)$
  style errors


CMakeFiles/style-check.dir/build.make:57: recipe for target 'CMakeFiles/style-check' 
failed
make[3]: *** [CMakeFiles/style-check] Error 1
CMakeFiles/Makefile2:195: recipe for target 'CMakeFiles/style-check.dir/all' failed
make[2]: *** [CMakeFiles/style-check.dir/all] Error 2
CMakeFiles/Makefile2:202: recipe for target 'CMakeFiles/style-check.dir/rule' failed
make[1]: *** [CMakeFiles/style-check.dir/rule] Error 2
Makefile:236: recipe for target 'style-check' failed
make: *** [style-check] Error 2
```