### PR TITLE
[Standalone] Set MKLDNN kernel flag in ConvertLayout op.

### DIFF
--- a/src/ngraph/runtime/cpu/op/convert_layout.cpp
+++ b/src/ngraph/runtime/cpu/op/convert_layout.cpp
@@ -16,6 +16,7 @@
 
 #include "ngraph/runtime/cpu/op/convert_layout.hpp"
 #include "ngraph/runtime/cpu/cpu_layout_descriptor.hpp"
+#include "ngraph/runtime/cpu/mkldnn_utils.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -24,6 +25,7 @@ runtime::cpu::op::ConvertLayout::ConvertLayout(
     const shared_ptr<Node>& arg, const shared_ptr<runtime::cpu::LayoutDescriptor>& layout)
     : ConvertLayout(arg, 0, layout)
 {
+    runtime::cpu::mkldnn_utils::assign_mkldnn_kernel(this);
 }
 
 shared_ptr<Node>
@@ -44,6 +46,7 @@ runtime::cpu::op::ConvertLayout::ConvertLayout(
     , arg_output_index(output_index)
     , output_layout(layout)
 {
+    runtime::cpu::mkldnn_utils::assign_mkldnn_kernel(this);
     constructor_validate_and_infer_types();
 }
 


### PR DESCRIPTION
The previous approach that seemed to make more sense to everybody (https://github.com/NervanaSystems/ngraph/pull/2686) caused some problems out of the scope of this small change. I'm going back to the initial implementation that set the mkldnn flag for ConvertLayout in the constructor. We can address the op annotation issue separately, if needed.