### PR TITLE
[Standalone] Decouple MKLDNN primitive build from code generation

### DIFF
--- a/src/ngraph/runtime/cpu/builder/quantized_concat.cpp
+++ b/src/ngraph/runtime/cpu/builder/quantized_concat.cpp
@@ -59,8 +59,8 @@ namespace ngraph
 
                     size_t concat_dim = (static_cast<const ngraph::op::QuantizedConcat*>(node))
                                             ->get_concatenation_axis();
-                    auto concat_index =
-                        mkldnn_emitter->build_concat(inputs_data_desc, result_desc, concat_dim);
+                    auto concat_index = mkldnn_emitter->build_concat(
+                        inputs_data_desc, result_desc, concat_dim, node);
                     auto& deps = mkldnn_emitter->get_primitive_deps(concat_index);
 
                     auto functor = [&, arg_tensors, nargs, concat_index](

--- a/src/ngraph/runtime/cpu/cpu_external_function.cpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.cpp
@@ -458,6 +458,10 @@ void runtime::cpu::CPU_ExternalFunction::compile(ngraph::pass::PassConfig& pass_
 
     ngraph::pass::Manager pass_manager;
     register_common_passes(pass_manager, pass_config);
+
+    // Build mkldnn primitives for codegen.
+    pass_manager.register_pass<runtime::cpu::pass::MKLDNNPrimitiveBuildPass>(*m_mkldnn_emitter);
+
     unordered_map<Node*, Node*> node_function_map;
     string common_function_string;
     auto femitter = bind(&ngraph::runtime::cpu::CPU_ExternalFunction::emit_op_as_function,
@@ -1148,6 +1152,7 @@ void runtime::cpu::CPU_ExternalFunction::register_common_passes(
                         pass_config.get_pass_attribute("ReuseMemory");
     pass_manager.register_pass<runtime::cpu::pass::CPUMemoryAssignment>(
         bufferID_to_tensorSets, tensor_to_bufferID, size_t(s_memory_pool_alignment), !reuse_memory);
+
     pass_manager.get_state().set_visualize_tree_ops_map(runtime::cpu::get_visualize_tree_ops_map());
 }
 

--- a/src/ngraph/runtime/cpu/op/convert_layout.cpp
+++ b/src/ngraph/runtime/cpu/op/convert_layout.cpp
@@ -16,6 +16,7 @@
 
 #include "ngraph/runtime/cpu/op/convert_layout.hpp"
 #include "ngraph/runtime/cpu/cpu_layout_descriptor.hpp"
+#include "ngraph/runtime/cpu/mkldnn_utils.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -24,6 +25,7 @@ runtime::cpu::op::ConvertLayout::ConvertLayout(
     const shared_ptr<Node>& arg, const shared_ptr<runtime::cpu::LayoutDescriptor>& layout)
     : ConvertLayout(arg, 0, layout)
 {
+    runtime::cpu::mkldnn_utils::assign_mkldnn_kernel(this);
 }
 
 shared_ptr<Node>
@@ -44,6 +46,7 @@ runtime::cpu::op::ConvertLayout::ConvertLayout(
     , arg_output_index(output_index)
     , output_layout(layout)
 {
+    runtime::cpu::mkldnn_utils::assign_mkldnn_kernel(this);
     constructor_validate_and_infer_types();
 }
 


### PR DESCRIPTION
This patch introduces a new pass, MKLDNNPrimitiveBuildPass, which
iterates over all the ops assigned to MKLDNN and builds their
corresponding primitives. Primitive indexes are stored in MKLDNNEmitter
and can easily be retrieved with the get_primitive_index(node)
interface. This decouples the creation of primitives from codegen and
fixes the problem of MKLDNN primitives being created twice
(CommonFunctionCollection pass and codegen).

Current assertions only allow the creation of a single primitive per
node but it should be simple to remove this when needed. Using a pass
might not be the best approach here but I found it convenient for the
current needs and it should be straightforward to convert into a utility,
if needed.

These changes caused a conflict with recently introduced
'build_quantized_inner_product*'. These new build methods will be ported
in a follow up patch to new build approach.

Local testing with and without this patch is the same:

[----------] Global test environment tear-down
[==========] 2536 tests from 56 test cases ran. (565721 ms total)
[  PASSED  ] 2522 tests.
[  FAILED  ] 14 tests, listed below:
[  FAILED  ] CPU.sum_stable_acc
[  FAILED  ] CPU.one_hot_scalar_oob_in_3
[  FAILED  ] CPU.one_hot_vector_1_barely_oob
[  FAILED  ] builder.dynamic_scaled_QC
[  FAILED  ] builder.dynamic_scaled_QC_with_relu
[  FAILED  ] builder.dynamic_scaled_QC_with_bias
[  FAILED  ] builder.dynamic_scaled_QC_with_bias_add_and_relu
[  FAILED  ] builder.dynamic_scaled_QC_with_bias_signed_add_and_relu
[  FAILED  ] builder.dynamic_scaled_Q
[  FAILED  ] builder.dynamic_scaled_DQ
[  FAILED  ] builder.scaled_quantize_concat_unsigned
[  FAILED  ] builder.scaled_quantize_concat_signed
[  FAILED  ] builder.scaled_quantize_concat_unsigned_varying
[  FAILED  ] cpu_quant_fusion.qconvbsa

14 FAILED TESTS
  YOU HAVE 21 DISABLED TESTS