### PR TITLE
make distributed logging available for all comm's libs  

### DIFF
--- a/src/ngraph/log.cpp
+++ b/src/ngraph/log.cpp
@@ -113,7 +113,7 @@ void ngraph::LogPrintf(const char* fmt, ...)
 #pragma GCC diagnostic pop
     va_end(args2);
 
-#ifdef NGRAPH_DISTRIBUTED_OMPI_ENABLE
+#ifdef NGRAPH_DISTRIBUTED_ENABLE
     ngraph::Distributed dist;
     std::printf("%s [RANK: %d]: %s\n", get_timestamp().c_str(), dist.get_rank(), buf.data());
 #else

--- a/src/ngraph/log.hpp
+++ b/src/ngraph/log.hpp
@@ -30,7 +30,7 @@
 #endif
 #include <vector>
 
-#ifdef NGRAPH_DISTRIBUTED_OMPI_ENABLE
+#ifdef NGRAPH_DISTRIBUTED_ENABLE
 #include "ngraph/distributed.hpp"
 #endif
 


### PR DESCRIPTION
this allows the use of distributed logging for both OpenMPI as well as MLSL lib