### PR TITLE
[Standalone] Set MKLDNN kernel flag in ConvertLayout op.

### DIFF
--- a/src/ngraph/graph_util.cpp
+++ b/src/ngraph/graph_util.cpp
@@ -243,6 +243,15 @@ std::list<std::shared_ptr<ngraph::Node>>
             }
             auto cloned_node = node->copy_with_new_args(cloned_args);
 
+            // Copy op annotations.
+            if (auto cloned_op = dynamic_pointer_cast<ngraph::op::Op>(cloned_node))
+            {
+                if (auto op_annotations = cloned_op->get_op_annotations())
+                {
+                    cloned_op->set_op_annotations(op_annotations->clone());
+                }
+            }
+
             //copy control dependencies
             for (auto cdep : node->get_control_dependencies())
             {

--- a/src/ngraph/op/op.hpp
+++ b/src/ngraph/op/op.hpp
@@ -40,10 +40,9 @@ namespace ngraph
 
             virtual bool is_op() const override { return true; }
         protected:
-            Op(const std::string& node_type, const NodeVector& arguments);
-
-        private:
             std::shared_ptr<ngraph::op::util::OpAnnotations> m_op_annotations;
+
+            Op(const std::string& node_type, const NodeVector& arguments);
         };
     }
 }

--- a/src/ngraph/op/op.hpp
+++ b/src/ngraph/op/op.hpp
@@ -40,9 +40,10 @@ namespace ngraph
 
             virtual bool is_op() const override { return true; }
         protected:
-            std::shared_ptr<ngraph::op::util::OpAnnotations> m_op_annotations;
-
             Op(const std::string& node_type, const NodeVector& arguments);
+
+        private:
+            std::shared_ptr<ngraph::op::util::OpAnnotations> m_op_annotations;
         };
     }
 }

--- a/src/ngraph/op/util/op_annotations.hpp
+++ b/src/ngraph/op/util/op_annotations.hpp
@@ -35,6 +35,7 @@ namespace ngraph
             class OpAnnotations
             {
             public:
+                OpAnnotations() = default;
                 virtual ~OpAnnotations() = default;
 
                 void add_in_place_oi_pair(const struct oi_pair& oi)
@@ -56,6 +57,17 @@ namespace ngraph
 
                 bool is_cacheable() const { return m_cacheable; }
                 void set_cacheable(bool val) { m_cacheable = val; }
+                /// \returns a deep copy of this OpAnnotations object.
+                virtual std::shared_ptr<OpAnnotations> clone()
+                {
+                    auto* clone = new OpAnnotations(*this);
+                    return std::shared_ptr<OpAnnotations>(clone);
+                }
+
+            protected:
+                OpAnnotations(const OpAnnotations&) = default;
+                OpAnnotations& operator=(const OpAnnotations&) = default;
+
             private:
                 // map of output-input pairs for which in-place computation is valid
                 std::vector<struct oi_pair> m_in_place_oi_pairs;

--- a/src/ngraph/runtime/cpu/cpu_op_annotations.hpp
+++ b/src/ngraph/runtime/cpu/cpu_op_annotations.hpp
@@ -34,8 +34,18 @@ namespace ngraph
                 CPUOpAnnotations() {}
                 bool is_mkldnn_op() { return m_mkldnn_op; }
                 void set_mkldnn_op(bool val) { m_mkldnn_op = val; }
+                /// \returns a deep copy of this CPUOpAnnotations object.
+                virtual std::shared_ptr<OpAnnotations> clone() override
+                {
+                    auto* clone = new CPUOpAnnotations(*this);
+                    return std::shared_ptr<CPUOpAnnotations>(clone);
+                }
+
             private:
                 bool m_mkldnn_op = false;
+
+                CPUOpAnnotations(const CPUOpAnnotations&) = default;
+                CPUOpAnnotations& operator=(const CPUOpAnnotations&) = default;
             };
 
             std::function<std::shared_ptr<ngraph::op::util::OpAnnotations>(void)>

--- a/src/ngraph/runtime/cpu/mkldnn_emitter.cpp
+++ b/src/ngraph/runtime/cpu/mkldnn_emitter.cpp
@@ -1903,7 +1903,7 @@ size_t MKLDNNEmitter::build_leaky_relu(const mkldnn::memory::desc& input_desc,
 
 mkldnn::eltwise_forward::desc MKLDNNEmitter::get_leaky_relu_desc(const ngraph::Node* node)
 {
-    auto alpha = static_cast<const op::LeakyRelu*>(node)->get_alpha();
+    auto alpha = static_cast<const ngraph::op::LeakyRelu*>(node)->get_alpha();
 
     auto input_desc = mkldnn_utils::get_input_mkldnn_md(node, 0);
 
@@ -1951,7 +1951,7 @@ size_t MKLDNNEmitter::build_bounded_relu(const mkldnn::memory::desc& input_desc,
 
 mkldnn::eltwise_forward::desc MKLDNNEmitter::get_bounded_relu_desc(const ngraph::Node* node)
 {
-    auto alpha = static_cast<const op::BoundedRelu*>(node)->get_alpha();
+    auto alpha = static_cast<const ngraph::op::BoundedRelu*>(node)->get_alpha();
 
     auto input_desc = mkldnn_utils::get_input_mkldnn_md(node, 0);
 

--- a/src/ngraph/runtime/cpu/mkldnn_utils.cpp
+++ b/src/ngraph/runtime/cpu/mkldnn_utils.cpp
@@ -758,7 +758,7 @@ bool runtime::cpu::mkldnn_utils::can_use_mkldnn_batchnorm_bprop(const ngraph::No
 }
 
 std::shared_ptr<ngraph::runtime::cpu::op::ConvertLayout>
-    runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
+    runtime::cpu::mkldnn_utils::create_convert_layout(
         const std::shared_ptr<Node>& arg,
         size_t output_index,
         const std::shared_ptr<ngraph::runtime::cpu::LayoutDescriptor>& layout)

--- a/src/ngraph/runtime/cpu/mkldnn_utils.cpp
+++ b/src/ngraph/runtime/cpu/mkldnn_utils.cpp
@@ -33,6 +33,7 @@
 #include "ngraph/runtime/cpu/cpu_op_annotations.hpp"
 #include "ngraph/runtime/cpu/op/conv_bias.hpp"
 #include "ngraph/runtime/cpu/op/conv_relu.hpp"
+#include "ngraph/runtime/cpu/op/convert_layout.hpp"
 #include "ngraph/type/element_type.hpp"
 
 #include "mkldnn_utils.hpp"
@@ -754,4 +755,15 @@ bool runtime::cpu::mkldnn_utils::can_use_mkldnn_batchnorm_bprop(const ngraph::No
     {
         return false;
     }
+}
+
+std::shared_ptr<ngraph::runtime::cpu::op::ConvertLayout>
+    runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
+        const std::shared_ptr<Node>& arg,
+        size_t output_index,
+        const std::shared_ptr<ngraph::runtime::cpu::LayoutDescriptor>& layout)
+{
+    auto convert = make_shared<ngraph::runtime::cpu::op::ConvertLayout>(arg, output_index, layout);
+    assign_mkldnn_kernel(convert.get());
+    return convert;
 }

--- a/src/ngraph/runtime/cpu/mkldnn_utils.hpp
+++ b/src/ngraph/runtime/cpu/mkldnn_utils.hpp
@@ -154,7 +154,7 @@ namespace ngraph
                 }
 
                 /// Create a shared ConvertLayout operation and assign it mkldnn.
-                std::shared_ptr<op::ConvertLayout> make_shared_mkldnn_convert_layout(
+                std::shared_ptr<op::ConvertLayout> create_convert_layout(
                     const std::shared_ptr<Node>& arg,
                     size_t output_index,
                     const std::shared_ptr<ngraph::runtime::cpu::LayoutDescriptor>& layout);

--- a/src/ngraph/runtime/cpu/mkldnn_utils.hpp
+++ b/src/ngraph/runtime/cpu/mkldnn_utils.hpp
@@ -30,6 +30,11 @@ namespace ngraph
     {
         namespace cpu
         {
+            namespace op
+            {
+                class ConvertLayout;
+            }
+
             namespace mkldnn_utils
             {
                 extern mkldnn::engine global_cpu_engine;
@@ -147,6 +152,12 @@ namespace ngraph
                     }
                     return true;
                 }
+
+                /// Create a shared ConvertLayout operation and assign it mkldnn.
+                std::shared_ptr<op::ConvertLayout> make_shared_mkldnn_convert_layout(
+                    const std::shared_ptr<Node>& arg,
+                    size_t output_index,
+                    const std::shared_ptr<ngraph::runtime::cpu::LayoutDescriptor>& layout);
             }
         }
     }

--- a/src/ngraph/runtime/cpu/op/convert_layout.cpp
+++ b/src/ngraph/runtime/cpu/op/convert_layout.cpp
@@ -15,10 +15,13 @@
 //*****************************************************************************
 
 #include "ngraph/runtime/cpu/op/convert_layout.hpp"
+
+#include "ngraph/op/util/op_annotations.hpp"
 #include "ngraph/runtime/cpu/cpu_layout_descriptor.hpp"
 
 using namespace std;
 using namespace ngraph;
+using namespace ngraph::op::util;
 
 runtime::cpu::op::ConvertLayout::ConvertLayout(
     const shared_ptr<Node>& arg, const shared_ptr<runtime::cpu::LayoutDescriptor>& layout)
@@ -33,7 +36,14 @@ shared_ptr<Node>
     {
         throw ngraph_error("Incorrect number of new arguments");
     }
-    return make_shared<ConvertLayout>(new_args.at(0), output_layout);
+
+    auto copy = make_shared<ConvertLayout>(new_args.at(0), output_layout);
+
+    if (m_op_annotations)
+      // Copy annotations
+      copy->set_op_annotations(m_op_annotations->clone());
+
+    return copy;
 }
 
 runtime::cpu::op::ConvertLayout::ConvertLayout(

--- a/src/ngraph/runtime/cpu/op/convert_layout.cpp
+++ b/src/ngraph/runtime/cpu/op/convert_layout.cpp
@@ -37,13 +37,7 @@ shared_ptr<Node>
         throw ngraph_error("Incorrect number of new arguments");
     }
 
-    auto copy = make_shared<ConvertLayout>(new_args.at(0), output_layout);
-
-    if (m_op_annotations)
-      // Copy annotations
-      copy->set_op_annotations(m_op_annotations->clone());
-
-    return copy;
+    return make_shared<ConvertLayout>(new_args.at(0), output_layout);
 }
 
 runtime::cpu::op::ConvertLayout::ConvertLayout(

--- a/src/ngraph/runtime/cpu/pass/cpu_layout.cpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_layout.cpp
@@ -122,8 +122,9 @@ static shared_ptr<Node>
         {
             auto layout = std::make_shared<ngraph::runtime::cpu::LayoutDescriptor>(*tv);
             layout->set_mkldnn_md(required_mds[index]);
-            auto new_node = std::shared_ptr<Node>(
-                new runtime::cpu::op::ConvertLayout(output.get_node(), output.get_index(), layout));
+            auto new_node = runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
+                output.get_node(), output.get_index(), layout);
+
             new_args.push_back(new_node);
             replace_node = true;
             NGRAPH_DEBUG << "Inserted conversion node " << new_node->get_name() << " between "
@@ -203,8 +204,8 @@ static void set_native_layouts(runtime::cpu::CPU_ExternalFunction* external_func
             {
                 auto layout = std::make_shared<ngraph::runtime::cpu::LayoutDescriptor>(*tv);
                 layout->set_mkldnn_md(native_md);
-                auto new_node = std::shared_ptr<Node>(new runtime::cpu::op::ConvertLayout(
-                    output.get_node(), output.get_index(), layout));
+                auto new_node = runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
+                    output.get_node(), output.get_index(), layout);
                 new_args.push_back(new_node);
                 if (use_replace)
                 {

--- a/src/ngraph/runtime/cpu/pass/cpu_layout.cpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_layout.cpp
@@ -122,7 +122,7 @@ static shared_ptr<Node>
         {
             auto layout = std::make_shared<ngraph::runtime::cpu::LayoutDescriptor>(*tv);
             layout->set_mkldnn_md(required_mds[index]);
-            auto new_node = runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
+            auto new_node = runtime::cpu::mkldnn_utils::create_convert_layout(
                 output.get_node(), output.get_index(), layout);
 
             new_args.push_back(new_node);
@@ -204,7 +204,7 @@ static void set_native_layouts(runtime::cpu::CPU_ExternalFunction* external_func
             {
                 auto layout = std::make_shared<ngraph::runtime::cpu::LayoutDescriptor>(*tv);
                 layout->set_mkldnn_md(native_md);
-                auto new_node = runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
+                auto new_node = runtime::cpu::mkldnn_utils::create_convert_layout(
                     output.get_node(), output.get_index(), layout);
                 new_args.push_back(new_node);
                 if (use_replace)

--- a/src/ngraph/runtime/cpu/pass/cpu_post_layout_optimizations.cpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_post_layout_optimizations.cpp
@@ -49,8 +49,8 @@ void ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations::construct_weight_fu
     auto data_conv = std::make_shared<pattern::op::Label>(element::f32, Shape{16, 4, 7, 7});
     auto tvt = reshape_conv->get_outputs().at(0).get_tensor_ptr().get();
     auto lt_desc = std::make_shared<runtime::cpu::LayoutDescriptor>(*tvt);
-    auto cvt_lt_conv = ngraph::runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
-        reshape_conv, 0, lt_desc);
+    auto cvt_lt_conv =
+        ngraph::runtime::cpu::mkldnn_utils::create_convert_layout(reshape_conv, 0, lt_desc);
     auto conv = std::make_shared<ngraph::op::Convolution>(
         data_conv, cvt_lt_conv, Strides{1, 1}, Strides{1, 1});
 
@@ -129,8 +129,7 @@ void ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations::construct_slice_con
         param, Coordinate{0, 0, 0, 0}, Coordinate{1, 192, 17, 17});
     auto tvt = slice->get_outputs().at(0).get_tensor_ptr().get();
     auto lt_desc = std::make_shared<runtime::cpu::LayoutDescriptor>(*tvt);
-    auto cvt_lt =
-        ngraph::runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(slice, 0, lt_desc);
+    auto cvt_lt = ngraph::runtime::cpu::mkldnn_utils::create_convert_layout(slice, 0, lt_desc);
 
     pattern::graph_rewrite_callback callback = [param](pattern::Matcher& m) {
         NGRAPH_DEBUG << "In a callback for construct_slice_converLayout against "
@@ -193,8 +192,7 @@ void ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations::
         std::make_shared<ngraph::op::Reshape>(input, AxisVector{0, 1, 2, 3}, Shape{1, 1, 1, 1});
     auto lt_desc =
         std::make_shared<runtime::cpu::LayoutDescriptor>(*reshape->get_output_tensor_ptr());
-    auto cvt_lt =
-        ngraph::runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(reshape, 0, lt_desc);
+    auto cvt_lt = ngraph::runtime::cpu::mkldnn_utils::create_convert_layout(reshape, 0, lt_desc);
 
     pattern::graph_rewrite_callback callback = [](pattern::Matcher& m) {
         NGRAPH_DEBUG << "In a callback for construct_reshape_converLayout against "
@@ -247,7 +245,7 @@ void ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations::
             *reshape_m->get_argument(0)->get_output_tensor_ptr());
         rotated_lt_desc->set_mkldnn_md(rotated_md);
 
-        auto cvt_lt_n = ngraph::runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
+        auto cvt_lt_n = ngraph::runtime::cpu::mkldnn_utils::create_convert_layout(
             reshape_m->get_argument(0), 0, rotated_lt_desc);
         //cvt_lt_n->set_op_annotations(cvt_lt_m->get_op_annotations());
 

--- a/src/ngraph/runtime/cpu/pass/cpu_post_layout_optimizations.cpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_post_layout_optimizations.cpp
@@ -49,7 +49,8 @@ void ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations::construct_weight_fu
     auto data_conv = std::make_shared<pattern::op::Label>(element::f32, Shape{16, 4, 7, 7});
     auto tvt = reshape_conv->get_outputs().at(0).get_tensor_ptr().get();
     auto lt_desc = std::make_shared<runtime::cpu::LayoutDescriptor>(*tvt);
-    auto cvt_lt_conv = std::make_shared<runtime::cpu::op::ConvertLayout>(reshape_conv, lt_desc);
+    auto cvt_lt_conv = ngraph::runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
+        reshape_conv, 0, lt_desc);
     auto conv = std::make_shared<ngraph::op::Convolution>(
         data_conv, cvt_lt_conv, Strides{1, 1}, Strides{1, 1});
 
@@ -128,7 +129,8 @@ void ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations::construct_slice_con
         param, Coordinate{0, 0, 0, 0}, Coordinate{1, 192, 17, 17});
     auto tvt = slice->get_outputs().at(0).get_tensor_ptr().get();
     auto lt_desc = std::make_shared<runtime::cpu::LayoutDescriptor>(*tvt);
-    auto cvt_lt = std::make_shared<runtime::cpu::op::ConvertLayout>(slice, lt_desc);
+    auto cvt_lt =
+        ngraph::runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(slice, 0, lt_desc);
 
     pattern::graph_rewrite_callback callback = [param](pattern::Matcher& m) {
         NGRAPH_DEBUG << "In a callback for construct_slice_converLayout against "
@@ -191,7 +193,8 @@ void ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations::
         std::make_shared<ngraph::op::Reshape>(input, AxisVector{0, 1, 2, 3}, Shape{1, 1, 1, 1});
     auto lt_desc =
         std::make_shared<runtime::cpu::LayoutDescriptor>(*reshape->get_output_tensor_ptr());
-    auto cvt_lt = std::make_shared<runtime::cpu::op::ConvertLayout>(reshape, lt_desc);
+    auto cvt_lt =
+        ngraph::runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(reshape, 0, lt_desc);
 
     pattern::graph_rewrite_callback callback = [](pattern::Matcher& m) {
         NGRAPH_DEBUG << "In a callback for construct_reshape_converLayout against "
@@ -244,7 +247,7 @@ void ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations::
             *reshape_m->get_argument(0)->get_output_tensor_ptr());
         rotated_lt_desc->set_mkldnn_md(rotated_md);
 
-        auto cvt_lt_n = std::make_shared<runtime::cpu::op::ConvertLayout>(
+        auto cvt_lt_n = ngraph::runtime::cpu::mkldnn_utils::make_shared_mkldnn_convert_layout(
             reshape_m->get_argument(0), 0, rotated_lt_desc);
         //cvt_lt_n->set_op_annotations(cvt_lt_m->get_op_annotations());
 

--- a/src/ngraph/runtime/cpu/pass/cpu_post_layout_optimizations.cpp
+++ b/src/ngraph/runtime/cpu/pass/cpu_post_layout_optimizations.cpp
@@ -246,7 +246,7 @@ void ngraph::runtime::cpu::pass::CPUPostLayoutOptimizations::
 
         auto cvt_lt_n = std::make_shared<runtime::cpu::op::ConvertLayout>(
             reshape_m->get_argument(0), 0, rotated_lt_desc);
-        cvt_lt_n->set_op_annotations(cvt_lt_m->get_op_annotations());
+        //cvt_lt_n->set_op_annotations(cvt_lt_m->get_op_annotations());
 
         auto reshape_n =
             std::make_shared<ngraph::op::Reshape>(cvt_lt_n, reshape_order, cvt_lt_m->get_shape());


### PR DESCRIPTION
ConvertLayout is an MKLDNN specific op and the MKLDNN kernel flag
was not set. This led to assume that this operation was not
supported by MKLDNN.