### PR TITLE
[Warnings] Remove unused variable hso

### DIFF
--- a/src/ngraph/codegen/compiler.cpp
+++ b/src/ngraph/codegen/compiler.cpp
@@ -571,13 +571,8 @@ void codegen::CompilerCore::configure_search_path()
 void codegen::CompilerCore::load_headers_from_resource()
 {
     const std::string builtin_root = "";
-    HeaderSearchOptions& hso = m_compiler->getInvocation().getHeaderSearchOpts();
     PreprocessorOptions& preprocessor_options = m_compiler->getInvocation().getPreprocessorOpts();
-// for (const std::string& search_path : builtin_search_paths)
-// {
-//     std::string builtin = builtin_root + search_path;
-//     hso.AddPath(builtin, clang::frontend::System, false, false);
-// }
+
 #ifdef _WIN32
     for (const pair<std::string, vector<std::string>>& header_info : builtin_headers)
     {


### PR DESCRIPTION
And its annoying warning. Would it be better to remove all the commented code instead?