### PR TITLE
Rename CHECK macro to NGRAPH_CHECK

### DIFF
--- a/src/ngraph/check.hpp
+++ b/src/ngraph/check.hpp
@@ -66,7 +66,7 @@ namespace ngraph
 
 // TODO(amprocte): refactor so we don't have to introduce a locally-scoped variable and risk
 // shadowing here.
-#define CHECK(exc_class, ctx, check, ...)                                                          \
+#define NGRAPH_CHECK(exc_class, ctx, check, ...)                                                   \
     do                                                                                             \
     {                                                                                              \
         if (!(check))                                                                              \

--- a/src/ngraph/node.hpp
+++ b/src/ngraph/node.hpp
@@ -329,4 +329,4 @@ namespace ngraph
                                 ::ngraph::node_validation_assertion_string(node))
 
 #define NODE_VALIDATION_CHECK(node, cond, ...)                                                     \
-    CHECK(::NodeValidationFailure, (node), (cond), __VA_ARGS__)
+    NGRAPH_CHECK(::NodeValidationFailure, (node), (cond), __VA_ARGS__)


### PR DESCRIPTION
… so it's less likely to collide with other libraries