### PR TITLE
Provenance without post-dominated

### DIFF
--- a/src/ngraph/graph_util.cpp
+++ b/src/ngraph/graph_util.cpp
@@ -157,15 +157,6 @@ void ngraph::replace_node(std::shared_ptr<Node> target, std::shared_ptr<Node> re
         };
 
         traverse_nodes({target}, set_replacement_prov, false, replacement->get_arguments());
-
-        auto propagate_replacement_prov = [replacement](std::shared_ptr<Node> node) {
-            if (is_post_dominated(node.get(), replacement.get()))
-            {
-                node->merge_provenance_tags_from(replacement);
-            }
-        };
-
-        traverse_nodes({replacement}, propagate_replacement_prov, false);
     }
 
     // For each of target's output O with replacement output O_rep:

--- a/test/provenance.cpp
+++ b/test/provenance.cpp
@@ -209,48 +209,4 @@ TEST(provenance, provenance)
 
         EXPECT_EQ(d->get_provenance_tags(), (ProvSet{"tag_a", "tag_b", "tag_c"}));
     }
-
-    //
-    // Before:
-    //
-    //   A{tag_a}  B{tag_b}
-    //         |   |
-    //        C{tag_c}
-    //
-    // Replacement:
-    //
-    //        D{}
-    //         |
-    //   C -> E{}
-    //
-    // After:
-    //
-    //   D{tag_a,tag_b,tag_c}
-    //   |
-    //   E{tag_a,tag_b,tag_c}
-    //
-    // Comment:
-    //   * E is the replacement root, and its insertion kills A, B, and C.
-    //   * D is post-dominated by E, so the tags inherited by E should also be taken on by D.
-    //
-    {
-        auto x = make_shared<op::Parameter>(element::i32, PartialShape{2, 3, 4});
-        auto y = make_shared<op::Parameter>(element::i32, PartialShape{2, 3, 4});
-
-        auto a = make_shared<op::Add>(x, y);
-        a->add_provenance_tag("tag_a");
-        auto b = make_shared<op::Multiply>(y, x);
-        b->add_provenance_tag("tag_b");
-        auto c = make_shared<op::Subtract>(a, b);
-        c->add_provenance_tag("tag_c");
-
-        auto f = make_shared<Function>(c, ParameterVector{x, y});
-
-        auto d = make_zero(element::i32, Shape{2, 3, 4});
-        auto e = make_shared<op::Negative>(d);
-        replace_node(c, e);
-
-        EXPECT_EQ(d->get_provenance_tags(), (ProvSet{"tag_a", "tag_b", "tag_c"}));
-        EXPECT_EQ(e->get_provenance_tags(), (ProvSet{"tag_a", "tag_b", "tag_c"}));
-    }
 }


### PR DESCRIPTION
Removes provenance tag propagation to nodes post-dominated by replaced nodes.