### PR TITLE
bfloat16 testing and fixes

### DIFF
--- a/src/ngraph/type/bfloat16.cpp
+++ b/src/ngraph/type/bfloat16.cpp
@@ -40,6 +40,8 @@
 using namespace std;
 using namespace ngraph;
 
+static_assert(sizeof(bfloat16) == 2, "class bfloat16 must be exactly 2 bytes");
+
 bool float_isnan(const float& x)
 {
     return std::isnan(x);
@@ -111,7 +113,7 @@ bfloat16::operator double() const
     return static_cast<float>(m_value);
 }
 
-uint16_t bfloat16::get_bits() const
+uint16_t bfloat16::to_bits() const
 {
     return m_value;
 }

--- a/src/ngraph/type/bfloat16.cpp
+++ b/src/ngraph/type/bfloat16.cpp
@@ -72,9 +72,8 @@ bfloat16::bfloat16(float value, RoundingMode mode)
     else if (mode == RoundingMode::TRUNCATE)
     {
         // Truncate off 16 LSB, no rounding
-        // Treat system as little endian (Intel x86 family)
-        uint16_t* u16_ptr = reinterpret_cast<uint16_t*>(&value);
-        m_value = u16_ptr[1];
+        uint32_t* p = reinterpret_cast<uint32_t*>(&value);
+        m_value = static_cast<uint16_t>((*p) >> 16);
     }
     else
     {

--- a/src/ngraph/type/bfloat16.cpp
+++ b/src/ngraph/type/bfloat16.cpp
@@ -34,7 +34,6 @@
 #include <cmath>
 #include <iostream>
 
-#include "ngraph/log.hpp"
 #include "ngraph/type/bfloat16.hpp"
 
 using namespace std;

--- a/src/ngraph/type/bfloat16.cpp
+++ b/src/ngraph/type/bfloat16.cpp
@@ -60,26 +60,6 @@ std::vector<bfloat16> bfloat16::from_float_vector(const std::vector<float>& v_f3
     return v_bf16;
 }
 
-bfloat16::bfloat16(float value, RoundingMode mode)
-{
-    // Rounding with round-nearest-to-even to create bfloat16
-    // from float. Refer to TF implementation explanation:
-    // https://github.com/tensorflow/tensorflow/blob/d354efc/tensorflow/core/lib/bfloat16/bfloat16.h#L199
-    m_value =
-        (std::isnan(value)
-             ? BF16_NAN_VALUE
-             : (mode == RoundingMode::TRUNCATE
-                    ?
-                    // Truncate off 16 LSB, no rounding
-                    static_cast<uint16_t>((F32(value).i) >> 16)
-                    :
-                    // Rounding with round-nearest-to-even to create bfloat16
-                    // from float. Refer to TF implementation explanation:
-                    // https://github.com/tensorflow/tensorflow/blob/d354efc/tensorflow/core/lib/bfloat16/bfloat16.h#L199
-                    static_cast<uint16_t>((F32(value).i + (0x7fff + ((F32(value).i >> 15) & 1))) >>
-                                          16)));
-}
-
 ngraph::bfloat16 bfloat16::from_bits(uint16_t bits)
 {
     bfloat16 rc;

--- a/src/ngraph/type/bfloat16.cpp
+++ b/src/ngraph/type/bfloat16.cpp
@@ -111,7 +111,7 @@ bfloat16::operator double() const
     return static_cast<float>(m_value);
 }
 
-bfloat16::operator uint16_t() const
+uint16_t bfloat16::get_bits() const
 {
     return m_value;
 }

--- a/src/ngraph/type/bfloat16.cpp
+++ b/src/ngraph/type/bfloat16.cpp
@@ -33,6 +33,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <limits>
 
 #include "ngraph/type/bfloat16.hpp"
 
@@ -58,13 +59,6 @@ std::vector<bfloat16> bfloat16::from_float_vector(const std::vector<float>& v_f3
         v_bf16.push_back(static_cast<bfloat16>(a));
     }
     return v_bf16;
-}
-
-ngraph::bfloat16 bfloat16::from_bits(uint16_t bits)
-{
-    bfloat16 rc;
-    rc.m_value = bits;
-    return rc;
 }
 
 std::string bfloat16::to_string() const

--- a/src/ngraph/type/bfloat16.cpp
+++ b/src/ngraph/type/bfloat16.cpp
@@ -42,6 +42,8 @@ using namespace ngraph;
 
 static_assert(sizeof(bfloat16) == 2, "class bfloat16 must be exactly 2 bytes");
 
+uint16_t bfloat16::BF16_NAN_VALUE = 0x7FC0;
+
 bool float_isnan(const float& x)
 {
     return std::isnan(x);

--- a/src/ngraph/type/bfloat16.hpp
+++ b/src/ngraph/type/bfloat16.hpp
@@ -73,17 +73,18 @@ namespace ngraph
 
         static constexpr uint16_t round_to_nearest_even(float x)
         {
-            return static_cast<uint16_t>((F32(x).i + ((F32(x).i & 0x00010000) >> 1)) >> 16);
+            return static_cast<uint16_t>(
+                (static_cast<uint32_t>(x) + ((static_cast<uint32_t>(x) & 0x00010000) >> 1)) >> 16);
         }
 
         static constexpr uint16_t round_to_nearest(float x)
         {
-            return static_cast<uint16_t>((F32(x).i + 0x8000) >> 16);
+            return static_cast<uint16_t>((static_cast<uint32_t>(x) + 0x8000) >> 16);
         }
 
         static constexpr uint16_t truncate(float x)
         {
-            return static_cast<uint16_t>((F32(x).i) >> 16);
+            return static_cast<uint16_t>((static_cast<uint32_t>(x)) >> 16);
         }
 
     private:
@@ -93,25 +94,17 @@ namespace ngraph
             : m_value{value}
         {
         }
-        union F32 {
-            constexpr F32(float val)
-                : f{val}
-            {
-            }
-            constexpr F32(uint32_t val)
-                : i{val}
-            {
-            }
-            float f;
-            uint32_t i;
-        };
 
         static constexpr bool isnan_c(float x)
         {
-            return (((F32(x).i & 0x7F800000) == 0x7F800000) && ((F32(x).i & 0x007FFFFF) != 0));
+            return (((static_cast<uint32_t>(x) & 0x7F800000) == 0x7F800000) &&
+                    ((static_cast<uint32_t>(x) & 0x007FFFFF) != 0));
         }
 
-        static constexpr bool isinf_c(float x) { return ((F32(x).i & 0x7FFFFFFF) == 0x7F800000); }
+        static constexpr bool isinf_c(float x)
+        {
+            return ((static_cast<uint32_t>(x) & 0x7FFFFFFF) == 0x7F800000);
+        }
         uint16_t m_value;
 
         static constexpr uint16_t BF16_NAN_VALUE = 0x7FC0;

--- a/src/ngraph/type/bfloat16.hpp
+++ b/src/ngraph/type/bfloat16.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -37,6 +38,7 @@ namespace ngraph
         };
         bfloat16() {}
         bfloat16(float value, RoundingMode mode = RoundingMode::ROUND);
+
         bfloat16(const bfloat16&) = default;
         bfloat16& operator=(const bfloat16&) = default;
         virtual ~bfloat16() {}
@@ -63,6 +65,25 @@ namespace ngraph
         }
 
     private:
+        union F32 {
+            constexpr F32()
+                : i{0}
+            {
+            }
+            constexpr F32(float val)
+                : f{val}
+            {
+            }
+            constexpr F32(uint32_t val)
+                : i{val}
+            {
+            }
+            float f;
+            uint32_t i;
+        };
+
         uint16_t m_value{0};
+
+        static constexpr uint16_t BF16_NAN_VALUE = 0x7FC0;
     };
 }

--- a/src/ngraph/type/bfloat16.hpp
+++ b/src/ngraph/type/bfloat16.hpp
@@ -87,7 +87,7 @@ namespace ngraph
         bool operator>=(const bfloat16& other) const;
         operator float() const;
         operator double() const;
-        operator uint16_t() const;
+        uint16_t get_bits() const;
 
         static std::vector<float> to_float_vector(const std::vector<bfloat16>&);
         static std::vector<bfloat16> from_float_vector(const std::vector<float>&);

--- a/src/ngraph/type/bfloat16.hpp
+++ b/src/ngraph/type/bfloat16.hpp
@@ -43,12 +43,12 @@ namespace ngraph
         {
         }
         constexpr bfloat16(float value, RoundingMode mode = RoundingMode::ROUND)
-            : m_value{(std::isnan(value) ? BF16_NAN_VALUE
-                                         : (mode == RoundingMode::ROUND
-                                                ? round_to_nearest(value)
-                                                : (mode == RoundingMode::ROUND_TO_NEAREST_EVEN
-                                                       ? round_to_nearest_even(value)
-                                                       : truncate(value))))}
+            : m_value{(isnan_c(value) ? BF16_NAN_VALUE
+                                      : (mode == RoundingMode::ROUND
+                                             ? round_to_nearest(value)
+                                             : (mode == RoundingMode::ROUND_TO_NEAREST_EVEN
+                                                    ? round_to_nearest_even(value)
+                                                    : truncate(value))))}
         {
             // The initialization of m_value above is ugly so I have included the original source
             // that was used to create that monstrosity.
@@ -135,6 +135,11 @@ namespace ngraph
         {
             return static_cast<uint16_t>((F32(x).i) >> 16);
         }
+        static constexpr bool isnan_c(float x)
+        {
+            return (((F32(x).i & 0x7F800000) == 0x7F800000) && ((F32(x).i & 0x007FFFFF) != 0));
+        }
+        static constexpr bool isinf_c(float x) { return ((F32(x).i & 0x7FFFFFFF) == 0x7F800000); }
         uint16_t m_value;
 
         static constexpr uint16_t BF16_NAN_VALUE = 0x7FC0;

--- a/src/ngraph/type/bfloat16.hpp
+++ b/src/ngraph/type/bfloat16.hpp
@@ -36,12 +36,52 @@ namespace ngraph
             TRUNCATE,
             ROUND
         };
-        bfloat16() {}
-        bfloat16(float value, RoundingMode mode = RoundingMode::ROUND);
+        constexpr bfloat16()
+            : m_value{0}
+        {
+        }
+        constexpr bfloat16(float value, RoundingMode mode = RoundingMode::ROUND)
+            : m_value{(
+                  std::isnan(value)
+                      ? BF16_NAN_VALUE
+                      : (mode == RoundingMode::TRUNCATE
+                             ?
+                             // Truncate off 16 LSB, no rounding
+                             static_cast<uint16_t>((F32(value).i) >> 16)
+                             :
+                             // Rounding with round-nearest-to-even to create bfloat16
+                             // from float. Refer to TF implementation explanation:
+                             // https://github.com/tensorflow/tensorflow/blob/d354efc/tensorflow/core/lib/bfloat16/bfloat16.h#L199
+                             static_cast<uint16_t>(
+                                 (F32(value).i + (0x7fff + ((F32(value).i >> 15) & 1))) >> 16)))}
+        {
+            // The initialization of m_value above is ugly so I have included the original source
+            // that was used to create that monstrosity.
+            // This was done to add a c++11 constexpr ctor
+            // if (std::isnan(value))
+            // {
+            //     m_value = BF16_NAN_VALUE;
+            // }
+            // else if (mode == RoundingMode::TRUNCATE)
+            // {
+            //     // Truncate off 16 LSB, no rounding
+            //     uint32_t* p = reinterpret_cast<uint32_t*>(&value);
+            //     m_value = static_cast<uint16_t>((*p) >> 16);
+            // }
+            // else
+            // {
+            //     // Rounding with round-nearest-to-even to create bfloat16
+            //     // from float. Refer to TF implementation explanation:
+            //     // https://github.com/tensorflow/tensorflow/blob/d354efc/tensorflow/core/lib/bfloat16/bfloat16.h#L199
+            //     uint32_t* u32_ptr = reinterpret_cast<uint32_t*>(&value);
+            //     uint32_t u32_value = *u32_ptr;
+            //     uint32_t lsb = (u32_value >> 15) & 1;
+            //     uint32_t rounding_bias = 0x7fff + lsb;
+            //     u32_value += rounding_bias;
+            //     m_value = static_cast<uint16_t>(u32_value >> 16);
+            // }
+        }
 
-        bfloat16(const bfloat16&) = default;
-        bfloat16& operator=(const bfloat16&) = default;
-        virtual ~bfloat16() {}
         std::string to_string() const;
         size_t size() const;
         bool operator==(const bfloat16& other) const;
@@ -66,10 +106,6 @@ namespace ngraph
 
     private:
         union F32 {
-            constexpr F32()
-                : i{0}
-            {
-            }
             constexpr F32(float val)
                 : f{val}
             {
@@ -82,7 +118,7 @@ namespace ngraph
             uint32_t i;
         };
 
-        uint16_t m_value{0};
+        uint16_t m_value;
 
         static constexpr uint16_t BF16_NAN_VALUE = 0x7FC0;
     };

--- a/src/ngraph/type/bfloat16.hpp
+++ b/src/ngraph/type/bfloat16.hpp
@@ -30,8 +30,13 @@ namespace ngraph
     class bfloat16
     {
     public:
+        enum class RoundingMode
+        {
+            TRUNCATE,
+            ROUND
+        };
         bfloat16() {}
-        bfloat16(float value, bool rounding = false);
+        bfloat16(float value, RoundingMode mode = RoundingMode::ROUND);
         bfloat16(const bfloat16&) = default;
         bfloat16& operator=(const bfloat16&) = default;
         virtual ~bfloat16() {}
@@ -45,11 +50,17 @@ namespace ngraph
         bool operator>=(const bfloat16& other) const;
         operator float() const;
         operator double() const;
+        operator uint16_t() const;
 
         static std::vector<float> to_float_vector(const std::vector<bfloat16>&);
         static std::vector<bfloat16> from_float_vector(const std::vector<float>&);
+        static bfloat16 from_bits(uint16_t bits);
 
-        friend std::ostream& operator<<(std::ostream&, const bfloat16&);
+        friend std::ostream& operator<<(std::ostream& out, const bfloat16& obj)
+        {
+            out << static_cast<float>(obj);
+            return out;
+        }
 
     private:
         uint16_t m_value{0};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SRC
     algebraic_simplification.cpp
     all_close_f.cpp
     assertion.cpp
+    bfloat16.cpp
     build_graph.cpp
     builder_autobroadcast.cpp
     constant_folding.cpp

--- a/test/all_close_f.cpp
+++ b/test/all_close_f.cpp
@@ -24,104 +24,10 @@
 
 #include "ngraph/ngraph.hpp"
 #include "util/all_close_f.hpp"
+#include "util/float_util.hpp"
 
 using namespace std;
 using namespace ngraph;
-
-union FloatUnion {
-    FloatUnion() { i = 0; }
-    FloatUnion(float val) { f = val; }
-    FloatUnion(uint32_t val) { i = val; }
-    float f;
-    uint32_t i;
-};
-
-union DoubleUnion {
-    DoubleUnion() { i = 0; }
-    DoubleUnion(double val) { d = val; }
-    DoubleUnion(uint64_t val) { i = val; }
-    double d;
-    uint64_t i;
-};
-
-string float_to_bits(float f)
-{
-    FloatUnion fu{f};
-    stringstream ss;
-    ss << bitset<32>(fu.i);
-    string unformatted = ss.str();
-    string formatted;
-    formatted.reserve(41);
-    // Sign
-    formatted.push_back(unformatted[0]);
-    formatted.append("  ");
-    // Exponent
-    formatted.append(unformatted, 1, 8);
-    formatted.append("  ");
-    // Mantissa
-    formatted.append(unformatted, 9, 3);
-    for (int i = 12; i < 32; i += 4)
-    {
-        formatted.push_back(' ');
-        formatted.append(unformatted, i, 4);
-    }
-    return formatted;
-}
-
-string double_to_bits(double d)
-{
-    DoubleUnion du{d};
-    stringstream ss;
-    ss << bitset<64>(du.i);
-    string unformatted = ss.str();
-    string formatted;
-    formatted.reserve(80);
-    // Sign
-    formatted.push_back(unformatted[0]);
-    formatted.append("  ");
-    // Exponent
-    formatted.append(unformatted, 1, 11);
-    formatted.push_back(' ');
-    // Mantissa
-    for (int i = 12; i < 64; i += 4)
-    {
-        formatted.push_back(' ');
-        formatted.append(unformatted, i, 4);
-    }
-    return formatted;
-}
-
-float bits_to_float(const string& s)
-{
-    string unformatted = s;
-    unformatted.erase(remove_if(unformatted.begin(), unformatted.end(), ::isspace),
-                      unformatted.end());
-
-    if (unformatted.size() != 32)
-    {
-        throw ngraph_error("Input length must be 32");
-    }
-    bitset<32> bs(unformatted);
-    FloatUnion fu;
-    fu.i = static_cast<uint32_t>(bs.to_ulong());
-    return fu.f;
-}
-
-double bits_to_double(const string& s)
-{
-    string unformatted = s;
-    unformatted.erase(remove_if(unformatted.begin(), unformatted.end(), ::isspace),
-                      unformatted.end());
-
-    if (unformatted.size() != 64)
-    {
-        throw ngraph_error("Input length must be 64");
-    }
-    bitset<64> bs(unformatted);
-    DoubleUnion du;
-    du.i = static_cast<uint64_t>(bs.to_ullong());
-    return du.d;
-}
 
 class all_close_f_param_test : public testing::TestWithParam<::std::tuple<float, int>>
 {
@@ -137,7 +43,7 @@ protected:
     void SetUp() override
     {
         constexpr int mantissa_bits = 24;
-        uint32_t expected_as_int = FloatUnion(expected).i;
+        uint32_t expected_as_int = test::FloatUnion(expected).i;
 
         // Turn on targeted bit
         // e.g. for float with 24 bit mantissa, 2 bit accuracy, and hard-coded 8 bit exponent_bits
@@ -149,40 +55,40 @@ protected:
         if (expected > 0.f)
         {
             uint32_t upper_bound_as_int = expected_as_int + targeted_bit;
-            upper_bound = FloatUnion(upper_bound_as_int).f;
-            past_upper_bound = FloatUnion(upper_bound_as_int + 1).f;
+            upper_bound = test::FloatUnion(upper_bound_as_int).f;
+            past_upper_bound = test::FloatUnion(upper_bound_as_int + 1).f;
             min_signal_too_low = expected;
-            min_signal_enables_passing = FloatUnion(upper_bound_as_int + 2).f;
+            min_signal_enables_passing = test::FloatUnion(upper_bound_as_int + 2).f;
 
             uint32_t lower_bound_as_int = expected_as_int - targeted_bit;
-            lower_bound = FloatUnion(lower_bound_as_int).f;
-            past_lower_bound = FloatUnion(lower_bound_as_int - 1).f;
+            lower_bound = test::FloatUnion(lower_bound_as_int).f;
+            past_lower_bound = test::FloatUnion(lower_bound_as_int - 1).f;
         }
         else if (expected < 0.f)
         {
             // Same logic/math as above, but reversed variable name order
             uint32_t lower_bound_as_int = expected_as_int + targeted_bit;
-            lower_bound = FloatUnion(lower_bound_as_int).f;
-            past_lower_bound = FloatUnion(lower_bound_as_int + 1).f;
+            lower_bound = test::FloatUnion(lower_bound_as_int).f;
+            past_lower_bound = test::FloatUnion(lower_bound_as_int + 1).f;
             min_signal_too_low = expected;
-            min_signal_enables_passing = FloatUnion(lower_bound_as_int + 2).f;
+            min_signal_enables_passing = test::FloatUnion(lower_bound_as_int + 2).f;
 
             uint32_t upper_bound_as_int = expected_as_int - targeted_bit;
-            upper_bound = FloatUnion(upper_bound_as_int).f;
-            past_upper_bound = FloatUnion(upper_bound_as_int - 1).f;
+            upper_bound = test::FloatUnion(upper_bound_as_int).f;
+            past_upper_bound = test::FloatUnion(upper_bound_as_int - 1).f;
         }
         else // (expected == 0.f) || (expected == -0.f)
         {
             // Special handling of 0 / -0 which get same bounds
             uint32_t upper_bound_as_int = targeted_bit;
-            upper_bound = FloatUnion(upper_bound_as_int).f;
+            upper_bound = test::FloatUnion(upper_bound_as_int).f;
             uint32_t past_upper_bound_as_int = upper_bound_as_int + 1;
-            past_upper_bound = FloatUnion(past_upper_bound_as_int).f;
+            past_upper_bound = test::FloatUnion(past_upper_bound_as_int).f;
             min_signal_too_low = expected;
-            min_signal_enables_passing = FloatUnion(upper_bound_as_int + 2).f;
+            min_signal_enables_passing = test::FloatUnion(upper_bound_as_int + 2).f;
 
-            lower_bound = FloatUnion(upper_bound_as_int | 0x80000000).f;
-            past_lower_bound = FloatUnion(past_upper_bound_as_int | 0x80000000).f;
+            lower_bound = test::FloatUnion(upper_bound_as_int | 0x80000000).f;
+            past_lower_bound = test::FloatUnion(past_upper_bound_as_int | 0x80000000).f;
         }
     }
 
@@ -206,13 +112,13 @@ TEST_P(all_close_f_param_test, test_boundaries)
 
     // Format verbose info to only print out in case of test failure
     stringstream ss;
-    ss << "Testing target of: " << expected << " (" << float_to_bits(expected) << ")\n";
+    ss << "Testing target of: " << expected << " (" << test::float_to_bits(expected) << ")\n";
     ss << "Matching to targets with: " << tolerance_bits << " tolerance_bits\n";
-    ss << "upper_bound: " << upper_bound << " (" << float_to_bits(upper_bound) << ")\n";
-    ss << "lower_bound: " << lower_bound << " (" << float_to_bits(lower_bound) << ")\n";
-    ss << "past_upper_bound: " << past_upper_bound << " (" << float_to_bits(past_upper_bound)
+    ss << "upper_bound: " << upper_bound << " (" << test::float_to_bits(upper_bound) << ")\n";
+    ss << "lower_bound: " << lower_bound << " (" << test::float_to_bits(lower_bound) << ")\n";
+    ss << "past_upper_bound: " << past_upper_bound << " (" << test::float_to_bits(past_upper_bound)
        << ")\n";
-    ss << "past_lower_bound: " << past_lower_bound << " (" << float_to_bits(past_lower_bound)
+    ss << "past_lower_bound: " << past_lower_bound << " (" << test::float_to_bits(past_lower_bound)
        << ")\n";
 
     EXPECT_TRUE(test::close_f(expected, upper_bound, tolerance_bits)) << ss.str();
@@ -295,7 +201,7 @@ protected:
     void SetUp() override
     {
         constexpr int mantissa_bits = 53;
-        uint64_t expected_as_int = DoubleUnion(expected).i;
+        uint64_t expected_as_int = test::DoubleUnion(expected).i;
         // Turn on targeted bit
         // e.g. for double with 52 bit mantissa, 2 bit accuracy, and hard-coded 11 bit exponent_bits
         // tolerance_bit_shift = 64 -           (1 +  11 + (52 -     1         ) - 2             )
@@ -306,40 +212,40 @@ protected:
         if (expected > 0.)
         {
             uint64_t upper_bound_as_int = expected_as_int + targeted_bit;
-            upper_bound = DoubleUnion(upper_bound_as_int).d;
-            past_upper_bound = DoubleUnion(upper_bound_as_int + 1).d;
+            upper_bound = test::DoubleUnion(upper_bound_as_int).d;
+            past_upper_bound = test::DoubleUnion(upper_bound_as_int + 1).d;
             min_signal_too_low = expected;
-            min_signal_enables_passing = DoubleUnion(upper_bound_as_int + 2).d;
+            min_signal_enables_passing = test::DoubleUnion(upper_bound_as_int + 2).d;
 
             uint64_t lower_bound_as_int = expected_as_int - targeted_bit;
-            lower_bound = DoubleUnion(lower_bound_as_int).d;
-            past_lower_bound = DoubleUnion(lower_bound_as_int - 1).d;
+            lower_bound = test::DoubleUnion(lower_bound_as_int).d;
+            past_lower_bound = test::DoubleUnion(lower_bound_as_int - 1).d;
         }
         else if (expected < 0.)
         {
             // Same logic/math as above, but reversed variable name order
             uint64_t lower_bound_as_int = expected_as_int + targeted_bit;
-            lower_bound = DoubleUnion(lower_bound_as_int).d;
-            past_lower_bound = DoubleUnion(lower_bound_as_int + 1).d;
+            lower_bound = test::DoubleUnion(lower_bound_as_int).d;
+            past_lower_bound = test::DoubleUnion(lower_bound_as_int + 1).d;
             min_signal_too_low = expected;
-            min_signal_enables_passing = DoubleUnion(lower_bound_as_int + 2).d;
+            min_signal_enables_passing = test::DoubleUnion(lower_bound_as_int + 2).d;
 
             uint64_t upper_bound_as_int = expected_as_int - targeted_bit;
-            upper_bound = DoubleUnion(upper_bound_as_int).d;
-            past_upper_bound = DoubleUnion(upper_bound_as_int - 1).d;
+            upper_bound = test::DoubleUnion(upper_bound_as_int).d;
+            past_upper_bound = test::DoubleUnion(upper_bound_as_int - 1).d;
         }
         else // (expected == 0.) || (expected == -0.)
         {
             // Special handling of 0 / -0 which get same bounds
             uint64_t upper_bound_as_int = targeted_bit;
-            upper_bound = DoubleUnion(upper_bound_as_int).d;
+            upper_bound = test::DoubleUnion(upper_bound_as_int).d;
             uint64_t past_upper_bound_as_int = upper_bound_as_int + 1;
-            past_upper_bound = DoubleUnion(past_upper_bound_as_int).d;
+            past_upper_bound = test::DoubleUnion(past_upper_bound_as_int).d;
             min_signal_too_low = expected;
-            min_signal_enables_passing = DoubleUnion(upper_bound_as_int + 2).d;
+            min_signal_enables_passing = test::DoubleUnion(upper_bound_as_int + 2).d;
 
-            lower_bound = DoubleUnion(upper_bound_as_int | 0x8000000000000000).d;
-            past_lower_bound = DoubleUnion(past_upper_bound_as_int | 0x8000000000000000).d;
+            lower_bound = test::DoubleUnion(upper_bound_as_int | 0x8000000000000000).d;
+            past_lower_bound = test::DoubleUnion(past_upper_bound_as_int | 0x8000000000000000).d;
         }
     }
 
@@ -363,13 +269,13 @@ TEST_P(all_close_f_double_param_test, test_boundaries)
 
     // Format verbose info to only print out in case of test failure
     stringstream ss;
-    ss << "Testing target of: " << expected << " (" << double_to_bits(expected) << ")\n";
+    ss << "Testing target of: " << expected << " (" << test::double_to_bits(expected) << ")\n";
     ss << "Matching to targets with: " << tolerance_bits << " tolerance_bits\n";
-    ss << "upper_bound: " << upper_bound << " (" << double_to_bits(upper_bound) << ")\n";
-    ss << "lower_bound: " << lower_bound << " (" << double_to_bits(lower_bound) << ")\n";
-    ss << "past_upper_bound: " << past_upper_bound << " (" << double_to_bits(past_upper_bound)
+    ss << "upper_bound: " << upper_bound << " (" << test::double_to_bits(upper_bound) << ")\n";
+    ss << "lower_bound: " << lower_bound << " (" << test::double_to_bits(lower_bound) << ")\n";
+    ss << "past_upper_bound: " << past_upper_bound << " (" << test::double_to_bits(past_upper_bound)
        << ")\n";
-    ss << "past_lower_bound: " << past_lower_bound << " (" << double_to_bits(past_lower_bound)
+    ss << "past_lower_bound: " << past_lower_bound << " (" << test::double_to_bits(past_lower_bound)
        << ")\n";
 
     EXPECT_TRUE(test::close_f(expected, upper_bound, tolerance_bits)) << ss.str();
@@ -470,19 +376,20 @@ TEST(all_close_f, mantissa_8_near_0)
     constexpr int tolerance_bits = (FLOAT_MANTISSA_BITS - BFLOAT_MANTISSA_BITS + 2);
 
     // 0.f, the ground-truth value
-    float expected = bits_to_float("0  00000000  000 0000 0000 0000 0000 0000");
+    float expected = test::bits_to_float("0  00000000  000 0000 0000 0000 0000 0000");
     float computed;
-    float min_signal_too_low = bits_to_float("0  00000000  000 0100 0000 0000 0000 0001");
-    float min_signal_enables_passing = bits_to_float("0  00000000  000 0100 0000 0000 0000 0010");
+    float min_signal_too_low = test::bits_to_float("0  00000000  000 0100 0000 0000 0000 0001");
+    float min_signal_enables_passing =
+        test::bits_to_float("0  00000000  000 0100 0000 0000 0000 0010");
 
     // ~3.67342E-40, the exact upper bound
-    computed = bits_to_float("0  00000000  000 0100 0000 0000 0000 0000");
+    computed = test::bits_to_float("0  00000000  000 0100 0000 0000 0000 0000");
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // ~3.67343E-40, the next representable number bigger than upper bound
-    computed = bits_to_float("0  00000000  000 0100 0000 0000 0000 0001");
+    computed = test::bits_to_float("0  00000000  000 0100 0000 0000 0000 0001");
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits, min_signal_too_low));
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits, min_signal_enables_passing));
@@ -496,13 +403,13 @@ TEST(all_close_f, mantissa_8_near_0)
                                   min_signal_enables_passing));
 
     // ~-3.67342E-40, the exact lower bound
-    computed = bits_to_float("1  00000000  000 0100 0000 0000 0000 0000");
+    computed = test::bits_to_float("1  00000000  000 0100 0000 0000 0000 0000");
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // ~-3.67343E-40, the next representable number smaller than lower bound
-    computed = bits_to_float("1  00000000  000 0100 0000 0000 0000 0001");
+    computed = test::bits_to_float("1  00000000  000 0100 0000 0000 0000 0001");
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits, min_signal_too_low));
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits, min_signal_enables_passing));
@@ -558,19 +465,20 @@ TEST(all_close_f, mantissa_8_near_n0)
     constexpr int tolerance_bits = (FLOAT_MANTISSA_BITS - BFLOAT_MANTISSA_BITS + 2);
 
     // 0.f, the ground-truth value
-    float expected = bits_to_float("1  00000000  000 0000 0000 0000 0000 0000");
+    float expected = test::bits_to_float("1  00000000  000 0000 0000 0000 0000 0000");
     float computed;
-    float min_signal_too_low = bits_to_float("0  00000000  000 0100 0000 0000 0000 0001");
-    float min_signal_enables_passing = bits_to_float("0  00000000  000 0100 0000 0000 0000 0010");
+    float min_signal_too_low = test::bits_to_float("0  00000000  000 0100 0000 0000 0000 0001");
+    float min_signal_enables_passing =
+        test::bits_to_float("0  00000000  000 0100 0000 0000 0000 0010");
 
     // ~3.67342E-40, the exact upper bound
-    computed = bits_to_float("0  00000000  000 0100 0000 0000 0000 0000");
+    computed = test::bits_to_float("0  00000000  000 0100 0000 0000 0000 0000");
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // ~3.67343E-40, the next representable number bigger than upper bound
-    computed = bits_to_float("0  00000000  000 0100 0000 0000 0000 0001");
+    computed = test::bits_to_float("0  00000000  000 0100 0000 0000 0000 0001");
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits, min_signal_too_low));
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits, min_signal_enables_passing));
@@ -584,13 +492,13 @@ TEST(all_close_f, mantissa_8_near_n0)
                                   min_signal_enables_passing));
 
     // ~-3.67342E-40, the exact lower bound
-    computed = bits_to_float("1  00000000  000 0100 0000 0000 0000 0000");
+    computed = test::bits_to_float("1  00000000  000 0100 0000 0000 0000 0000");
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // ~-3.67343E-40, the next representable number smaller than lower bound
-    computed = bits_to_float("1  00000000  000 0100 0000 0000 0000 0001");
+    computed = test::bits_to_float("1  00000000  000 0100 0000 0000 0000 0001");
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits, min_signal_too_low));
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits, min_signal_enables_passing));
@@ -640,29 +548,29 @@ TEST(all_close_f, mantissa_8_near_1)
     constexpr int tolerance_bits = (FLOAT_MANTISSA_BITS - BFLOAT_MANTISSA_BITS + 2);
 
     // 1.f, the ground-truth value
-    float expected = bits_to_float("0  01111111  000 0000 0000 0000 0000 0000");
+    float expected = test::bits_to_float("0  01111111  000 0000 0000 0000 0000 0000");
     float computed;
 
     // 1.03125f, the exact upper bound
-    computed = bits_to_float("0  01111111  000 0100 0000 0000 0000 0000");
+    computed = test::bits_to_float("0  01111111  000 0100 0000 0000 0000 0000");
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // 1.031250119f, the next representable number bigger than upper bound
-    computed = bits_to_float("0  01111111  000 0100 0000 0000 0000 0001");
+    computed = test::bits_to_float("0  01111111  000 0100 0000 0000 0000 0001");
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_FALSE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // 0.984375f, the exact lower bound
-    computed = bits_to_float("0  01111110  111 1100 0000 0000 0000 0000");
+    computed = test::bits_to_float("0  01111110  111 1100 0000 0000 0000 0000");
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // 0.9843749404f, the next representable number smaller than lower bound
-    computed = bits_to_float("0  01111110  111 1011 1111 1111 1111 1111");
+    computed = test::bits_to_float("0  01111110  111 1011 1111 1111 1111 1111");
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_FALSE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
@@ -704,29 +612,29 @@ TEST(all_close_f, mantissa_8_near_n1)
     constexpr int tolerance_bits = (FLOAT_MANTISSA_BITS - BFLOAT_MANTISSA_BITS + 2);
 
     // -1.f, the ground-truth value
-    float expected = bits_to_float("1  01111111  000 0000 0000 0000 0000 0000");
+    float expected = test::bits_to_float("1  01111111  000 0000 0000 0000 0000 0000");
     float computed;
 
     // -0.984375f, the exact upper bound
-    computed = bits_to_float("1  01111110  111 1100 0000 0000 0000 0000");
+    computed = test::bits_to_float("1  01111110  111 1100 0000 0000 0000 0000");
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // -0.984374940395355224609375f, the next representable number bigger than upper bound
-    computed = bits_to_float("1  01111110  111 1011 1111 1111 1111 1111");
+    computed = test::bits_to_float("1  01111110  111 1011 1111 1111 1111 1111");
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_FALSE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // -1.03125f, the exact lower bound
-    computed = bits_to_float("1  01111111  000 0100 0000 0000 0000 0000");
+    computed = test::bits_to_float("1  01111111  000 0100 0000 0000 0000 0000");
     EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
 
     // -1.03125011920928955078125f, the next representable number smaller than lower bound
-    computed = bits_to_float("1  01111111  000 0100 0000 0000 0000 0001");
+    computed = test::bits_to_float("1  01111111  000 0100 0000 0000 0000 0001");
     EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
     EXPECT_FALSE(
         test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
@@ -874,10 +782,10 @@ TEST(all_close_f, mantissa_24_near_0_1_10_100_1000)
 
     // Bounds around 0: 0 +- 5.6e-45
     expected = 0.f;
-    upper_bound = bits_to_float("0  00000000  000 0000 0000 0000 0000 0100");
-    bigger_than_upper_bound = bits_to_float("0  00000000  000 0000 0000 0000 0000 0101");
-    lower_bound = bits_to_float("1  00000000  000 0000 0000 0000 0000 0100");
-    smaller_than_lower_bound = bits_to_float("1  00000000  000 0000 0000 0000 0000 0101");
+    upper_bound = test::bits_to_float("0  00000000  000 0000 0000 0000 0000 0100");
+    bigger_than_upper_bound = test::bits_to_float("0  00000000  000 0000 0000 0000 0000 0101");
+    lower_bound = test::bits_to_float("1  00000000  000 0000 0000 0000 0000 0100");
+    smaller_than_lower_bound = test::bits_to_float("1  00000000  000 0000 0000 0000 0000 0101");
     EXPECT_TRUE(test::close_f(expected, upper_bound, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({upper_bound}), tolerance_bits));
@@ -893,10 +801,10 @@ TEST(all_close_f, mantissa_24_near_0_1_10_100_1000)
 
     // Bounds around 1: 1 +- 4.77e-7
     expected = 1.f;
-    upper_bound = bits_to_float("0  01111111  000 0000 0000 0000 0000 0100");
-    bigger_than_upper_bound = bits_to_float("0  01111111  000 0000 0000 0000 0000 0101");
-    lower_bound = bits_to_float("0  01111110  111 1111 1111 1111 1111 1100");
-    smaller_than_lower_bound = bits_to_float("0  01111110  111 1111 1111 1111 1111 1011");
+    upper_bound = test::bits_to_float("0  01111111  000 0000 0000 0000 0000 0100");
+    bigger_than_upper_bound = test::bits_to_float("0  01111111  000 0000 0000 0000 0000 0101");
+    lower_bound = test::bits_to_float("0  01111110  111 1111 1111 1111 1111 1100");
+    smaller_than_lower_bound = test::bits_to_float("0  01111110  111 1111 1111 1111 1111 1011");
     EXPECT_TRUE(test::close_f(expected, upper_bound, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({upper_bound}), tolerance_bits));
@@ -912,10 +820,10 @@ TEST(all_close_f, mantissa_24_near_0_1_10_100_1000)
 
     // Bounds around 10: 10 +- 3.81e-6
     expected = 10.f;
-    upper_bound = bits_to_float("0  10000010  010 0000 0000 0000 0000 0100");
-    bigger_than_upper_bound = bits_to_float("0  10000010  010 0000 0000 0000 0000 0101");
-    lower_bound = bits_to_float("0  10000010  001 1111 1111 1111 1111 1100");
-    smaller_than_lower_bound = bits_to_float("0  10000010  001 1111 1111 1111 1111 1011");
+    upper_bound = test::bits_to_float("0  10000010  010 0000 0000 0000 0000 0100");
+    bigger_than_upper_bound = test::bits_to_float("0  10000010  010 0000 0000 0000 0000 0101");
+    lower_bound = test::bits_to_float("0  10000010  001 1111 1111 1111 1111 1100");
+    smaller_than_lower_bound = test::bits_to_float("0  10000010  001 1111 1111 1111 1111 1011");
     EXPECT_TRUE(test::close_f(expected, upper_bound, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({upper_bound}), tolerance_bits));
@@ -931,10 +839,10 @@ TEST(all_close_f, mantissa_24_near_0_1_10_100_1000)
 
     // Bounds around 100: 100 +- 3.05e-5
     expected = 100.f;
-    upper_bound = bits_to_float("0  10000101  100 1000 0000 0000 0000 0100");
-    bigger_than_upper_bound = bits_to_float("0  10000101  100 1000 0000 0000 0000 0101");
-    lower_bound = bits_to_float("0  10000101  100 0111 1111 1111 1111 1100");
-    smaller_than_lower_bound = bits_to_float("0  10000101  100 0111 1111 1111 1111 1011");
+    upper_bound = test::bits_to_float("0  10000101  100 1000 0000 0000 0000 0100");
+    bigger_than_upper_bound = test::bits_to_float("0  10000101  100 1000 0000 0000 0000 0101");
+    lower_bound = test::bits_to_float("0  10000101  100 0111 1111 1111 1111 1100");
+    smaller_than_lower_bound = test::bits_to_float("0  10000101  100 0111 1111 1111 1111 1011");
     EXPECT_TRUE(test::close_f(expected, upper_bound, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({upper_bound}), tolerance_bits));
@@ -950,10 +858,10 @@ TEST(all_close_f, mantissa_24_near_0_1_10_100_1000)
 
     // Bounds around 1000: 1000 +- 2.44e-4
     expected = 1000.f;
-    upper_bound = bits_to_float("0  10001000  111 1010 0000 0000 0000 0100");
-    bigger_than_upper_bound = bits_to_float("0  10001000  111 1010 0000 0000 0000 0101");
-    lower_bound = bits_to_float("0  10001000  111 1001 1111 1111 1111 1100");
-    smaller_than_lower_bound = bits_to_float("0  10001000  111 1001 1111 1111 1111 1011");
+    upper_bound = test::bits_to_float("0  10001000  111 1010 0000 0000 0000 0100");
+    bigger_than_upper_bound = test::bits_to_float("0  10001000  111 1010 0000 0000 0000 0101");
+    lower_bound = test::bits_to_float("0  10001000  111 1001 1111 1111 1111 1100");
+    smaller_than_lower_bound = test::bits_to_float("0  10001000  111 1001 1111 1111 1111 1011");
     EXPECT_TRUE(test::close_f(expected, upper_bound, tolerance_bits));
     EXPECT_TRUE(
         test::all_close_f(vector<float>({expected}), vector<float>({upper_bound}), tolerance_bits));

--- a/test/bfloat16.cpp
+++ b/test/bfloat16.cpp
@@ -1,0 +1,30 @@
+//*****************************************************************************
+// Copyright 2017-2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include "gtest/gtest.h"
+
+#include "ngraph/type/bfloat16.hpp"
+
+using namespace std;
+using namespace ngraph;
+
+TEST(bfloat16, from_float)
+{
+}
+
+TEST(bfloat16, to_float)
+{
+}

--- a/test/bfloat16.cpp
+++ b/test/bfloat16.cpp
@@ -25,6 +25,14 @@
 using namespace std;
 using namespace ngraph;
 
+template <typename T>
+string to_hex(T value)
+{
+    stringstream ss;
+    ss << "0x" << hex << setw(sizeof(T) * 2) << setfill('0') << value;
+    return ss.str();
+}
+
 //***********************
 // NOTE
 //***********************
@@ -53,62 +61,83 @@ TEST(bfloat16, conversions)
 
 TEST(bfloat16, round_to_nearest)
 {
-    // 1.03515625f, the next representable number which should round up
-    string fstring = "0  01111111  000 0100 1000 0000 0000 0000";
-    float fvalue = test::bits_to_float(fstring);
-    uint16_t bf_trunc = bfloat16::truncate(fvalue);
-    uint16_t bf_round = bfloat16::round_to_nearest(fvalue);
-    EXPECT_EQ(bf_trunc, bfloat16(1.03125).to_bits());
-    EXPECT_EQ(bf_round, bfloat16(1.0390625).to_bits());
+    string fstring;
+    string expected;
+    float fvalue;
+    uint16_t bf_round;
 
-    // 1.99609375f, the next representable number which should round up
+    fstring = "0  01111111  000 0100 1000 0000 0000 0000";
+    fvalue = test::bits_to_float(fstring);
+    bf_round = bfloat16::round_to_nearest(fvalue);
+    EXPECT_EQ(bf_round, 0x3F85);
+
+    fstring = "0  01111111  000 0100 0000 0000 0000 0000";
+    fvalue = test::bits_to_float(fstring);
+    bf_round = bfloat16::round_to_nearest(fvalue);
+    EXPECT_EQ(bf_round, 0x3F84);
+
     fstring = "0  01111111  111 1111 1000 0000 0000 0000";
     fvalue = test::bits_to_float(fstring);
-    bf_trunc = bfloat16::truncate(fvalue);
     bf_round = bfloat16::round_to_nearest(fvalue);
-    EXPECT_EQ(bf_trunc, bfloat16(1.9921875).to_bits());
-    EXPECT_EQ(bf_round, bfloat16(2.0).to_bits());
+    EXPECT_EQ(bf_round, 0x4000);
 
     // 1.9921875f, the next representable number which should not round up
     fstring = "0  01111111  111 1111 0000 0000 0000 0000";
     fvalue = test::bits_to_float(fstring);
-    bf_trunc = bfloat16::truncate(fvalue);
     bf_round = bfloat16::round_to_nearest(fvalue);
-    EXPECT_EQ(bf_trunc, bfloat16(1.9921875).to_bits());
-    EXPECT_EQ(bf_round, bfloat16(1.9921875).to_bits());
+    EXPECT_EQ(bf_round, 0x3FFF);
 }
 
 TEST(bfloat16, round_to_nearest_even)
 {
-    string fstring = "0  01111111  000 0100 1000 0000 0000 0000";
-    string expected = "0  01111111  000 0100";
-    float fvalue = test::bits_to_float(fstring);
-    uint16_t bf_round = bfloat16::round_to_nearest_even(fvalue);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
+    string fstring;
+    string expected;
+    float fvalue;
+    uint16_t bf_round;
+
+    fstring = "0  01111111  000 0100 1000 0000 0000 0000";
+    expected = "0  01111111  000 0100";
+    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
+    fvalue = test::bits_to_float(fstring);
+    bf_round = bfloat16::round_to_nearest_even(fvalue);
+    NGRAPH_INFO << to_hex(bf_round);
+    EXPECT_EQ(bf_round, 0x3F84);
+    NGRAPH_INFO;
 
     fstring = "0  01111111  000 0101 1000 0000 0000 0000";
     expected = "0  01111111  000 0110";
+    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
     fvalue = test::bits_to_float(fstring);
     bf_round = bfloat16::round_to_nearest_even(fvalue);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
+    NGRAPH_INFO << to_hex(bf_round);
+    EXPECT_EQ(bf_round, 0x3F86);
+    NGRAPH_INFO;
 
     fstring = "0  01111111  000 0101 0000 0000 0000 0000";
     expected = "0  01111111  000 0101";
+    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
     fvalue = test::bits_to_float(fstring);
     bf_round = bfloat16::round_to_nearest_even(fvalue);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
+    NGRAPH_INFO << to_hex(bf_round);
+    EXPECT_EQ(bf_round, 0x3F85);
+    NGRAPH_INFO;
 
     fstring = "0  01111111  111 1111 1000 0000 0000 0000";
     expected = "0  10000000  000 0000";
+    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
     fvalue = test::bits_to_float(fstring);
     bf_round = bfloat16::round_to_nearest_even(fvalue);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
+    NGRAPH_INFO << to_hex(bf_round);
+    EXPECT_EQ(bf_round, 0x4000);
+    NGRAPH_INFO;
 
     fstring = "0  01111111  111 1111 0000 0000 0000 0000";
     expected = "0  01111111  111 1111";
+    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
     fvalue = test::bits_to_float(fstring);
     bf_round = bfloat16::round_to_nearest_even(fvalue);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
+    NGRAPH_INFO << to_hex(bf_round);
+    EXPECT_EQ(bf_round, 0x3FFF);
 }
 
 TEST(bfloat16, to_float)

--- a/test/bfloat16.cpp
+++ b/test/bfloat16.cpp
@@ -141,8 +141,7 @@ TEST(benchmark, bfloat16)
     {
         f[i] = distribution(rng);
     }
-    NGRAPH_INFO << "buffer size " << data.size() << " floats or " << data.size() * sizeof(float)
-                << " bytes";
+    NGRAPH_INFO << "buffer size " << buffer_size << " floats or " << data.size() << " bytes";
 
     {
         ngraph::runtime::AlignedBuffer bf_data(buffer_size * sizeof(bfloat16), 4096);

--- a/test/bfloat16.cpp
+++ b/test/bfloat16.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //*****************************************************************************
 
+#include <random>
+
 #include "gtest/gtest.h"
 
 #include "ngraph/type/bfloat16.hpp"
@@ -53,26 +55,26 @@ TEST(bfloat16, round_to_nearest)
     // 1.03515625f, the next representable number which should round up
     string fstring = "0  01111111  000 0100 1000 0000 0000 0000";
     float fvalue = test::bits_to_float(fstring);
-    bfloat16 bf_trunc = bfloat16(fvalue, bfloat16::RoundingMode::TRUNCATE);
-    bfloat16 bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND);
-    EXPECT_EQ(bf_trunc, bfloat16(1.03125));
-    EXPECT_EQ(bf_round, bfloat16(1.0390625));
+    uint16_t bf_trunc = bfloat16::truncate(fvalue);
+    uint16_t bf_round = bfloat16::round_to_nearest(fvalue);
+    EXPECT_EQ(bf_trunc, bfloat16(1.03125).to_bits());
+    EXPECT_EQ(bf_round, bfloat16(1.0390625).to_bits());
 
     // 1.99609375f, the next representable number which should round up
     fstring = "0  01111111  111 1111 1000 0000 0000 0000";
     fvalue = test::bits_to_float(fstring);
-    bf_trunc = bfloat16(fvalue, bfloat16::RoundingMode::TRUNCATE);
-    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND);
-    EXPECT_EQ(bf_trunc, bfloat16(1.9921875));
-    EXPECT_EQ(bf_round, bfloat16(2.0));
+    bf_trunc = bfloat16::truncate(fvalue);
+    bf_round = bfloat16::round_to_nearest(fvalue);
+    EXPECT_EQ(bf_trunc, bfloat16(1.9921875).to_bits());
+    EXPECT_EQ(bf_round, bfloat16(2.0).to_bits());
 
     // 1.9921875f, the next representable number which should not round up
     fstring = "0  01111111  111 1111 0000 0000 0000 0000";
     fvalue = test::bits_to_float(fstring);
-    bf_trunc = bfloat16(fvalue, bfloat16::RoundingMode::TRUNCATE);
-    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND);
-    EXPECT_EQ(bf_trunc, bfloat16(1.9921875));
-    EXPECT_EQ(bf_round, bfloat16(1.9921875));
+    bf_trunc = bfloat16::truncate(fvalue);
+    bf_round = bfloat16::round_to_nearest(fvalue);
+    EXPECT_EQ(bf_trunc, bfloat16(1.9921875).to_bits());
+    EXPECT_EQ(bf_round, bfloat16(1.9921875).to_bits());
 }
 
 TEST(bfloat16, round_to_nearest_even)
@@ -80,32 +82,32 @@ TEST(bfloat16, round_to_nearest_even)
     string fstring = "0  01111111  000 0100 1000 0000 0000 0000";
     string expected = "0  01111111  000 0100";
     float fvalue = test::bits_to_float(fstring);
-    bfloat16 bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
+    uint16_t bf_round = bfloat16::round_to_nearest_even(fvalue);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
 
     fstring = "0  01111111  000 0101 1000 0000 0000 0000";
     expected = "0  01111111  000 0110";
     fvalue = test::bits_to_float(fstring);
-    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
+    bf_round = bfloat16::round_to_nearest_even(fvalue);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
 
     fstring = "0  01111111  000 0101 0000 0000 0000 0000";
     expected = "0  01111111  000 0101";
     fvalue = test::bits_to_float(fstring);
-    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
+    bf_round = bfloat16::round_to_nearest_even(fvalue);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
 
     fstring = "0  01111111  111 1111 1000 0000 0000 0000";
     expected = "0  10000000  000 0000";
     fvalue = test::bits_to_float(fstring);
-    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
+    bf_round = bfloat16::round_to_nearest_even(fvalue);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
 
     fstring = "0  01111111  111 1111 0000 0000 0000 0000";
     expected = "0  01111111  111 1111";
     fvalue = test::bits_to_float(fstring);
-    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
-    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
+    bf_round = bfloat16::round_to_nearest_even(fvalue);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected).to_bits());
 }
 
 TEST(bfloat16, to_float)
@@ -124,4 +126,71 @@ TEST(bfloat16, to_float)
     bf = test::bits_to_bfloat16(source_string);
     f = static_cast<float>(bf);
     EXPECT_EQ(f, 1.03125f);
+}
+
+TEST(benchmark, bfloat16)
+{
+    vector<float> data(128 * 3 * 224 * 224);
+    mt19937 rng(2112);
+    uniform_real_distribution<float> distribution(-300, 300);
+    for (float& f : data)
+    {
+        f = distribution(rng);
+    }
+    NGRAPH_INFO << test::float_to_bits(data[0]);
+    NGRAPH_INFO << "buffer size " << data.size() << " floats or " << data.size() * sizeof(float)
+                << " bytes";
+
+    {
+        vector<bfloat16> bf_data;
+        bf_data.reserve(data.size());
+        stopwatch timer;
+        timer.start();
+        for (const float& f : data)
+        {
+            bf_data.emplace_back(f);
+        }
+        timer.stop();
+        NGRAPH_INFO << "float to bfloat16 truncate " << timer.get_milliseconds() << "ms";
+    }
+
+    {
+        vector<uint16_t> bf_data;
+        bf_data.reserve(data.size());
+        stopwatch timer;
+        timer.start();
+        for (const float& f : data)
+        {
+            bf_data.emplace_back(bfloat16::truncate(f));
+        }
+        timer.stop();
+        NGRAPH_INFO << "float to bfloat16 truncate " << timer.get_milliseconds() << "ms";
+    }
+
+    {
+        vector<uint16_t> bf_data;
+        bf_data.reserve(data.size());
+        stopwatch timer;
+        timer.start();
+        for (const float& f : data)
+        {
+            bf_data.emplace_back(bfloat16::round_to_nearest(f));
+        }
+        timer.stop();
+        NGRAPH_INFO << "float to bfloat16 round to nearest " << timer.get_milliseconds() << "ms";
+    }
+
+    {
+        vector<uint16_t> bf_data;
+        bf_data.reserve(data.size());
+        stopwatch timer;
+        timer.start();
+        for (const float& f : data)
+        {
+            bf_data.emplace_back(bfloat16::round_to_nearest_even(f));
+        }
+        timer.stop();
+        NGRAPH_INFO << "float to bfloat16 truncate round to nearest even "
+                    << timer.get_milliseconds() << "ms";
+    }
 }

--- a/test/bfloat16.cpp
+++ b/test/bfloat16.cpp
@@ -46,7 +46,10 @@ TEST(bfloat16, conversions)
     EXPECT_EQ(bf, bfloat16(1.03125));
     bf_string = test::bfloat16_to_bits(bf);
     EXPECT_STREQ(source_string.c_str(), bf_string.c_str());
+}
 
+TEST(bfloat16, round_to_nearest)
+{
     // 1.03515625f, the next representable number which should round up
     string fstring = "0  01111111  000 0100 1000 0000 0000 0000";
     float fvalue = test::bits_to_float(fstring);
@@ -70,6 +73,39 @@ TEST(bfloat16, conversions)
     bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND);
     EXPECT_EQ(bf_trunc, bfloat16(1.9921875));
     EXPECT_EQ(bf_round, bfloat16(1.9921875));
+}
+
+TEST(bfloat16, round_to_nearest_even)
+{
+    string fstring = "0  01111111  000 0100 1000 0000 0000 0000";
+    string expected = "0  01111111  000 0100";
+    float fvalue = test::bits_to_float(fstring);
+    bfloat16 bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
+
+    fstring = "0  01111111  000 0101 1000 0000 0000 0000";
+    expected = "0  01111111  000 0110";
+    fvalue = test::bits_to_float(fstring);
+    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
+
+    fstring = "0  01111111  000 0101 0000 0000 0000 0000";
+    expected = "0  01111111  000 0101";
+    fvalue = test::bits_to_float(fstring);
+    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
+
+    fstring = "0  01111111  111 1111 1000 0000 0000 0000";
+    expected = "0  10000000  000 0000";
+    fvalue = test::bits_to_float(fstring);
+    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
+
+    fstring = "0  01111111  111 1111 0000 0000 0000 0000";
+    expected = "0  01111111  111 1111";
+    fvalue = test::bits_to_float(fstring);
+    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND_TO_NEAREST_EVEN);
+    EXPECT_EQ(bf_round, test::bits_to_bfloat16(expected));
 }
 
 TEST(bfloat16, to_float)

--- a/test/bfloat16.cpp
+++ b/test/bfloat16.cpp
@@ -22,6 +22,56 @@
 using namespace std;
 using namespace ngraph;
 
+//***********************
+// NOTE
+//***********************
+// This test uses exact comparisons of floating point values. It is testing for bit-exact
+// creation and truncation/rounding of bfloat16 values.
+TEST(bfloat16, utils)
+{
+    bfloat16 bf;
+    string source_string;
+    string bf_string;
+
+    // 1.f, the ground-truth value
+    source_string = "0  01111111  000 0000";
+    bf = test::bits_to_bfloat16(source_string);
+    EXPECT_EQ(bf, bfloat16(1.0));
+    bf_string = test::bfloat16_to_bits(bf);
+    EXPECT_STREQ(source_string.c_str(), bf_string.c_str());
+
+    // 1.03125f, the exact upper bound
+    source_string = "0  01111111  000 0100";
+    bf = test::bits_to_bfloat16(source_string);
+    EXPECT_EQ(bf, bfloat16(1.03125));
+    bf_string = test::bfloat16_to_bits(bf);
+    EXPECT_STREQ(source_string.c_str(), bf_string.c_str());
+
+    // 1.03515625f, the next representable number which should round up
+    string fstring = "0  01111111  000 0100 1000 0000 0000 0000";
+    float fvalue = test::bits_to_float(fstring);
+    bfloat16 bf_trunc = bfloat16(fvalue, bfloat16::RoundingMode::TRUNCATE);
+    bfloat16 bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND);
+    EXPECT_EQ(bf_trunc, bfloat16(1.03125));
+    EXPECT_EQ(bf_round, bfloat16(1.0390625));
+
+    // 1.99609375f, the next representable number which should round up
+    fstring = "0  01111111  111 1111 1000 0000 0000 0000";
+    fvalue = test::bits_to_float(fstring);
+    bf_trunc = bfloat16(fvalue, bfloat16::RoundingMode::TRUNCATE);
+    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND);
+    EXPECT_EQ(bf_trunc, bfloat16(1.9921875));
+    EXPECT_EQ(bf_round, bfloat16(2.0));
+
+    // 1.9921875f, the next representable number which should not round up
+    fstring = "0  01111111  111 1111 0000 0000 0000 0000";
+    fvalue = test::bits_to_float(fstring);
+    bf_trunc = bfloat16(fvalue, bfloat16::RoundingMode::TRUNCATE);
+    bf_round = bfloat16(fvalue, bfloat16::RoundingMode::ROUND);
+    EXPECT_EQ(bf_trunc, bfloat16(1.9921875));
+    EXPECT_EQ(bf_round, bfloat16(1.9921875));
+}
+
 TEST(bfloat16, from_float)
 {
     // // 1.f, the ground-truth value

--- a/test/bfloat16.cpp
+++ b/test/bfloat16.cpp
@@ -91,52 +91,32 @@ TEST(bfloat16, round_to_nearest)
 TEST(bfloat16, round_to_nearest_even)
 {
     string fstring;
-    string expected;
     float fvalue;
     uint16_t bf_round;
 
     fstring = "0  01111111  000 0100 1000 0000 0000 0000";
-    expected = "0  01111111  000 0100";
-    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
     fvalue = test::bits_to_float(fstring);
     bf_round = bfloat16::round_to_nearest_even(fvalue);
-    NGRAPH_INFO << to_hex(bf_round);
     EXPECT_EQ(bf_round, 0x3F84);
-    NGRAPH_INFO;
 
     fstring = "0  01111111  000 0101 1000 0000 0000 0000";
-    expected = "0  01111111  000 0110";
-    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
     fvalue = test::bits_to_float(fstring);
     bf_round = bfloat16::round_to_nearest_even(fvalue);
-    NGRAPH_INFO << to_hex(bf_round);
     EXPECT_EQ(bf_round, 0x3F86);
-    NGRAPH_INFO;
 
     fstring = "0  01111111  000 0101 0000 0000 0000 0000";
-    expected = "0  01111111  000 0101";
-    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
     fvalue = test::bits_to_float(fstring);
     bf_round = bfloat16::round_to_nearest_even(fvalue);
-    NGRAPH_INFO << to_hex(bf_round);
     EXPECT_EQ(bf_round, 0x3F85);
-    NGRAPH_INFO;
 
     fstring = "0  01111111  111 1111 1000 0000 0000 0000";
-    expected = "0  10000000  000 0000";
-    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
     fvalue = test::bits_to_float(fstring);
     bf_round = bfloat16::round_to_nearest_even(fvalue);
-    NGRAPH_INFO << to_hex(bf_round);
     EXPECT_EQ(bf_round, 0x4000);
-    NGRAPH_INFO;
 
     fstring = "0  01111111  111 1111 0000 0000 0000 0000";
-    expected = "0  01111111  111 1111";
-    NGRAPH_INFO << to_hex(test::bits_to_bfloat16(expected).to_bits());
     fvalue = test::bits_to_float(fstring);
     bf_round = bfloat16::round_to_nearest_even(fvalue);
-    NGRAPH_INFO << to_hex(bf_round);
     EXPECT_EQ(bf_round, 0x3FFF);
 }
 

--- a/test/bfloat16.cpp
+++ b/test/bfloat16.cpp
@@ -27,7 +27,7 @@ using namespace ngraph;
 //***********************
 // This test uses exact comparisons of floating point values. It is testing for bit-exact
 // creation and truncation/rounding of bfloat16 values.
-TEST(bfloat16, utils)
+TEST(bfloat16, conversions)
 {
     bfloat16 bf;
     string source_string;
@@ -72,41 +72,20 @@ TEST(bfloat16, utils)
     EXPECT_EQ(bf_round, bfloat16(1.9921875));
 }
 
-TEST(bfloat16, from_float)
-{
-    // // 1.f, the ground-truth value
-    // float expected = bits_to_float("0  01111111  000 0000 0000 0000 0000 0000");
-    // float computed;
-
-    // // 1.03125f, the exact upper bound
-    // computed = bits_to_float("0  01111111  000 0100 0000 0000 0000 0000");
-    // EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
-    // EXPECT_TRUE(
-    //     test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
-
-    // // 1.031250119f, the next representable number bigger than upper bound
-    // computed = bits_to_float("0  01111111  000 0100 0000 0000 0000 0001");
-    // EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
-    // EXPECT_FALSE(
-    //     test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
-
-    // // 0.984375f, the exact lower bound
-    // computed = bits_to_float("0  01111110  111 1100 0000 0000 0000 0000");
-    // EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
-    // EXPECT_TRUE(
-    //     test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
-
-    // // 0.9843749404f, the next representable number smaller than lower bound
-    // computed = bits_to_float("0  01111110  111 1011 1111 1111 1111 1111");
-    // EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
-    // EXPECT_FALSE(
-    //     test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
-}
-
-TEST(bfloat16, from_float_rounding)
-{
-}
-
 TEST(bfloat16, to_float)
 {
+    bfloat16 bf;
+    string source_string;
+
+    // 1.f, the ground-truth value
+    source_string = "0  01111111  000 0000";
+    bf = test::bits_to_bfloat16(source_string);
+    float f = static_cast<float>(bf);
+    EXPECT_EQ(f, 1.0f);
+
+    // 1.03125f, the exact upper bound
+    source_string = "0  01111111  000 0100";
+    bf = test::bits_to_bfloat16(source_string);
+    f = static_cast<float>(bf);
+    EXPECT_EQ(f, 1.03125f);
 }

--- a/test/bfloat16.cpp
+++ b/test/bfloat16.cpp
@@ -17,11 +17,43 @@
 #include "gtest/gtest.h"
 
 #include "ngraph/type/bfloat16.hpp"
+#include "util/float_util.hpp"
 
 using namespace std;
 using namespace ngraph;
 
 TEST(bfloat16, from_float)
+{
+    // // 1.f, the ground-truth value
+    // float expected = bits_to_float("0  01111111  000 0000 0000 0000 0000 0000");
+    // float computed;
+
+    // // 1.03125f, the exact upper bound
+    // computed = bits_to_float("0  01111111  000 0100 0000 0000 0000 0000");
+    // EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
+    // EXPECT_TRUE(
+    //     test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
+
+    // // 1.031250119f, the next representable number bigger than upper bound
+    // computed = bits_to_float("0  01111111  000 0100 0000 0000 0000 0001");
+    // EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
+    // EXPECT_FALSE(
+    //     test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
+
+    // // 0.984375f, the exact lower bound
+    // computed = bits_to_float("0  01111110  111 1100 0000 0000 0000 0000");
+    // EXPECT_TRUE(test::close_f(expected, computed, tolerance_bits));
+    // EXPECT_TRUE(
+    //     test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
+
+    // // 0.9843749404f, the next representable number smaller than lower bound
+    // computed = bits_to_float("0  01111110  111 1011 1111 1111 1111 1111");
+    // EXPECT_FALSE(test::close_f(expected, computed, tolerance_bits));
+    // EXPECT_FALSE(
+    //     test::all_close_f(vector<float>({expected}), vector<float>({computed}), tolerance_bits));
+}
+
+TEST(bfloat16, from_float_rounding)
 {
 }
 

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -17,6 +17,7 @@
 set (SRC
     autodiff/backprop_function.cpp
     all_close_f.cpp
+    float_util.cpp
     test_tools.cpp
     test_control.cpp
 )

--- a/test/util/float_util.cpp
+++ b/test/util/float_util.cpp
@@ -35,7 +35,7 @@ union DoubleUnion {
 std::string ngraph::test::bfloat16_to_bits(bfloat16 f)
 {
     std::stringstream ss;
-    ss << std::bitset<16>(static_cast<uint16_t>(f));
+    ss << std::bitset<16>(f.get_bits());
     std::string unformatted = ss.str();
     std::string formatted;
     formatted.reserve(41);

--- a/test/util/float_util.cpp
+++ b/test/util/float_util.cpp
@@ -35,7 +35,7 @@ union DoubleUnion {
 std::string ngraph::test::bfloat16_to_bits(bfloat16 f)
 {
     std::stringstream ss;
-    ss << std::bitset<16>(f.get_bits());
+    ss << std::bitset<16>(f.to_bits());
     std::string unformatted = ss.str();
     std::string formatted;
     formatted.reserve(41);

--- a/test/util/float_util.cpp
+++ b/test/util/float_util.cpp
@@ -32,6 +32,29 @@ union DoubleUnion {
     uint64_t i;
 };
 
+std::string ngraph::test::bfloat16_to_bits(bfloat16 f)
+{
+    std::stringstream ss;
+    ss << std::bitset<16>(static_cast<uint16_t>(f));
+    std::string unformatted = ss.str();
+    std::string formatted;
+    formatted.reserve(41);
+    // Sign
+    formatted.push_back(unformatted[0]);
+    formatted.append("  ");
+    // Exponent
+    formatted.append(unformatted, 1, 8);
+    formatted.append("  ");
+    // Mantissa
+    formatted.append(unformatted, 9, 3);
+    for (int i = 12; i < 16; i += 4)
+    {
+        formatted.push_back(' ');
+        formatted.append(unformatted, i, 4);
+    }
+    return formatted;
+}
+
 std::string ngraph::test::float_to_bits(float f)
 {
     FloatUnion fu{f};
@@ -79,20 +102,18 @@ std::string ngraph::test::double_to_bits(double d)
     return formatted;
 }
 
-float ngraph::test::bits_to_bfloat16(const std::string& s)
+ngraph::bfloat16 ngraph::test::bits_to_bfloat16(const std::string& s)
 {
     std::string unformatted = s;
     unformatted.erase(remove_if(unformatted.begin(), unformatted.end(), ::isspace),
                       unformatted.end());
 
-    if (unformatted.size() != 32)
+    if (unformatted.size() != 16)
     {
-        throw ngraph_error("Input length must be 32");
+        throw ngraph_error("Input length must be 16");
     }
-    std::bitset<32> bs(unformatted);
-    FloatUnion fu;
-    fu.i = static_cast<uint32_t>(bs.to_ulong());
-    return fu.f;
+    std::bitset<16> bs(unformatted);
+    return bfloat16::from_bits(static_cast<uint16_t>(bs.to_ulong()));
 }
 
 float ngraph::test::bits_to_float(const std::string& s)

--- a/test/util/float_util.cpp
+++ b/test/util/float_util.cpp
@@ -1,0 +1,128 @@
+//*****************************************************************************
+// Copyright 2017-2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include "util/float_util.hpp"
+
+union FloatUnion {
+    FloatUnion() { i = 0; }
+    FloatUnion(float val) { f = val; }
+    FloatUnion(uint32_t val) { i = val; }
+    float f;
+    uint32_t i;
+};
+
+union DoubleUnion {
+    DoubleUnion() { i = 0; }
+    DoubleUnion(double val) { d = val; }
+    DoubleUnion(uint64_t val) { i = val; }
+    double d;
+    uint64_t i;
+};
+
+std::string ngraph::test::float_to_bits(float f)
+{
+    FloatUnion fu{f};
+    std::stringstream ss;
+    ss << std::bitset<32>(fu.i);
+    std::string unformatted = ss.str();
+    std::string formatted;
+    formatted.reserve(41);
+    // Sign
+    formatted.push_back(unformatted[0]);
+    formatted.append("  ");
+    // Exponent
+    formatted.append(unformatted, 1, 8);
+    formatted.append("  ");
+    // Mantissa
+    formatted.append(unformatted, 9, 3);
+    for (int i = 12; i < 32; i += 4)
+    {
+        formatted.push_back(' ');
+        formatted.append(unformatted, i, 4);
+    }
+    return formatted;
+}
+
+std::string ngraph::test::double_to_bits(double d)
+{
+    DoubleUnion du{d};
+    std::stringstream ss;
+    ss << std::bitset<64>(du.i);
+    std::string unformatted = ss.str();
+    std::string formatted;
+    formatted.reserve(80);
+    // Sign
+    formatted.push_back(unformatted[0]);
+    formatted.append("  ");
+    // Exponent
+    formatted.append(unformatted, 1, 11);
+    formatted.push_back(' ');
+    // Mantissa
+    for (int i = 12; i < 64; i += 4)
+    {
+        formatted.push_back(' ');
+        formatted.append(unformatted, i, 4);
+    }
+    return formatted;
+}
+
+float ngraph::test::bits_to_bfloat16(const std::string& s)
+{
+    std::string unformatted = s;
+    unformatted.erase(remove_if(unformatted.begin(), unformatted.end(), ::isspace),
+                      unformatted.end());
+
+    if (unformatted.size() != 32)
+    {
+        throw ngraph_error("Input length must be 32");
+    }
+    std::bitset<32> bs(unformatted);
+    FloatUnion fu;
+    fu.i = static_cast<uint32_t>(bs.to_ulong());
+    return fu.f;
+}
+
+float ngraph::test::bits_to_float(const std::string& s)
+{
+    std::string unformatted = s;
+    unformatted.erase(remove_if(unformatted.begin(), unformatted.end(), ::isspace),
+                      unformatted.end());
+
+    if (unformatted.size() != 32)
+    {
+        throw ngraph_error("Input length must be 32");
+    }
+    std::bitset<32> bs(unformatted);
+    FloatUnion fu;
+    fu.i = static_cast<uint32_t>(bs.to_ulong());
+    return fu.f;
+}
+
+double ngraph::test::bits_to_double(const std::string& s)
+{
+    std::string unformatted = s;
+    unformatted.erase(remove_if(unformatted.begin(), unformatted.end(), ::isspace),
+                      unformatted.end());
+
+    if (unformatted.size() != 64)
+    {
+        throw ngraph_error("Input length must be 64");
+    }
+    std::bitset<64> bs(unformatted);
+    DoubleUnion du;
+    du.i = static_cast<uint64_t>(bs.to_ullong());
+    return du.d;
+}

--- a/test/util/float_util.hpp
+++ b/test/util/float_util.hpp
@@ -1,0 +1,55 @@
+//*****************************************************************************
+// Copyright 2017-2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include <algorithm>
+#include <bitset>
+#include <cmath>
+#include <limits>
+#include <sstream>
+
+#include "ngraph/ngraph.hpp"
+
+namespace ngraph
+{
+    namespace test
+    {
+        union FloatUnion {
+            FloatUnion() { i = 0; }
+            FloatUnion(float val) { f = val; }
+            FloatUnion(uint32_t val) { i = val; }
+            float f;
+            uint32_t i;
+        };
+
+        union DoubleUnion {
+            DoubleUnion() { i = 0; }
+            DoubleUnion(double val) { d = val; }
+            DoubleUnion(uint64_t val) { i = val; }
+            double d;
+            uint64_t i;
+        };
+
+        std::string float_to_bits(float f);
+
+        std::string double_to_bits(double d);
+
+        float bits_to_bfloat16(const std::string& s);
+
+        float bits_to_float(const std::string& s);
+
+        double bits_to_double(const std::string& s);
+    }
+}

--- a/test/util/float_util.hpp
+++ b/test/util/float_util.hpp
@@ -42,11 +42,13 @@ namespace ngraph
             uint64_t i;
         };
 
+        std::string bfloat16_to_bits(bfloat16 f);
+
         std::string float_to_bits(float f);
 
         std::string double_to_bits(double d);
 
-        float bits_to_bfloat16(const std::string& s);
+        bfloat16 bits_to_bfloat16(const std::string& s);
 
         float bits_to_float(const std::string& s);
 


### PR DESCRIPTION
Added some unit tests for conversion to/from float as well as utils to convert bfloat to/from ascii binary strings. This involved moving some code from all_close_f to float_util.?pp files.

Added separate routines for `truncate`, `round_to_nearest`, and `round_to_nearest_even` and unit tests for each.

There was a bug in the cast to float operator which gave incorrect results.

Here are some timings from running on an LCR lab machine. I believe that the bulk of the time is from moving memory and that the computations for any of these is very fast in relationship to the move.

```
[INFO] 2019-04-01T17:49:39z test/bfloat16.cpp 144       buffer size 19267584 floats or 77070336 bytes
[INFO] 2019-04-01T17:49:39z test/bfloat16.cpp 157       float to bfloat16 ctor                  25ms
[INFO] 2019-04-01T17:49:39z test/bfloat16.cpp 171       float to bfloat16 truncate              24ms
[INFO] 2019-04-01T17:49:39z test/bfloat16.cpp 185       float to bfloat16 round to nearest      25ms
[INFO] 2019-04-01T17:49:39z test/bfloat16.cpp 199       float to bfloat16 round to nearest even 25ms
```
