### PR TITLE
Fixed CentOS build issues 

### DIFF
--- a/src/ngraph/log.cpp
+++ b/src/ngraph/log.cpp
@@ -18,7 +18,6 @@
 #include <condition_variable>
 #include <ctime>
 #include <functional>
-#include <iomanip>
 #include <iostream>
 #include <mutex>
 #include <thread>
@@ -27,7 +26,6 @@
 
 using namespace std;
 using namespace ngraph;
-using namespace std::chrono;
 
 void ngraph::default_logger_handler_func(const string& s)
 {
@@ -75,20 +73,24 @@ LogHelper::~LogHelper()
 std::string ngraph::get_timestamp()
 {
     // get current time
-    auto now = system_clock::now();
+    auto now = std::chrono::system_clock::now();
 
     // get number of nanoseconds for the current second
     // (remainder after division into seconds)
-    auto ns = duration_cast<nanoseconds>(now.time_since_epoch()) % 1000000;
+    auto ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()) % 1000000;
 
     // convert to std::time_t in order to convert to std::tm (broken time)
-    auto timer = system_clock::to_time_t(now);
+    auto timer = std::chrono::system_clock::to_time_t(now);
 
     // convert to broken time
-    std::tm bt = *std::localtime(&timer);
+    std::tm* bt = std::localtime(&timer);
+
+    char buffer[256];
+    strftime(buffer, sizeof(buffer), "%H:%M:%S", bt);
 
     std::ostringstream timestamp;
-    timestamp << std::put_time(&bt, "%H:%M:%S"); // HH:MM:SS
+    timestamp << buffer;
     timestamp << '.' << std::setfill('0') << std::setw(3) << ns.count();
 
     return timestamp.str();

--- a/src/ngraph/log.hpp
+++ b/src/ngraph/log.hpp
@@ -36,21 +36,6 @@
 
 namespace ngraph
 {
-#if defined(__linux) || defined(__APPLE__)
-    std::string get_timestamp();
-    void LogPrintf(const char* fmt, ...);
-    extern bool DISABLE_LOGGING;
-#define NGRAPH_DEBUG_PRINT(fmt, ...)                                                               \
-    do                                                                                             \
-    {                                                                                              \
-        if (!DISABLE_LOGGING)                                                                      \
-        {                                                                                          \
-            LogPrintf(fmt, __VA_ARGS__);                                                           \
-        }                                                                                          \
-    } while (0)
-#else
-#define NGRAPH_DEBUG_PRINT(fmt, ...)
-#endif
     class ConstString
     {
     public:
@@ -187,5 +172,22 @@ namespace ngraph
 
 #define NGRAPH_DEBUG                                                                               \
     ::ngraph::NullLogger {}
+#endif
+
+#if defined(__linux) || defined(__APPLE__)
+    std::string get_timestamp();
+    void LogPrintf(const char* fmt, ...);
+    extern bool DISABLE_LOGGING;
+
+#define NGRAPH_DEBUG_PRINT(fmt, ...)                                                               \
+    do                                                                                             \
+    {                                                                                              \
+        if (!ngraph::DISABLE_LOGGING)                                                              \
+        {                                                                                          \
+            ngraph::LogPrintf(fmt, __VA_ARGS__);                                                   \
+        }                                                                                          \
+    } while (0)
+#else
+#define NGRAPH_DEBUG_PRINT(fmt, ...)
 #endif
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -37,10 +37,6 @@ int main(int argc, char** argv)
     DistributedSetup distributed_setup;
     distributed_setup.set_comm_size(dist->get_size());
     distributed_setup.set_comm_rank(dist->get_rank());
-    if (dist->get_size() == 1)
-    {
-        dist.reset();
-    }
 #endif
 
     const char* exclude = "--gtest_filter=-benchmark.*";
@@ -54,8 +50,11 @@ int main(int argc, char** argv)
     argc++;
 
     ::testing::InitGoogleTest(&argc, argv_vector.data());
+    auto start = std::chrono::system_clock::now();
     int rc = RUN_ALL_TESTS();
-
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now() - start);
+    NGRAPH_DEBUG_PRINT("[MAIN] Tests finished: Time: %d ms Exit code: %d", elapsed.count(), rc);
 #ifdef NGRAPH_DISTRIBUTED_ENABLE
     if (dist)
     {


### PR DESCRIPTION
Fixed the `std::put_time(...)` issue that's not supported on `gcc 4.8.5`. Also fixed a logical error in distributed setup for the unit test.