### PR TITLE
Do not allow builder to access tensor_data map directly.

### DIFF
--- a/src/ngraph/runtime/cpu/builder/argmax.cpp
+++ b/src/ngraph/runtime/cpu/builder/argmax.cpp
@@ -33,13 +33,12 @@ namespace ngraph
             void Builder::BUILDER_DECL(ngraph::op::ArgMax)
             {
                 auto& functors = external_function->get_functors();
-                auto& tensor_data = external_function->get_tensor_data();
 
                 const ngraph::op::ArgMax* argmax = static_cast<const ngraph::op::ArgMax*>(node);
                 CPUKernelFunctor functor;
 
-                auto& arg_tensor = tensor_data[args[0].get_name()];
-                auto& out_tensor = tensor_data[out[0].get_name()];
+                auto& arg_tensor = external_function->get_tensor_data(args[0].get_name());
+                auto& out_tensor = external_function->get_tensor_data(out[0].get_name());
                 if (out[0].get_element_type() != element::i64 &&
                     out[0].get_element_type() != element::i32)
                 {

--- a/src/ngraph/runtime/cpu/builder/argmin.cpp
+++ b/src/ngraph/runtime/cpu/builder/argmin.cpp
@@ -33,13 +33,12 @@ namespace ngraph
             void Builder::BUILDER_DECL(ngraph::op::ArgMin)
             {
                 auto& functors = external_function->get_functors();
-                auto& tensor_data = external_function->get_tensor_data();
 
                 const ngraph::op::ArgMin* argmin = static_cast<const ngraph::op::ArgMin*>(node);
                 CPUKernelFunctor functor;
 
-                auto& arg_tensor = tensor_data[args[0].get_name()];
-                auto& out_tensor = tensor_data[out[0].get_name()];
+                auto& arg_tensor = external_function->get_tensor_data(args[0].get_name());
+                auto& out_tensor = external_function->get_tensor_data(out[0].get_name());
                 if (out[0].get_element_type() != element::i64 &&
                     out[0].get_element_type() != element::i32)
                 {

--- a/src/ngraph/runtime/cpu/builder/embedding_lookup.cpp
+++ b/src/ngraph/runtime/cpu/builder/embedding_lookup.cpp
@@ -33,13 +33,12 @@ namespace ngraph
             void Builder::BUILDER_DECL(ngraph::op::EmbeddingLookup)
             {
                 auto& functors = external_function->get_functors();
-                auto& tensor_data = external_function->get_tensor_data();
 
                 CPUKernelFunctor functor;
+                auto& arg0_tensor = external_function->get_tensor_data(args[0].get_name());
+                auto& arg1_tensor = external_function->get_tensor_data(args[1].get_name());
+                auto& out_tensor = external_function->get_tensor_data(out[0].get_name());
 
-                auto& arg0_tensor = tensor_data[args[0].get_name()];
-                auto& arg1_tensor = tensor_data[args[1].get_name()];
-                auto& out_tensor = tensor_data[out[0].get_name()];
                 if (out[0].get_element_type() != element::f32 &&
                     out[0].get_element_type() != element::f64)
                 {

--- a/src/ngraph/runtime/cpu/builder/quantization.cpp
+++ b/src/ngraph/runtime/cpu/builder/quantization.cpp
@@ -39,7 +39,6 @@ namespace ngraph
             void Builder::BUILDER_DECL(ngraph::op::Dequantize)
             {
                 auto& functors = external_function->get_functors();
-                auto& tensor_data = external_function->get_tensor_data();
 
                 const ngraph::op::Dequantize* dequantize =
                     static_cast<const ngraph::op::Dequantize*>(node);
@@ -47,8 +46,9 @@ namespace ngraph
 
                 if (runtime::cpu::mkldnn_utils::use_mkldnn_kernel(node))
                 {
-                    auto& arg0_tensor = tensor_data[args[0].get_name()];
-                    auto& out_tensor = tensor_data[out[0].get_name()];
+                    auto& arg0_tensor = external_function->get_tensor_data(args[0].get_name());
+                    auto& out_tensor = external_function->get_tensor_data(out[0].get_name());
+
                     auto& mkldnn_emitter = external_function->get_mkldnn_emitter();
                     auto input_desc = mkldnn_utils::get_input_mkldnn_md(node, 0);
                     auto result_desc = mkldnn_utils::get_output_mkldnn_md(node, 0);
@@ -106,10 +106,11 @@ namespace ngraph
                 }
                 else
                 {
-                    auto& arg0_tensor = tensor_data[args[0].get_name()];
-                    auto& arg1_tensor = tensor_data[args[1].get_name()];
-                    auto& arg2_tensor = tensor_data[args[2].get_name()];
-                    auto& out_tensor = tensor_data[out[0].get_name()];
+                    auto& arg0_tensor = external_function->get_tensor_data(args[0].get_name());
+                    auto& arg1_tensor = external_function->get_tensor_data(args[1].get_name());
+                    auto& arg2_tensor = external_function->get_tensor_data(args[2].get_name());
+                    auto& out_tensor = external_function->get_tensor_data(out[0].get_name());
+
                     auto arg0_shape = args[0].get_shape();
                     auto arg1_shape = args[1].get_shape();
                     auto daxes = dequantize->get_axes();
@@ -306,16 +307,15 @@ namespace ngraph
                 else
                 {
                     auto& functors = external_function->get_functors();
-                    auto& tensor_data = external_function->get_tensor_data();
 
                     const ngraph::op::Quantize* quantize =
                         static_cast<const ngraph::op::Quantize*>(node);
                     CPUKernelFunctor functor;
 
-                    auto& arg0_tensor = tensor_data[args[0].get_name()];
-                    auto& arg1_tensor = tensor_data[args[1].get_name()];
-                    auto& arg2_tensor = tensor_data[args[2].get_name()];
-                    auto& out_tensor = tensor_data[out[0].get_name()];
+                    auto& arg0_tensor = external_function->get_tensor_data(args[0].get_name());
+                    auto& arg1_tensor = external_function->get_tensor_data(args[1].get_name());
+                    auto& arg2_tensor = external_function->get_tensor_data(args[2].get_name());
+                    auto& out_tensor = external_function->get_tensor_data(out[0].get_name());
 
                     auto arg0_shape = args[0].get_shape();
                     auto arg1_shape = args[1].get_shape();

--- a/src/ngraph/runtime/cpu/cpu_external_function.hpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.hpp
@@ -132,7 +132,6 @@ namespace ngraph
                 static constexpr size_t s_memory_pool_alignment = 4096;
 
                 std::vector<CPUKernelFunctor>& get_functors() { return functors; }
-                std::unordered_map<std::string, void*>& get_tensor_data() { return tensor_data; }
                 void*& get_tensor_data(const std::string& name);
                 std::function<void(CPURuntimeContext*, std::vector<void*>&, std::vector<void*>&)>&
                     get_executor()


### PR DESCRIPTION
Builder should use external_function->get_tensor_data(tensor_name) to get tensor due to tensor alias.