### PR TITLE
Serialize cleanup

### DIFF
--- a/src/ngraph/serializer.cpp
+++ b/src/ngraph/serializer.cpp
@@ -122,6 +122,14 @@ using namespace std;
 using json = nlohmann::json;
 using const_data_callback_t = shared_ptr<Node>(const string&, const element::Type&, const Shape&);
 
+static bool s_serialize_output_shapes_enabled =
+    (std::getenv("NGRAPH_SERIALIZER_OUTPUT_SHAPES") != nullptr);
+
+void ngraph::set_serialize_output_shapes(bool enable)
+{
+    s_serialize_output_shapes_enabled = enable;
+}
+
 // This expands the op list in op_tbl.hpp into a list of enumerations that look like this:
 // Abs,
 // Acos,
@@ -465,7 +473,6 @@ static shared_ptr<ngraph::Function>
             vector<string> node_outputs = get_value<vector<string>>(node_js, "outputs");
             shared_ptr<Node> node;
             vector<shared_ptr<Node>> args;
-            // vector<shared_ptr<Node>> control_deps;
             for (const string& name : node_inputs)
             {
                 args.push_back(node_map.at(name));
@@ -1468,7 +1475,7 @@ static json write(const Node& n, bool binary_constant_data)
         node["outputs"] = outputs;
     }
 
-    if (std::getenv("NGRAPH_SERIALIZER_OUTPUT_SHAPES") != nullptr)
+    if (s_serialize_output_shapes_enabled)
     {
         json output_shapes = json::array();
         for (size_t i = 0; i < n.get_output_size(); ++i)

--- a/src/ngraph/serializer.cpp
+++ b/src/ngraph/serializer.cpp
@@ -1084,15 +1084,11 @@ static shared_ptr<ngraph::Function>
                 // This is a legacy field whose functionality is no longer supported. The new
                 // behavior is equivalent to interior padding of 0, so we will accept it under
                 // those conditions.
-                auto padding_interior_maybe = node_js.find("padding_interior");
-                if (padding_interior_maybe != node_js.end())
-                {
-                    auto padding_interior = padding_interior_maybe->get<vector<size_t>>();
-                    NGRAPH_CHECK(std::all_of(padding_interior.begin(),
-                                             padding_interior.end(),
-                                             [](size_t s) { return s == 0; }),
-                                 "Legacy padding_interior field must be zero everywhere.");
-                }
+                auto padding_interior = get_value<vector<size_t>>(node_js, "padding_interior");
+                NGRAPH_CHECK(std::all_of(padding_interior.begin(),
+                                         padding_interior.end(),
+                                         [](size_t s) { return s == 0; }),
+                             "Legacy padding_interior field must be zero everywhere.");
 
                 auto pad_mode = node_js.count("pad_mode") == 0
                                     ? op::PadMode::CONSTANT

--- a/src/ngraph/serializer.hpp
+++ b/src/ngraph/serializer.hpp
@@ -55,4 +55,10 @@ namespace ngraph
     /// \brief Deserialize a Function
     /// \param str The json formatted string to deseriailze.
     std::shared_ptr<ngraph::Function> deserialize(const std::string& str);
+
+    /// \brief If enabled adds output shapes to the serialized graph
+    /// \param enable Set to true to enable or false otherwise
+    ///
+    /// Option may be enabled by setting the environment variable NGRAPH_SERIALIZER_OUTPUT_SHAPES
+    void set_serialize_output_shapes(bool enable);
 }

--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -204,6 +204,10 @@ TEST(benchmark, serialize)
     shared_ptr<Function> f = ngraph::deserialize(json_string);
     timer.stop();
     cout << "deserialize took " << timer.get_milliseconds() << "ms\n";
+
+    ngraph::set_serialize_output_shapes(true);
+    ofstream out("test.json");
+    out << serialize(f, 4);
 }
 
 MATCHER_P2(IsOutputShape, type, shape, "")


### PR DESCRIPTION
Add new function `get_value` that checks for the existence of a value and then gets the value or returns a default constructed value.
Don't serialize `input`, `output`, or `control_deps` if they are empty. Deserialize handles these missing values by creating empty values.