### PR TITLE
Change behavior for bad/out-of-bounds OneHot values

### DIFF
--- a/src/ngraph/runtime/cpu/kernel/one_hot.hpp
+++ b/src/ngraph/runtime/cpu/kernel/one_hot.hpp
@@ -36,10 +36,14 @@ namespace ngraph
                     void* arg, void* out, const Shape& out_shape, size_t one_hot_axis, int arena)
 
                 {
-                    memset(out, 0, sizeof(ElementType) * shape_size(out_shape));
+                    size_t element_count = shape_size(out_shape);
+                    memset(out, 0, sizeof(ElementType) * element_count);
                     auto pos_raw = (static_cast<ElementType*>(arg))[0];
                     size_t pos = pos_raw;
-                    (static_cast<ElementType*>(out))[pos] = 1;
+                    // if (pos < element_count)
+                    {
+                        (static_cast<ElementType*>(out))[pos] = 1;
+                    }
                 }
 
                 template <typename ElementType>

--- a/src/ngraph/runtime/cpu/kernel/one_hot.hpp
+++ b/src/ngraph/runtime/cpu/kernel/one_hot.hpp
@@ -40,7 +40,7 @@ namespace ngraph
                     memset(out, 0, sizeof(ElementType) * element_count);
                     auto pos_raw = (static_cast<ElementType*>(arg))[0];
                     size_t pos = pos_raw;
-                    // if (pos < element_count)
+                    if (pos < element_count)
                     {
                         (static_cast<ElementType*>(out))[pos] = 1;
                     }

--- a/src/ngraph/runtime/cpu/unit_test.manifest
+++ b/src/ngraph/runtime/cpu/unit_test.manifest
@@ -1,11 +1,3 @@
-# one hot tests that expect exceptions
-# Consider removing
-one_hot_scalar_fp_nonint_in_3
-one_hot_scalar_oob_in_3
-one_hot_vector_1_barely_oob
-one_hot_vector_1_far_oob
-one_hot_vector_1_fp_nonint
-
 backwards_maxpool_n2_c1_hw5_3x3_str2_max_pad1x2_2x3
 backwards_batch_norm_training
 shape_of_scalar

--- a/src/ngraph/runtime/gpu/unit_test.manifest
+++ b/src/ngraph/runtime/gpu/unit_test.manifest
@@ -95,3 +95,4 @@ all_2x2x3_eliminate_dims_0_1_2
 # GPU backend uses floats to implement these ops for int32 
 floor_int32
 divide_int32
+one_hot_scalar_oob_in_3

--- a/src/ngraph/runtime/reference/one_hot.hpp
+++ b/src/ngraph/runtime/reference/one_hot.hpp
@@ -27,8 +27,6 @@ namespace ngraph
     {
         namespace reference
         {
-            // NOTE: Execution throws `std::range_error` if either a non-integral value or an out-of-bounds
-            // value is detected in the input tensor.
             template <typename T>
             void one_hot(const T* arg,
                          T* out,

--- a/src/ngraph/runtime/reference/one_hot.hpp
+++ b/src/ngraph/runtime/reference/one_hot.hpp
@@ -54,14 +54,14 @@ namespace ngraph
 
                     if (std::floor(val) < val || std::floor(val) > val)
                     {
-                        throw(std::range_error("One-hot: non-integral value in input"));
+                        continue;
                     }
 
                     size_t one_hot_pos = static_cast<size_t>(val);
 
                     if (one_hot_pos >= out_shape[one_hot_axis])
                     {
-                        throw(std::range_error("One-hot: value is out of category range"));
+                        continue;
                     }
 
                     Coordinate one_hot_coord = inject(input_coord, one_hot_axis, one_hot_pos);

--- a/test/backend_one_hot.in.cpp
+++ b/test/backend_one_hot.in.cpp
@@ -136,22 +136,13 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_scalar_oob_in_3)
 
     // Create some tensors for input/output
     auto a = backend->create_tensor(element::i32, shape_a);
-    copy_data(a, vector<int32_t>{3000000});
-    auto result = backend->create_tensor(element::i32, shape_r);
+    copy_data(a, vector<int32_t>{3});
+    vector<int32_t> r_data(4);
+    auto result = backend->create_tensor(element::i32, shape_r, r_data.data());
 
-    try
-    {
-        auto handle = backend->compile(f);
-        handle->call_with_validate({result}, {a});
-    }
-    catch (const std::exception& e)
-    {
-        EXPECT_EQ(e.what(), std::string("One-hot: value is out of category range"));
-    }
-    catch (...)
-    {
-        FAIL() << "Expected a std::out_of_range exception";
-    }
+    auto handle = backend->compile(f);
+    handle->call_with_validate({result}, {a});
+    EXPECT_EQ(r_data[3], 0);
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, one_hot_vector_0)
@@ -213,49 +204,42 @@ NGRAPH_TEST(${BACKEND_NAME}, one_hot_vector_1_barely_oob)
     copy_data(a, vector<int32_t>{2, 1, 0, 0, 3, 2, 1, 0});
     auto result = backend->create_tensor(element::i32, shape_r);
 
-    try
-    {
-        auto handle = backend->compile(f);
-        handle->call_with_validate({result}, {a});
-    }
-    catch (const std::exception& e)
-    {
-        EXPECT_EQ(e.what(), std::string("One-hot: value is out of category range"));
-    }
-    catch (...)
-    {
-        FAIL() << "Expected a std::out_of_range exception";
-    }
-}
+    auto handle = backend->compile(f);
+    handle->call_with_validate({result}, {a});
+    vector<int32_t> rv = read_vector<int32_t>(result);
 
-NGRAPH_TEST(${BACKEND_NAME}, one_hot_vector_1_far_oob)
-{
-    Shape shape_a{8};
-    auto A = make_shared<op::Parameter>(element::i32, shape_a);
-    Shape shape_r{8, 3};
-    auto r = make_shared<op::OneHot>(A, Shape{8, 3}, 1);
-    auto f = make_shared<Function>(r, ParameterVector{A});
+    EXPECT_EQ(rv[0], 0);
+    EXPECT_EQ(rv[1], 0);
+    EXPECT_EQ(rv[2], 1);
 
-    auto backend = runtime::Backend::create("${BACKEND_NAME}");
+    EXPECT_EQ(rv[3], 0);
+    EXPECT_EQ(rv[4], 1);
+    EXPECT_EQ(rv[5], 0);
 
-    // Create some tensors for input/output
-    auto a = backend->create_tensor(element::i32, shape_a);
-    copy_data(a, vector<int32_t>{2, 1, 0, 0, 3000000, 2, 1, 0});
-    auto result = backend->create_tensor(element::i32, shape_r);
+    EXPECT_EQ(rv[6], 1);
+    EXPECT_EQ(rv[7], 0);
+    EXPECT_EQ(rv[8], 0);
 
-    try
-    {
-        auto handle = backend->compile(f);
-        handle->call_with_validate({result}, {a});
-    }
-    catch (const std::exception& e)
-    {
-        EXPECT_EQ(e.what(), std::string("One-hot: value is out of category range"));
-    }
-    catch (...)
-    {
-        FAIL() << "Expected a std::out_of_range exception";
-    }
+    EXPECT_EQ(rv[9], 1);
+    EXPECT_EQ(rv[10], 0);
+    EXPECT_EQ(rv[11], 0);
+
+    // These are undefined since value is out of bounds
+    // EXPECT_EQ(rv[12], 0);
+    // EXPECT_EQ(rv[13], 0);
+    // EXPECT_EQ(rv[14], 0);
+
+    EXPECT_EQ(rv[15], 0);
+    EXPECT_EQ(rv[16], 0);
+    EXPECT_EQ(rv[17], 1);
+
+    EXPECT_EQ(rv[18], 0);
+    EXPECT_EQ(rv[19], 1);
+    EXPECT_EQ(rv[20], 0);
+
+    EXPECT_EQ(rv[21], 1);
+    EXPECT_EQ(rv[22], 0);
+    EXPECT_EQ(rv[23], 0);
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, one_hot_matrix_0)


### PR DESCRIPTION
The behavior for OneHot values which are either out-of-bounds or invalid (like a non-integer value) is now changed to be `undefined`. A test was added to check that out-of-bounds values that are beyond the size of the tensor don't actually write to memory and a fix was added to the CPU OneHot kernel.

Out-of-bounds results can't be checked if they are `valid` because the result of out-of-bounds is undefined.

The CPU backend now passes all one hot unit tests :)