### PR TITLE
Use updated reduced-size clDNN

### DIFF
--- a/cmake/external_cldnn.cmake
+++ b/cmake/external_cldnn.cmake
@@ -23,7 +23,6 @@ include(ExternalProject)
 
 set(CLDNN_GIT_REPO_URL https://github.com/intel/clDNN.git)
 set(CLDNN_GIT_LABEL 7cdec74c3307bbe98c5c0b7bd0e17536f60a3c12)
-set(BOOST_VERSION 1.64.0)
 set(OUT_DIR ${EXTERNAL_PROJECTS_ROOT}/cldnn/out)
 
 ExternalProject_Add(
@@ -41,7 +40,6 @@ ExternalProject_Add(
                 ${NGRAPH_FORWARD_CMAKE_ARGS}
                 -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                 # -DCLDNN__OUTPUT_DIR=out/Debug
-                -DCLDNN__BOOST_VERSION=${BOOST_VERSION}
                 -DCLDNN__INCLUDE_TESTS=OFF
                 -DCLDNN__INCLUDE_CORE_INTERNAL_TESTS=OFF
                 -DCLDNN__INCLUDE_TUTORIAL=OFF

--- a/cmake/external_cldnn.cmake
+++ b/cmake/external_cldnn.cmake
@@ -22,7 +22,7 @@ include(ExternalProject)
 #------------------------------------------------------------------------------
 
 set(CLDNN_GIT_REPO_URL https://github.com/intel/clDNN.git)
-set(CLDNN_GIT_LABEL a05c9f29c5690a4beb9cd8c9f712cfb4399b2a6d)
+set(CLDNN_GIT_LABEL 7cdec74c3307bbe98c5c0b7bd0e17536f60a3c12)
 set(BOOST_VERSION 1.64.0)
 set(OUT_DIR ${EXTERNAL_PROJECTS_ROOT}/cldnn/out)
 


### PR DESCRIPTION
This PR updates clDNN to the newest version, which is stripped from boost. The updated version, when built, is only ~7MB, while the current - 350MB.