### PR TITLE
Add sitemap for OTC team

### DIFF
--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -96,13 +96,3 @@ Indices and tables
 
    * :ref:`search`
    * :ref:`genindex`
-
-
-
-.. _nGraph ONNX companion tool: https://github.com/NervanaSystems/ngraph-onnx
-.. _ONNX: http://onnx.ai
-.. _Movidius: https://www.movidius.com/
-.. _contributions: https://github.com/NervanaSystems/ngraph#how-to-contribute
-.. _TensorFlow bridge to nGraph: https://github.com/NervanaSystems/ngraph-tf/blob/master/README.md
-.. _Compiling MXNet with nGraph: https://github.com/NervanaSystems/ngraph-mxnet/blob/master/README.md
-.. _ecosystem: https://github.com/NervanaSystems/ngraph/blob/master/ecosystem-overview.md

--- a/doc/sphinx/source/sitemap.rst
+++ b/doc/sphinx/source/sitemap.rst
@@ -1,0 +1,16 @@
+:orphan:
+
+.. _sitemap.rst:
+
+.. toctree::
+   :maxdepth: 1 
+
+   Introduction <project/introduction.rst>
+   Framework Support <frameworks/index.rst>
+   nGraph Core <core/overview.rst>
+   Backend support <backend-support/index.rst>
+   Distributed training <distr/index.rst>
+   Diagnostics and visualization <diagnostics/nbench.rst>
+   Tutorials <tutorials/index.rst>
+   Project <project/index.rst> 
+


### PR DESCRIPTION
This PR simply adds a new file, a  `sitemap` that the OTC team working on our website can use to help build docs.  Tested and builds. 