### PR TITLE
Add GetOutputElement to outputs of FunctionCall

### DIFF
--- a/src/ngraph/runtime/hybrid/hybrid_util.cpp
+++ b/src/ngraph/runtime/hybrid/hybrid_util.cpp
@@ -225,10 +225,9 @@ void runtime::hybrid::rewrite_function(const shared_ptr<Function>& f,
                     goe->set_placement_index(0);
 
                     auto old_source = cluster_outputs[i];
-                    auto new_source = goe;
                     auto target = function_call_outputs[i];
                     descriptor::Input* target_input = target->get_input_from(old_source);
-                    descriptor::Output& new_output = new_source->get_outputs()[0];
+                    descriptor::Output& new_output = goe->get_outputs()[0];
                     target_input->replace_output(new_output);
                 }
             }

--- a/src/ngraph/runtime/hybrid/hybrid_util.cpp
+++ b/src/ngraph/runtime/hybrid/hybrid_util.cpp
@@ -17,6 +17,7 @@
 #include "ngraph/runtime/hybrid/hybrid_util.hpp"
 #include "ngraph/graph_util.hpp"
 #include "ngraph/log.hpp"
+#include "ngraph/op/get_output_element.hpp"
 #include "ngraph/pass/manager.hpp"
 #include "ngraph/pass/visualize_tree.hpp"
 #include "ngraph/runtime/hybrid/op/function_call.hpp"
@@ -219,14 +220,15 @@ void runtime::hybrid::rewrite_function(const shared_ptr<Function>& f,
                 fc->set_placement_index(0);
                 for (size_t i = 0; i < function_call_outputs.size(); i++)
                 {
-                    // // First add a GetOutputElement to the ith output of the FunctionCall
-                    // auto goe = make_shared<GetOutpu
+                    // First add a GetOutputElement to the ith output of the FunctionCall
+                    auto goe = make_shared<ngraph::op::GetOutputElement>(fc, i);
+                    goe->set_placement_index(0);
 
                     auto old_source = cluster_outputs[i];
-                    auto new_source = fc;
+                    auto new_source = goe;
                     auto target = function_call_outputs[i];
                     descriptor::Input* target_input = target->get_input_from(old_source);
-                    descriptor::Output& new_output = new_source->get_outputs()[i];
+                    descriptor::Output& new_output = new_source->get_outputs()[0];
                     target_input->replace_output(new_output);
                 }
             }


### PR DESCRIPTION
So much code is written that assumes that nodes have exactly one output that I thought it would just be easier to provide that condition.