### PR TITLE
Converted some unit tests to all_close_f - for r0.15.1

### DIFF
--- a/test/backend_pool.in.cpp
+++ b/test/backend_pool.in.cpp
@@ -1249,7 +1249,8 @@ NGRAPH_TEST_P(${BACKEND_NAME}, avg_pool_3d_params, avg_pool_3d_uneven_strided_pa
     auto backend_results = execute(cpu_f, args, "${BACKEND_NAME}");
     for (size_t i = 0; i < backend_results.size(); i++)
     {
-        EXPECT_TRUE(test::all_close(backend_results.at(i), int_results.at(i), 1.0e-4f, 1.0e-4f));
+        EXPECT_TRUE(test::all_close_f(
+            backend_results.at(i), int_results.at(i), DEFAULT_FLOAT_TOLERANCE_BITS + 1));
     }
 }
 

--- a/test/ref_generators/generate_convolution_ref.py
+++ b/test/ref_generators/generate_convolution_ref.py
@@ -358,6 +358,7 @@ def main():
 #include "ngraph/ngraph.hpp"
 #include "util/test_tools.hpp"
 #include "util/autodiff/numeric_compare.hpp"
+#include "util/all_close_f.hpp"
 #include "util/test_control.hpp"
 
 using namespace std;

--- a/test/ref_generators/generate_convolution_ref.py
+++ b/test/ref_generators/generate_convolution_ref.py
@@ -248,7 +248,7 @@ NGRAPH_TEST (${BACKEND_NAME}, %s)
 
     auto handle = backend->compile(function);
     handle->call_with_validate({result}, {a, b});
-    EXPECT_TRUE(test::all_close<float>(vector<float>{expected_result}, read_vector<float>(result), 1.0e-4f, 1.0e-6f));
+    EXPECT_TRUE(test::all_close_f(vector<float>{expected_result}, read_vector<float>(result), tolerance));
     // only test backprop for certain cases as it takes significant compute resources
     %sEXPECT_TRUE(autodiff_numeric_compare<float>(backend.get(), make_graph, {a, b}, .01f, .01f));
 }
@@ -364,6 +364,11 @@ using namespace std;
 using namespace ngraph;
 
 static string s_manifest = "${MANIFEST}";
+
+// for float this will be 18 bits matching
+// for bfloat this will be 6 bits matching
+constexpr int three_quarters_of_available_bits = (MAX_FLOAT_BITS * 3) / 4;
+constexpr int tolerance = FLOAT_MANTISSA_BITS - three_quarters_of_available_bits;
 
 ''')
 


### PR DESCRIPTION
Repeated:
https://github.com/NervanaSystems/ngraph/pull/2601
But for r0.15.1 for more immediate use.