### PR TITLE
Windows support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ include(cmake/external_cldnn.cmake)
 
 if (NGRAPH_USE_PREBUILT_LLVM OR DEFINED LLVM_TARBALL_URL)
     include(cmake/external_llvm_prebuilt.cmake)
-else()
+elseif (NOT NGRAPH_DEX_ONLY OR NOT MSVS)
     include(cmake/external_llvm.cmake)
 endif()
 

--- a/cmake/external_gtest.cmake
+++ b/cmake/external_gtest.cmake
@@ -72,9 +72,7 @@ ExternalProject_Get_Property(ext_gtest SOURCE_DIR BINARY_DIR)
 add_library(libgtest INTERFACE)
 add_dependencies(libgtest ext_gtest)
 target_include_directories(libgtest SYSTEM INTERFACE ${SOURCE_DIR}/googletest/include)
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(GTEST_LIB_NAME gtestd)
-else()
-    set(GTEST_LIB_NAME gtest)
-endif()
-target_link_libraries(libgtest INTERFACE ${GTEST_OUTPUT_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${GTEST_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
+
+target_link_libraries(libgtest INTERFACE
+    debug ${GTEST_OUTPUT_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtestd${CMAKE_STATIC_LIBRARY_SUFFIX}
+    optimized ${GTEST_OUTPUT_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX})

--- a/cmake/external_mkldnn.cmake
+++ b/cmake/external_mkldnn.cmake
@@ -62,7 +62,7 @@ elseif (APPLE)
 elseif (WIN32)
     set(MKLPACKAGE "mklml_win_${MKLVERSION}.zip")
     set(MKL_SHA1_HASH 97f01ab854d8ee88cc0429f301df84844d7cce6b)
-    set(MKL_LIBS mklml.dll libiomp5md.dll)
+    set(MKL_LIBS mklml.lib libiomp5md.lib)
 endif()
 set(MKLURL ${MKLURLROOT}${MKLPACKAGE})
 
@@ -84,7 +84,11 @@ set(MKL_SOURCE_DIR ${source_dir})
 add_library(libmkl INTERFACE)
 add_dependencies(libmkl ext_mkl)
 foreach(LIB ${MKL_LIBS})
-    list(APPEND TMP_PATHS ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/${LIB})
+    if (WIN32)
+        list(APPEND TMP_PATHS ${EXTERNAL_PROJECTS_ROOT}/mkl/src/ext_mkl/lib/${LIB})
+    else()
+        list(APPEND TMP_PATHS ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/${LIB})
+    endif()
 endforeach()
 set(MKL_LIBS ${TMP_PATHS})
 target_link_libraries(libmkl INTERFACE ${MKL_LIBS})
@@ -185,9 +189,15 @@ add_custom_command(TARGET ext_mkldnn POST_BUILD
 add_library(libmkldnn INTERFACE)
 add_dependencies(libmkldnn ext_mkldnn)
 target_include_directories(libmkldnn SYSTEM INTERFACE ${EXTERNAL_PROJECTS_ROOT}/mkldnn/include)
-target_link_libraries(libmkldnn INTERFACE
+if (WIN32)
+    target_link_libraries(libmkldnn INTERFACE
+    ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/mkldnn.lib
+    libmkl
+    )
+else()
+    target_link_libraries(libmkldnn INTERFACE
     ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/${CMAKE_SHARED_LIBRARY_PREFIX}mkldnn${CMAKE_SHARED_LIBRARY_SUFFIX}
     libmkl
     )
-
+endif()
 install(DIRECTORY ${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/ DESTINATION ${NGRAPH_INSTALL_LIB} OPTIONAL)

--- a/src/ngraph/runtime/CMakeLists.txt
+++ b/src/ngraph/runtime/CMakeLists.txt
@@ -17,8 +17,11 @@
 add_subdirectory(interpreter)
 add_subdirectory(hybrid)
 
+# With CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS, when creating cpu_backend.dll, link reports error: library limit of 65535 objects exceeded
 if (NGRAPH_CPU_ENABLE)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS FALSE)
     add_subdirectory(cpu)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 endif()
 
 if (NGRAPH_INTELGPU_ENABLE)

--- a/src/ngraph/runtime/cpu/CMakeLists.txt
+++ b/src/ngraph/runtime/cpu/CMakeLists.txt
@@ -194,6 +194,13 @@ if (NGRAPH_CPU_ENABLE)
          message(WARNING "The build toolset doesn't support OpenMP. This will impact performance and lead to slowdowns.")
     endif()
 
+    if (MSVS)
+        target_compile_definitions(cpu_backend PRIVATE EIGEN_HAS_CONSTEXPR)
+        # under debug mode, more files besides builder/dot.cpp rises the error
+        target_compile_options(cpu_backend PRIVATE "/bigobj" )
+    endif()
+    target_compile_definitions(cpu_backend PRIVATE CPU_BACKEND_DLL_EXPORTS)
+
     if(NGRAPH_DISTRIBUTED_ENABLE)
         target_compile_definitions(cpu_backend PRIVATE NGRAPH_DISTRIBUTED)
         target_include_directories(cpu_backend SYSTEM PRIVATE libmlsl)
@@ -207,7 +214,7 @@ if (NGRAPH_CPU_ENABLE)
     endif()
     target_include_directories(cpu_backend SYSTEM PUBLIC libmkldnn)
     set_target_properties(cpu_backend PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${NGRAPH_BUILD_DIR})
-    if (NOT APPLE)
+    if (NOT APPLE AND NOT MSVS)
         # CPU backend uses third-party libraries like Eigen that might be linked in and
         # exported by other DSOs as well. In the absence of versioning, this could lead to the
         # CPU backend picking up the wrong version or even multiple versions of the

--- a/src/ngraph/runtime/cpu/builder/convert_layout.cpp
+++ b/src/ngraph/runtime/cpu/builder/convert_layout.cpp
@@ -86,6 +86,7 @@ namespace ngraph
                 };
                 functors.emplace_back(functor);
             }
+            REGISTER_CPU_OP_BUILDER(ConvertLayout);
         }
     }
 }

--- a/src/ngraph/runtime/cpu/builder/dot.cpp
+++ b/src/ngraph/runtime/cpu/builder/dot.cpp
@@ -187,9 +187,9 @@ namespace ngraph
                     return;
                 }
 
-                std::function<decltype(runtime::cpu::kernel::dot<float>)> kernel;
+                std::function<decltype(runtime::cpu::kernel::dot_ref<float>)> kernel;
 
-                SELECT_KERNEL(kernel, out[0].get_element_type(), runtime::cpu::kernel::dot);
+                SELECT_KERNEL(kernel, out[0].get_element_type(), runtime::cpu::kernel::dot_ref);
 
                 auto functor =
                     [&, kernel, arg0_shape, arg1_shape, result_shape, reduction_axes_count](

--- a/src/ngraph/runtime/cpu/builder/matmul_bias.cpp
+++ b/src/ngraph/runtime/cpu/builder/matmul_bias.cpp
@@ -78,12 +78,12 @@ namespace ngraph
                             k,
                             1.0f,
                             static_cast<float*>(arg0_tensor),
-                            max(1UL, lda),
+                            max<size_t>(1, lda),
                             static_cast<float*>(arg1_tensor),
-                            max(1UL, ldb),
+                            max<size_t>(1, ldb),
                             beta,
                             static_cast<float*>(out0_tensor),
-                            max(1UL, arg2_shape[1]));
+                            max<size_t>(1, arg2_shape[1]));
                     };
 
                 CPUKernelFunctor bias_functor = [](CPURuntimeContext* ctx,
@@ -111,10 +111,10 @@ namespace ngraph
                                                    ones_row.data(),
                                                    1UL,
                                                    static_cast<float*>(arg2_tensor),
-                                                   max(1UL, arg2_shape[1]),
+                                                   max<size_t>(1, arg2_shape[1]),
                                                    1.0f,
                                                    static_cast<float*>(out0_tensor),
-                                                   max(1UL, arg2_shape[1]));
+                                                   max<size_t>(1, arg2_shape[1]));
                             };
                         }
                         else
@@ -132,10 +132,10 @@ namespace ngraph
                                                    static_cast<float*>(arg2_tensor),
                                                    1UL,
                                                    ones_col.data(),
-                                                   max(1UL, arg2_shape[1]),
+                                                   max<size_t>(1, arg2_shape[1]),
                                                    1.0f,
                                                    static_cast<float*>(out0_tensor),
-                                                   max(1UL, arg2_shape[1]));
+                                                   max<size_t>(1, arg2_shape[1]));
                             };
                         }
                     }
@@ -161,10 +161,10 @@ namespace ngraph
                                                ones_scalar.data(),
                                                1UL,
                                                bias.data(),
-                                               max(1UL, arg2_shape[1]),
+                                               max<size_t>(1, arg2_shape[1]),
                                                1.0f,
                                                static_cast<float*>(out0_tensor),
-                                               max(1UL, arg2_shape[1]));
+                                               max<size_t>(1, arg2_shape[1]));
                         };
                     }
                 }
@@ -262,8 +262,8 @@ namespace ngraph
                 size_t m = shape_a[1];
                 size_t k = shape_a[2];
                 size_t n = shape_b[2];
-                size_t lda = std::max(1UL, k);
-                size_t ldb = std::max(1UL, n);
+                size_t lda = std::max<size_t>(1, k);
+                size_t ldb = std::max<size_t>(1, n);
                 cblas::Transpose ctranspose_a = cblas::Transpose::None;
                 cblas::Transpose ctranspose_b = cblas::Transpose::None;
 
@@ -272,15 +272,15 @@ namespace ngraph
                     ctranspose_a = cblas::Transpose::Transpose;
                     m = shape_a[2];
                     k = shape_a[1];
-                    lda = std::max(1UL, m);
+                    lda = std::max<size_t>(1, m);
                 }
                 if (transpose_b)
                 {
                     ctranspose_b = cblas::Transpose::Transpose;
                     n = shape_b[1];
-                    ldb = std::max(1UL, k);
+                    ldb = std::max<size_t>(1, k);
                 }
-                size_t ldc = std::max(1UL, n);
+                size_t ldc = std::max<size_t>(1, n);
 
                 CblasGemmOptions options(data_a, data_b, data_c);
 

--- a/src/ngraph/runtime/cpu/builder/pad.cpp
+++ b/src/ngraph/runtime/cpu/builder/pad.cpp
@@ -72,9 +72,9 @@ namespace ngraph
                 {
                     auto padding_interior = pad->get_padding_interior();
 
-                    std::function<decltype(runtime::cpu::kernel::pad<float>)> kernel;
+                    std::function<decltype(runtime::cpu::kernel::pad_ref<float>)> kernel;
 
-                    SELECT_KERNEL(kernel, args[0].get_element_type(), runtime::cpu::kernel::pad);
+                    SELECT_KERNEL(kernel, args[0].get_element_type(), runtime::cpu::kernel::pad_ref);
 
                     auto functor = [&,
                                     kernel,

--- a/src/ngraph/runtime/cpu/builder/reshape.cpp
+++ b/src/ngraph/runtime/cpu/builder/reshape.cpp
@@ -113,9 +113,9 @@ namespace ngraph
                 }
                 else
                 {
-                    std::function<decltype(runtime::cpu::kernel::reshape<float>)> ref_kernel;
+                    std::function<decltype(runtime::cpu::kernel::reshape_ref<float>)> ref_kernel;
 
-                    SELECT_KERNEL(ref_kernel, result_element_type, runtime::cpu::kernel::reshape);
+                    SELECT_KERNEL(ref_kernel, result_element_type, runtime::cpu::kernel::reshape_ref);
 
                     auto functor = [&, ref_kernel, arg_shape, input_order, result_shape](
                         CPURuntimeContext* ctx, CPUExecutionContext* ectx) {

--- a/src/ngraph/runtime/cpu/cpu_backend.cpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.cpp
@@ -23,18 +23,19 @@
 #include "ngraph/runtime/cpu/cpu_external_function.hpp"
 #include "ngraph/runtime/cpu/cpu_tensor_view.hpp"
 #include "ngraph/util.hpp"
+#include "cpu_backend_visibility.h"
 
 using namespace ngraph;
 using namespace std;
 
-extern "C" runtime::Backend* new_backend(const char* configuration_string)
+extern "C" CPU_BACKEND_API runtime::Backend* new_backend(const char* configuration_string)
 {
     // Force TBB to link to the backend
     tbb::TBB_runtime_interface_version();
     return new runtime::cpu::CPU_Backend();
 }
 
-extern "C" void delete_backend(runtime::Backend* backend)
+extern "C" CPU_BACKEND_API void delete_backend(runtime::Backend* backend)
 {
     delete backend;
 }

--- a/src/ngraph/runtime/cpu/cpu_backend.hpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "ngraph/runtime/backend.hpp"
+#include "cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -30,7 +31,7 @@ namespace ngraph
             class CPU_ExternalFunction;
             class CPU_CallFrame;
 
-            class CPU_Backend : public runtime::Backend
+            class CPU_BACKEND_API CPU_Backend : public runtime::Backend
             {
             public:
                 std::shared_ptr<CPU_CallFrame>

--- a/src/ngraph/runtime/cpu/cpu_backend_visibility.h
+++ b/src/ngraph/runtime/cpu/cpu_backend_visibility.h
@@ -1,0 +1,50 @@
+//*****************************************************************************
+// Copyright 2017-2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+// https://gcc.gnu.org/wiki/Visibility
+// Generic helper definitions for shared library support
+#if defined _WIN32 || defined __CYGWIN__
+#define CPU_BACKEND_HELPER_DLL_IMPORT __declspec(dllimport)
+#define CPU_BACKEND_HELPER_DLL_EXPORT __declspec(dllexport)
+#define CPU_BACKEND_HELPER_DLL_LOCAL
+#else
+#if __GNUC__ >= 4
+#define CPU_BACKEND_HELPER_DLL_IMPORT __attribute__((visibility("default")))
+#define CPU_BACKEND_HELPER_DLL_EXPORT __attribute__((visibility("default")))
+#define CPU_BACKEND_HELPER_DLL_LOCAL __attribute__((visibility("hidden")))
+#else
+#define CPU_BACKEND_HELPER_DLL_IMPORT
+#define CPU_BACKEND_HELPER_DLL_EXPORT
+#define CPU_BACKEND_HELPER_DLL_LOCAL
+#endif
+#endif
+
+// Now we use the generic helper definitions above to define CPU_BACKEND_API and CPU_BACKEND_LOCAL.
+// CPU_BACKEND_API is used for the public API symbols. It either DLL imports or DLL exports
+//    (or does nothing for static build)
+// CPU_BACKEND_LOCAL is used for non-api symbols.
+
+// #ifdef CPU_BACKEND_DLL         // defined if CPU_BACKEND is compiled as a DLL
+#ifdef CPU_BACKEND_DLL_EXPORTS // defined if we are building the CPU_BACKEND DLL (instead of using it)
+#define CPU_BACKEND_API CPU_BACKEND_HELPER_DLL_EXPORT
+#else
+#define CPU_BACKEND_API CPU_BACKEND_HELPER_DLL_IMPORT
+#endif // CPU_BACKEND_DLL_EXPORTS
+#define CPU_BACKEND_LOCAL CPU_BACKEND_HELPER_DLL_LOCAL
+// #else // CPU_BACKEND_DLL is not defined: this means CPU_BACKEND is a static lib.
+// #define CPU_BACKEND_API
+// #define CPU_BACKEND_LOCAL
+// #endif // CPU_BACKEND_DLL

--- a/src/ngraph/runtime/cpu/cpu_builder.cpp
+++ b/src/ngraph/runtime/cpu/cpu_builder.cpp
@@ -366,8 +366,6 @@ namespace ngraph
             {
                 static BuildOpMap build_dispatcher{
                     {TI(ngraph::op::Parameter), &runtime::cpu::Builder::nop},
-                    {TI(ngraph::runtime::cpu::op::ConvertLayout),
-                     &runtime::cpu::Builder::build<ngraph::runtime::cpu::op::ConvertLayout>},
                     {TI(ngraph::runtime::cpu::op::LoopKernel),
                      &runtime::cpu::Builder::build<ngraph::runtime::cpu::op::LoopKernel>},
                     {TI(ngraph::runtime::cpu::op::HalideOp),

--- a/src/ngraph/runtime/cpu/cpu_builder.hpp
+++ b/src/ngraph/runtime/cpu/cpu_builder.hpp
@@ -242,6 +242,16 @@
         }                                                                                          \
     } __register_##OP##_builder_instance;
 
+#define REGISTER_CPU_OP_BUILDER(OP)                                                                \
+    static struct __register_##OP##_builder                                                        \
+    {                                                                                              \
+        __register_##OP##_builder()                                                                \
+        {                                                                                          \
+            GetGlobalBuildDispatcher().insert({type_index(typeid(ngraph::runtime::cpu::op::OP)),   \
+                                 &runtime::cpu::Builder::build<ngraph::runtime::cpu::op::OP>});    \
+        }                                                                                          \
+    } __register_##OP##_builder_instance;
+
 namespace ngraph
 {
     namespace runtime

--- a/src/ngraph/runtime/cpu/cpu_debugger.hpp
+++ b/src/ngraph/runtime/cpu/cpu_debugger.hpp
@@ -29,6 +29,7 @@
 #include "ngraph/runtime/cpu/cpu_layout_descriptor.hpp"
 #include "ngraph/runtime/cpu/cpu_runtime_context.hpp"
 #include "ngraph/runtime/tensor.hpp"
+#include "cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -36,7 +37,7 @@ namespace ngraph
     {
         namespace cpu
         {
-            class CPU_CountTracepoint
+            class CPU_BACKEND_API CPU_CountTracepoint
             {
             public:
                 /// \brief A convenience class that wraps user's callback to run it every *count* iterations
@@ -56,7 +57,7 @@ namespace ngraph
                 size_t m_iteration;
             };
 
-            class CPU_Debugger
+            class CPU_BACKEND_API CPU_Debugger
             {
             public:
                 CPU_Debugger(CPU_CallFrame& callframe);

--- a/src/ngraph/runtime/cpu/cpu_layout_descriptor.hpp
+++ b/src/ngraph/runtime/cpu/cpu_layout_descriptor.hpp
@@ -25,6 +25,7 @@
 
 #include "ngraph/descriptor/layout/tensor_layout.hpp"
 #include "ngraph/shape.hpp"
+#include "cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -32,7 +33,7 @@ namespace ngraph
     {
         namespace cpu
         {
-            class LayoutDescriptor : public ngraph::descriptor::layout::TensorLayout
+            class CPU_BACKEND_API LayoutDescriptor : public ngraph::descriptor::layout::TensorLayout
             {
             public:
                 LayoutDescriptor(const ngraph::descriptor::Tensor& tv);

--- a/src/ngraph/runtime/cpu/kernel/dot.hpp
+++ b/src/ngraph/runtime/cpu/kernel/dot.hpp
@@ -168,7 +168,7 @@ namespace ngraph
                 }
 
                 template <typename ElementType>
-                void dot(void* arg0,
+                void dot_ref(void* arg0,
                          void* arg1,
                          void* out,
                          const Shape& arg0_shape,

--- a/src/ngraph/runtime/cpu/kernel/pad.hpp
+++ b/src/ngraph/runtime/cpu/kernel/pad.hpp
@@ -60,7 +60,7 @@ namespace ngraph
                 }
 
                 template <typename ElementType>
-                void pad(const void* arg0,
+                void pad_ref(const void* arg0,
                          const void* arg1,
                          void* out,
                          const Shape& arg0_shape,

--- a/src/ngraph/runtime/cpu/kernel/reshape.hpp
+++ b/src/ngraph/runtime/cpu/kernel/reshape.hpp
@@ -145,7 +145,7 @@ namespace ngraph
                 }
 
                 template <typename ElementType>
-                void reshape(const void* arg,
+                void reshape_ref(const void* arg,
                              void* out,
                              const Shape& in_shape,
                              const AxisVector& in_axis_order,

--- a/src/ngraph/runtime/cpu/mkldnn_emitter.cpp
+++ b/src/ngraph/runtime/cpu/mkldnn_emitter.cpp
@@ -79,7 +79,7 @@ mkldnn::memory::desc MKLDNNEmitter::build_memory_descriptor(const TensorViewWrap
         fmt);
 }
 
-mkldnn::memory::desc MKLDNNEmitter::build_memory_descriptor(const Shape& shape,
+mkldnn::memory::desc MKLDNNEmitter::build_memory_descriptor(const ngraph::Shape& shape,
                                                             const ngraph::element::Type& et,
                                                             mkldnn::memory::format fmt) const
 {

--- a/src/ngraph/runtime/cpu/op/batch_norm_relu.hpp
+++ b/src/ngraph/runtime/cpu/op/batch_norm_relu.hpp
@@ -22,6 +22,7 @@
 #include "ngraph/node_vector.hpp"
 #include "ngraph/op/op.hpp"
 #include "ngraph/util.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -30,7 +31,7 @@ namespace ngraph
         class BatchNormTrainingRelu : public Op
         {
         public:
-            BatchNormTrainingRelu(double eps,
+            CPU_BACKEND_API BatchNormTrainingRelu(double eps,
                                   std::shared_ptr<Node> gamma,
                                   std::shared_ptr<Node> beta,
                                   std::shared_ptr<Node> input);

--- a/src/ngraph/runtime/cpu/op/conv_bias.hpp
+++ b/src/ngraph/runtime/cpu/op/conv_bias.hpp
@@ -18,6 +18,7 @@
 
 #include "ngraph/op/convolution.hpp"
 #include "ngraph/op/op.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -27,11 +28,11 @@ namespace ngraph
         class ConvolutionBias : public Op
         {
         public:
-            ConvolutionBias(const std::shared_ptr<op::Convolution>& conv,
+            CPU_BACKEND_API ConvolutionBias(const std::shared_ptr<op::Convolution>& conv,
                             const std::shared_ptr<Node>& bias,
                             const bool with_relu = false);
 
-            ConvolutionBias(const std::shared_ptr<Node>& data_batch,
+            CPU_BACKEND_API ConvolutionBias(const std::shared_ptr<Node>& data_batch,
                             const std::shared_ptr<Node>& filters,
                             const std::shared_ptr<Node>& bias,
                             const Strides& window_movement_strides,

--- a/src/ngraph/runtime/cpu/op/conv_relu.hpp
+++ b/src/ngraph/runtime/cpu/op/conv_relu.hpp
@@ -19,6 +19,7 @@
 #include "ngraph/op/convolution.hpp"
 #include "ngraph/op/op.hpp"
 #include "ngraph/runtime/cpu/op/conv_bias.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -28,9 +29,9 @@ namespace ngraph
         class ConvolutionRelu : public Op
         {
         public:
-            ConvolutionRelu(const std::shared_ptr<op::Convolution>& conv);
+            CPU_BACKEND_API ConvolutionRelu(const std::shared_ptr<op::Convolution>& conv);
 
-            ConvolutionRelu(const std::shared_ptr<Node>& data_batch,
+            CPU_BACKEND_API ConvolutionRelu(const std::shared_ptr<Node>& data_batch,
                             const std::shared_ptr<Node>& filters,
                             const Strides& window_movement_strides,
                             const Strides& window_dilation_strides,

--- a/src/ngraph/runtime/cpu/op/convert_layout.hpp
+++ b/src/ngraph/runtime/cpu/op/convert_layout.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ngraph/op/op.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -31,14 +32,14 @@ namespace ngraph
                 /// \brief Layout Conversion
                 ///
                 /// Converts an input tensor to a tensor with the given layout descriptor
-                class ConvertLayout : public ngraph::op::Op
+                class  ConvertLayout : public ngraph::op::Op
                 {
                 public:
-                    ConvertLayout(
+                    CPU_BACKEND_API ConvertLayout(
                         const std::shared_ptr<Node>& arg,
                         const std::shared_ptr<ngraph::runtime::cpu::LayoutDescriptor>& layout);
 
-                    ConvertLayout(
+                    CPU_BACKEND_API ConvertLayout(
                         const std::shared_ptr<Node>& arg,
                         size_t output_index,
                         const std::shared_ptr<ngraph::runtime::cpu::LayoutDescriptor>& layout);

--- a/src/ngraph/runtime/cpu/op/group_conv.hpp
+++ b/src/ngraph/runtime/cpu/op/group_conv.hpp
@@ -18,6 +18,7 @@
 
 #include "ngraph/op/convolution.hpp"
 #include "ngraph/op/op.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -27,7 +28,7 @@ namespace ngraph
         class GroupConvolution : public Op
         {
         public:
-            GroupConvolution(const std::shared_ptr<Node>& data_batch,
+            CPU_BACKEND_API GroupConvolution(const std::shared_ptr<Node>& data_batch,
                              const std::shared_ptr<Node>& filters,
                              const Strides& window_movement_strides,
                              const Strides& window_dilation_strides,

--- a/src/ngraph/runtime/cpu/op/matmul_bias.hpp
+++ b/src/ngraph/runtime/cpu/op/matmul_bias.hpp
@@ -18,6 +18,7 @@
 
 #include "ngraph/axis_set.hpp"
 #include "ngraph/op/op.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -26,7 +27,7 @@ namespace ngraph
         class MatmulBias : public Op
         {
         public:
-            MatmulBias(std::shared_ptr<Node> W,
+            CPU_BACKEND_API MatmulBias(std::shared_ptr<Node> W,
                        std::shared_ptr<Node> x,
                        std::shared_ptr<Node> b,
                        Shape shape_w,

--- a/src/ngraph/runtime/cpu/op/rnn.hpp
+++ b/src/ngraph/runtime/cpu/op/rnn.hpp
@@ -18,6 +18,7 @@
 
 #include "ngraph/op/op.hpp"
 #include "ngraph/util.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -46,7 +47,7 @@ namespace ngraph
         class Rnn : public Op
         {
         public:
-            Rnn(std::shared_ptr<Node> src_layer,
+            CPU_BACKEND_API Rnn(std::shared_ptr<Node> src_layer,
                 std::shared_ptr<Node> src_iter,
                 std::shared_ptr<Node> weights_layer,
                 std::shared_ptr<Node> weights_iter,

--- a/src/ngraph/runtime/cpu/op/sigmoid_mul.hpp
+++ b/src/ngraph/runtime/cpu/op/sigmoid_mul.hpp
@@ -18,6 +18,7 @@
 
 #include "ngraph/op/op.hpp"
 #include "ngraph/util.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 #include <array>
 
@@ -39,7 +40,7 @@ namespace ngraph
             };
             /// Input nodes are expected to be actual inputs where the corresponding input
             /// FunctionType will be applied to those inputs in the fused operation.
-            SigmoidMultiply(std::shared_ptr<Node> input_0,
+            CPU_BACKEND_API SigmoidMultiply(std::shared_ptr<Node> input_0,
                             std::shared_ptr<Node> input_1,
                             const FunctionType input_0_type,
                             const FunctionType input_1_type);
@@ -53,7 +54,7 @@ namespace ngraph
                 return m_input_type[index];
             }
             /// Identifies the corresponding FunctionType for the input node.
-            static FunctionType identify_node_type(const std::shared_ptr<ngraph::Node>& node);
+            static CPU_BACKEND_API FunctionType identify_node_type(const std::shared_ptr<ngraph::Node>& node);
 
         private:
             std::array<FunctionType, 2> m_input_type;

--- a/src/ngraph/runtime/cpu/pass/cpu_fusion.hpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_fusion.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ngraph/pass/graph_rewrite.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -32,7 +33,7 @@ namespace ngraph
     }
 }
 
-class ngraph::runtime::cpu::pass::CPUFusion : public ngraph::pass::GraphRewrite
+class CPU_BACKEND_API ngraph::runtime::cpu::pass::CPUFusion : public ngraph::pass::GraphRewrite
 {
 public:
     CPUFusion(ngraph::pass::FusionType fusions = ngraph::pass::ALL_FUSIONS)

--- a/src/ngraph/runtime/cpu/pass/cpu_mat_fusion.hpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_mat_fusion.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ngraph/pass/pass.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -26,13 +27,13 @@ namespace ngraph
         {
             namespace pass
             {
-                class CPURnnMatFusion : public ngraph::pass::FunctionPass
+                class CPU_BACKEND_API CPURnnMatFusion : public ngraph::pass::FunctionPass
                 {
                 public:
                     virtual bool
                         run_on_function(std::shared_ptr<ngraph::Function> function) override;
                 };
-                class CPUBatchFusion : public ngraph::pass::FunctionPass
+                class CPU_BACKEND_API CPUBatchFusion : public ngraph::pass::FunctionPass
                 {
                 public:
                     CPUBatchFusion(ngraph::pass::FusionType type = ngraph::pass::ALL_FUSIONS)

--- a/src/ngraph/runtime/cpu/pass/cpu_post_layout_optimizations.hpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_post_layout_optimizations.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include "ngraph/pass/graph_rewrite.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -31,7 +32,7 @@ namespace ngraph
     }
 }
 
-class ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations : public ngraph::pass::GraphRewrite
+class CPU_BACKEND_API ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations : public ngraph::pass::GraphRewrite
 {
 public:
     CPUPostLayoutOptimizations()

--- a/src/ngraph/runtime/cpu/pass/cpu_rnn_fusion.hpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_rnn_fusion.hpp
@@ -18,6 +18,7 @@
 
 #include "ngraph/pass/graph_rewrite.hpp"
 #include "ngraph/runtime/cpu/pass/cpu_fusion.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -35,7 +36,7 @@ namespace ngraph
     }
 }
 
-class ngraph::runtime::cpu::pass::LSTMFusion : public ngraph::pass::GraphRewrite
+class CPU_BACKEND_API ngraph::runtime::cpu::pass::LSTMFusion : public ngraph::pass::GraphRewrite
 {
 public:
     LSTMFusion()
@@ -50,7 +51,7 @@ private:
     void construct_lstm_fprop();
 };
 
-class ngraph::runtime::cpu::pass::RNNFusion : public ngraph::pass::RecurrentGraphRewrite
+class CPU_BACKEND_API ngraph::runtime::cpu::pass::RNNFusion : public ngraph::pass::RecurrentGraphRewrite
 {
 public:
     RNNFusion()

--- a/src/ngraph/runtime/cpu/pass/cpu_workspace_insertion.hpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_workspace_insertion.hpp
@@ -18,6 +18,7 @@
 #include "ngraph/node_vector.hpp"
 #include "ngraph/pass/pass.hpp"
 #include "ngraph/pattern/matcher.hpp"
+#include "ngraph/runtime/cpu/cpu_backend_visibility.h"
 
 namespace ngraph
 {
@@ -33,7 +34,7 @@ namespace ngraph
     }
 }
 
-class ngraph::runtime::cpu::pass::CPUWorkspaceInsertion : public ngraph::pass::FunctionPass
+class CPU_BACKEND_API ngraph::runtime::cpu::pass::CPUWorkspaceInsertion : public ngraph::pass::FunctionPass
 {
 public:
     CPUWorkspaceInsertion(ngraph::NodeVector& indices_list, bool return_indices = true)

--- a/src/resource/CMakeLists.txt
+++ b/src/resource/CMakeLists.txt
@@ -39,7 +39,11 @@ if(NGRAPH_TBB_ENABLE)
 endif()
 
 add_executable(resource_generator EXCLUDE_FROM_ALL ${SRC})
-add_dependencies(resource_generator ext_llvm)
+
+if (NOT NGRAPH_DEX_ONLY)
+    add_dependencies(resource_generator ext_llvm)
+endif()
+
 if(NGRAPH_CPU_ENABLE)
     add_dependencies(resource_generator ext_eigen ext_mkldnn)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRC
     includes.cpp
     input_output_assign.cpp
     main.cpp
+    misc.cpp
     nop_elimination.cpp
     op.cpp
     partial_shape.cpp
@@ -245,10 +246,19 @@ if (NGRAPH_ONNXIFI_ENABLE)
     target_link_libraries(unit-test PRIVATE onnxifi-ngraph)
 endif()
 
-add_custom_target(unit-test-check
-    COMMAND ${PROJECT_BINARY_DIR}/test/unit-test \${ARGS}
-    DEPENDS unit-test
-)
+# If all the runtime libraries are installed into one location, that will make life easier.
+if (MSVS)
+    add_custom_target(unit-test-check
+        COMMAND set "PATH=${EXTERNAL_PROJECTS_ROOT}/src/ngraph/Release;${EXTERNAL_PROJECTS_ROOT}/mkldnn/lib/;${EXTERNAL_PROJECTS_ROOT}/mkl/src/ext_mkl/lib/;${EXTERNAL_PROJECTS_ROOT}/ext_tbb-prefix/src/ext_tbb/tbb2019_20181203oss/bin/intel64/vc14;%PATH%"
+        COMMAND ${PROJECT_BINARY_DIR}/test/unit-test \${ARGS}
+        DEPENDS unit-test
+    )
+else()
+    add_custom_target(unit-test-check
+        COMMAND ${PROJECT_BINARY_DIR}/test/unit-test \${ARGS}
+        DEPENDS unit-test
+    )
+endif()
 
 add_custom_target(check
     DEPENDS

--- a/test/backend_unary_elementwise.in.cpp
+++ b/test/backend_unary_elementwise.in.cpp
@@ -392,7 +392,7 @@ NGRAPH_TEST(${BACKEND_NAME}, sqrt)
 
     auto handle = backend->compile(f);
     backend->call_with_validate(handle, {result}, {a});
-    EXPECT_EQ((vector<float>{4, 2, 9, 10, 100, 0}), read_vector<float>(result));
+    EXPECT_TRUE(test::all_close_f(vector<float>{4, 2, 9, 10, 100, 0}, read_vector<float>(result)));
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, tan)

--- a/test/cpu_fusion.cpp
+++ b/test/cpu_fusion.cpp
@@ -1339,9 +1339,9 @@ TEST(cpu_fusion, rnn_fusion_from_json_model)
     shared_ptr<Function> func = ngraph::deserialize(ss);
     pass_manager.run_passes(func);
     const size_t NUM_STEPS = 10;
-    auto mmb_predicate = [](std::shared_ptr<Node> node) {
+    auto mmb_predicate = [=](std::shared_ptr<Node> node) {
         auto users = node->get_users();
-        return users.size() == NUM_STEPS &&
+        return (users.size() == NUM_STEPS) &&
                std::all_of(begin(users), end(users), [](std::shared_ptr<Node> n) {
                    return std::dynamic_pointer_cast<op::Slice>(n) != nullptr;
                });

--- a/test/cpu_test.cpp
+++ b/test/cpu_test.cpp
@@ -41,6 +41,7 @@
 #include "util/ndarray.hpp"
 #include "util/random.hpp"
 #include "util/test_tools.hpp"
+#include "misc.hpp"
 
 using namespace ngraph;
 using namespace std;
@@ -124,7 +125,7 @@ TEST(cpu_test, abc_tbb)
     bool use_tbb = (getenv("NGRAPH_CPU_USE_TBB") != nullptr);
     if (!use_tbb)
     {
-        setenv("NGRAPH_CPU_USE_TBB", "1", 1);
+        set_environment("NGRAPH_CPU_USE_TBB", "1", 1);
     }
 
     Shape shape{2, 2};
@@ -160,7 +161,7 @@ TEST(cpu_test, abc_tbb)
 
     if (!use_tbb)
     {
-        unsetenv("NGRAPH_CPU_USE_TBB");
+        unset_environment("NGRAPH_CPU_USE_TBB");
     }
 }
 #endif // NGRAPH_TBB_ENABLE

--- a/test/misc.cpp
+++ b/test/misc.cpp
@@ -13,9 +13,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#include "cpu_backend_visibility.h"
+#include "misc.hpp"
 
-extern "C" CPU_BACKEND_API const char* get_ngraph_version_string()
-{
-    return NGRAPH_VERSION;
+
+FILE *port_open(const char *command, const char *type) {
+#ifdef _WIN32
+    return _popen(command, type);
+#elif defined (__linux) || defined(__APPLE__)
+    return popen(command, type);
+#endif
+}
+
+int port_close(FILE *stream) {
+#ifdef _WIN32
+    return _pclose(stream);
+#elif defined (__linux) || defined(__APPLE__)
+    return pclose(stream);
+#endif
+}
+
+int set_environment(const char *name, const char *value, int overwrite) {
+#ifdef _WIN32
+    return _putenv_s(name, value);
+#elif defined (__linux) || defined(__APPLE__)
+    return setenv(name, value, overwrite);
+#endif
+}
+
+int unset_environment(const char *name) {
+#ifdef _WIN32
+    return _putenv_s(name, "");
+#elif defined (__linux) || defined(__APPLE__)
+    return unsetenv(name);
+#endif
 }

--- a/test/misc.hpp
+++ b/test/misc.hpp
@@ -13,9 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#include "cpu_backend_visibility.h"
 
-extern "C" CPU_BACKEND_API const char* get_ngraph_version_string()
-{
-    return NGRAPH_VERSION;
-}
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+
+FILE *port_open(const char *command, const char *type);
+int port_close(FILE *stream);
+int set_environment(const char *name, const char *value, int overwrite);
+int unset_environment(const char *name);

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -20,6 +20,7 @@
 #include "ngraph/cpio.hpp"
 #include "ngraph/file_util.hpp"
 #include "ngraph/log.hpp"
+#include "misc.hpp"
 
 using namespace ngraph;
 using namespace std;
@@ -33,7 +34,7 @@ TEST(tools, nbench_functional)
 
     ss << NBENCH_PATH << " -f " << model_path << " -b INTERPRETER -i 2 -w 2";
     auto cmd = ss.str();
-    auto f = popen(cmd.c_str(), "r");
+    auto f = port_open(cmd.c_str(), "r");
     if (f)
     {
         stringstream str;
@@ -45,7 +46,7 @@ TEST(tools, nbench_functional)
             str << s;
         }
         string output = str.str();
-        auto status = pclose(f);
+        auto status = port_close(f);
         ASSERT_EQ(status, 0) << output;
     }
     else


### PR DESCRIPTION
This is the local branch merged from the jfdong:winbuild fork. This fork was reviewed in #2321 

Delete dependency of LLVM when building with MSVC.
Use _popen on Windows instead of popen.

After this commit and importing dirent.h (Reason: It is a header file that is only on Linux system. Fix: https://github.com/tronkko/dirent is a project providing Linux compatible Dirent interface for Windows.), interpreter and unit test fully passed.

The build command with MSVC as follows:
set path=%path%;C:\work\ngraph\source\ngraph\build\src\ngraph\Release
cmake .. -G "Visual Studio 15 2017 Win64" -DGIT_EXECUTABLE="C:\Program Files\Git\cmd\git.exe" -DNGRAPH_CPU_ENABLE=OFF -DNGRAPH_DEX_ONLY=ON
msbuild "ngraph.sln" /t:Rebuild /p:Configuration=Release /m