### PR TITLE
Reshape elimination optimization

### DIFF
--- a/src/ngraph/pass/manager.cpp
+++ b/src/ngraph/pass/manager.cpp
@@ -170,7 +170,7 @@ void pass::Manager::run_passes(shared_ptr<Function> func, bool transitive)
 
             if (m_visualize)
             {
-                pass::VisualizeTree vt(base_filename);
+                pass::VisualizeTree vt(base_filename + ".pdf");
                 vt.set_ops_to_details(get_state().get_visualize_tree_ops_map());
                 vt.run_on_module(f_array);
             }

--- a/src/ngraph/pass/manager.cpp
+++ b/src/ngraph/pass/manager.cpp
@@ -170,7 +170,9 @@ void pass::Manager::run_passes(shared_ptr<Function> func, bool transitive)
 
             if (m_visualize)
             {
-                pass::VisualizeTree vt(base_filename + ".pdf");
+                auto format = std::getenv("NGRAPH_VISUALIZE_TRACING_FORMAT");
+                auto file_ext = format ? std::string(format) : std::string("svg");
+                pass::VisualizeTree vt(base_filename + std::string(".") + file_ext);
                 vt.set_ops_to_details(get_state().get_visualize_tree_ops_map());
                 vt.run_on_module(f_array);
             }

--- a/src/ngraph/pass/reshape_elimination.cpp
+++ b/src/ngraph/pass/reshape_elimination.cpp
@@ -95,28 +95,30 @@ void pass::ReshapeElimination::construct_reshapex2_pattern()
         auto r2 = static_pointer_cast<op::Reshape>(m.get_match_root());
         auto r1 = static_pointer_cast<op::Reshape>(r2->get_argument(0));
 
-        // First reshape transposes and second reshape only changes shape
-        // Replace with a transpose that changes shape
-        if (apply_permutation(gop->get_shape(), r1->get_input_order()) == r2->get_shape() &&
-            r2->get_input_order() == get_default_order(r1->get_shape()) &&
-            r1->get_users().size() == 1)
+        if (gop->get_shape() != m.get_match_root()->get_shape())
         {
-            replace_node(m.get_match_root(),
-                         make_shared<op::Reshape>(gop, r1->get_input_order(), r2->get_shape()));
-            return true;
+            // First reshape transposes and second reshape only changes shape
+            // Replace with a transpose that changes shape
+            if (apply_permutation(gop->get_shape(), r1->get_input_order()) == r2->get_shape() &&
+                r2->get_input_order() == get_default_order(r1->get_shape()) &&
+                r1->get_users().size() == 1)
+            {
+                replace_node(m.get_match_root(),
+                             make_shared<op::Reshape>(gop, r1->get_input_order(), r2->get_shape()));
+                return true;
+            }
+            else
+            {
+                NGRAPH_DEBUG << "Operand shape doesn't match the shape of the second reshape!";
+                NGRAPH_DEBUG << "gop " << gop->get_name()
+                             << "shape = " << vector_to_string(gop->get_shape());
+                NGRAPH_DEBUG << "match_root " << m.get_match_root()->get_name()
+                             << "shape = " << vector_to_string(m.get_match_root()->get_shape());
+                return false;
+            }
         }
 
         // Check for sequence of reshapes/transposes that cancel out.
-        if (gop->get_shape() != m.get_match_root()->get_shape())
-        {
-            NGRAPH_DEBUG << "Operand shape doesn't match the shape of the second reshape!";
-            NGRAPH_DEBUG << "gop " << gop->get_name()
-                         << "shape = " << vector_to_string(gop->get_shape());
-            NGRAPH_DEBUG << "match_root " << m.get_match_root()->get_name()
-                         << "shape = " << vector_to_string(m.get_match_root()->get_shape());
-            return false;
-        }
-
         auto do_r2 = get_default_order(r1->get_shape());
         auto do_r1 = get_default_order(gop->get_shape());
 

--- a/src/ngraph/pass/reshape_elimination.cpp
+++ b/src/ngraph/pass/reshape_elimination.cpp
@@ -92,6 +92,21 @@ void pass::ReshapeElimination::construct_reshapex2_pattern()
 
         auto gop = pattern_map[op];
 
+        auto r2 = static_pointer_cast<op::Reshape>(m.get_match_root());
+        auto r1 = static_pointer_cast<op::Reshape>(r2->get_argument(0));
+
+        // First reshape transposes and second reshape only changes shape
+        // Replace with a transpose that changes shape
+        if (apply_permutation(gop->get_shape(), r1->get_input_order()) == r2->get_shape() &&
+            r2->get_input_order() == get_default_order(r1->get_shape()) &&
+            r1->get_users().size() == 1)
+        {
+            replace_node(m.get_match_root(),
+                         make_shared<op::Reshape>(gop, r1->get_input_order(), r2->get_shape()));
+            return true;
+        }
+
+        // Check for sequence of reshapes/transposes that cancel out.
         if (gop->get_shape() != m.get_match_root()->get_shape())
         {
             NGRAPH_DEBUG << "Operand shape doesn't match the shape of the second reshape!";
@@ -101,9 +116,6 @@ void pass::ReshapeElimination::construct_reshapex2_pattern()
                          << "shape = " << vector_to_string(m.get_match_root()->get_shape());
             return false;
         }
-
-        auto r2 = dynamic_pointer_cast<op::Reshape>(m.get_match_root());
-        auto r1 = dynamic_pointer_cast<op::Reshape>(r2->get_argument(0));
 
         auto do_r2 = get_default_order(r1->get_shape());
         auto do_r1 = get_default_order(gop->get_shape());

--- a/src/ngraph/runtime/cpu/cpu_external_function.cpp
+++ b/src/ngraph/runtime/cpu/cpu_external_function.cpp
@@ -1194,7 +1194,8 @@ void runtime::cpu::CPU_ExternalFunction::register_common_passes(
     REGISTER_KNOBBED_PASS(BatchFusion, true, ngraph::pass);
     REGISTER_KNOBBED_PASS(CPUBatchFusion, true, runtime::cpu::pass);
     REGISTER_KNOBBED_PASS(ReshapeSinking, false, ngraph::pass);
-    REGISTER_KNOBBED_PASS(ReshapeElimination, false, ngraph::pass);
+    REGISTER_KNOBBED_PASS(ReshapeElimination, true, ngraph::pass);
+    REGISTER_KNOBBED_PASS(RecurrentReshapeElimination, false, ngraph::pass);
     REGISTER_KNOBBED_PASS_WITH_ARGS(
         CoreFusion, true, ngraph::pass, ngraph::pass::FusionType::ALL_FUSIONS);
     REGISTER_KNOBBED_PASS_WITH_ARGS(FusedOpDecomposition, true, ngraph::pass, is_supported);

--- a/src/ngraph/runtime/cpu/cpu_visualize_tree.cpp
+++ b/src/ngraph/runtime/cpu/cpu_visualize_tree.cpp
@@ -45,6 +45,10 @@ static void visualize_layout_format(const Node& node, ostream& ss)
         {
             return;
         }
+        if (auto reshape = dynamic_cast<const op::Reshape*>(&node))
+        {
+            ss << "\ninput_order=" << reshape->get_input_order();
+        }
         ss << "\nin="
            << runtime::cpu::mkldnn_utils::get_mkldnn_format_string(
                   static_cast<mkldnn::memory::format>(in_tvl->get_mkldnn_md().data.format));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21375855/58839676-8aa5c400-8617-11e9-97e4-e433d096b6da.png)

Replaces Reshape_1000 and Reshape_1003 with a single transpose-based reshape.

Also snuck in a change to get NGRAPH_ENABLE_VISUALIZE_TRACING working again.