### PR TITLE
Cleanup runtime context in CPU_CallFrame Destructor

### DIFF
--- a/src/ngraph/runtime/cpu/cpu_call_frame.cpp
+++ b/src/ngraph/runtime/cpu/cpu_call_frame.cpp
@@ -49,6 +49,7 @@ runtime::cpu::CPU_CallFrame::CPU_CallFrame(std::shared_ptr<CPU_ExternalFunction>
 
 runtime::cpu::CPU_CallFrame::~CPU_CallFrame()
 {
+    cleanup_runtime_context();
     if (!m_external_function->is_direct_execution())
     {
         NGRAPH_ASSERT(m_compiled_destroy_ctx_func) << "compiled_destroy_ctx_func cannot be null.";


### PR DESCRIPTION
I noticed that `cleanup_runtime_context();` was removed from the `CPU_CallFrame` destructor in #2421. However, this causes runtime context to never get cleaned up leading to a memory leak (#2646), so I put it back.

If it's easier for you all to do this internally, or if you would prefer an alternative fix, please feel free to close this pull request.

Mark