### PR TITLE
Change for better user experience with json option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,10 +427,6 @@ if(NGRAPH_DEPRECATED_ENABLE)
     add_definitions(-DNGRAPH_DEPRECATED_ENABLE)
 endif()
 
-if(NGRAPH_JSON_ENABLE)
-    add_definitions(-DNGRAPH_JSON_ENABLE)
-endif()
-
 add_definitions(-DPROJECT_ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
 #-----------------------------------------------------------------------------------------------

--- a/src/ngraph/CMakeLists.txt
+++ b/src/ngraph/CMakeLists.txt
@@ -503,6 +503,11 @@ else()
     add_library(ngraph SHARED ${SRC})
 endif()
 
+if(NOT NGRAPH_JSON_ENABLE)
+    message(STATUS "************************************ JSON Disabled")
+    target_compile_definitions(NGRAPH_JSON_DISABLE)
+endif()
+
 if(NGRAPH_DISTRIBUTED_ENABLE)
     if(NGRAPH_DISTRIBUTED_MLSL_ENABLE)
         target_include_directories(ngraph SYSTEM PRIVATE libmlsl)

--- a/src/ngraph/CMakeLists.txt
+++ b/src/ngraph/CMakeLists.txt
@@ -504,8 +504,7 @@ else()
 endif()
 
 if(NOT NGRAPH_JSON_ENABLE)
-    message(STATUS "************************************ JSON Disabled")
-    target_compile_definitions(NGRAPH_JSON_DISABLE)
+    target_compile_definitions(ngraph PUBLIC NGRAPH_JSON_DISABLE)
 endif()
 
 if(NGRAPH_DISTRIBUTED_ENABLE)

--- a/src/ngraph/pass/serialize.cpp
+++ b/src/ngraph/pass/serialize.cpp
@@ -19,7 +19,7 @@
 #include "ngraph/file_util.hpp"
 #include "ngraph/pass/serialize.hpp"
 #include "ngraph/util.hpp"
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 #include "ngraph/serializer.hpp"
 #include "nlohmann/json.hpp"
 #endif
@@ -34,7 +34,7 @@ pass::Serialization::Serialization(const string& name)
 
 bool pass::Serialization::run_on_module(vector<shared_ptr<Function>>& functions)
 {
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
     // serializing the outermost functions
     // also implicitly serializes any inner functions
     serialize(m_name, functions.at(0), 4);

--- a/src/ngraph/runtime/cpu/cpu_tracing.cpp
+++ b/src/ngraph/runtime/cpu/cpu_tracing.cpp
@@ -19,7 +19,7 @@
 
 #include "cpu_tracing.hpp"
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 void ngraph::runtime::cpu::to_json(nlohmann::json& json, const TraceEvent& event)
 {
     std::map<std::string, std::string> args;

--- a/src/ngraph/runtime/cpu/cpu_tracing.hpp
+++ b/src/ngraph/runtime/cpu/cpu_tracing.hpp
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include "ngraph/runtime/cpu/cpu_external_function.hpp"
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 #include "nlohmann/json.hpp"
 #endif
 
@@ -67,7 +67,7 @@ namespace ngraph
                 {
                 }
             };
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
             void to_json(nlohmann::json& json, const TraceEvent& event);
 #endif
 

--- a/src/ngraph/serializer.hpp
+++ b/src/ngraph/serializer.hpp
@@ -63,7 +63,7 @@ namespace ngraph
     void set_serialize_output_shapes(bool enable);
 }
 
-#ifndef NGRAPH_JSON_DISABLE
+#ifdef NGRAPH_JSON_DISABLE
 // Rather than making every reference to the serializer conditionally compile here we just
 // provide some null stubs to resolve link issues
 // The `inline` is so we don't get multiple definitions of function

--- a/src/ngraph/serializer.hpp
+++ b/src/ngraph/serializer.hpp
@@ -63,7 +63,7 @@ namespace ngraph
     void set_serialize_output_shapes(bool enable);
 }
 
-#ifndef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 // Rather than making every reference to the serializer conditionally compile here we just
 // provide some null stubs to resolve link issues
 // The `inline` is so we don't get multiple definitions of function

--- a/test/backend_api.cpp
+++ b/test/backend_api.cpp
@@ -37,7 +37,7 @@ TEST(backend_api, invalid_name)
     ASSERT_ANY_THROW(ngraph::runtime::Backend::create("COMPLETELY-BOGUS-NAME"));
 }
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 TEST(backend_api, save_load)
 {
     Shape shape{2, 2};

--- a/test/backend_broadcast.in.cpp
+++ b/test/backend_broadcast.in.cpp
@@ -462,7 +462,7 @@ NGRAPH_TEST(${BACKEND_NAME}, broadcast_matrix_2)
                                   MIN_FLOAT_TOLERANCE_BITS));
 }
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 NGRAPH_TEST(${BACKEND_NAME}, constant_broadcast)
 {
     const string js =

--- a/test/backend_test.in.cpp
+++ b/test/backend_test.in.cpp
@@ -6070,7 +6070,7 @@ NGRAPH_TEST(${BACKEND_NAME}, batch_norm_bprop_n4c3h2w2)
     auto df = make_shared<Function>(NodeVector{dinput, dgamma, dbeta},
                                     ParameterVector{mean, var, input, gamma, beta, C});
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
     // roundtrip serialization
     string js = serialize(df, 4);
     istringstream in(js);

--- a/test/control_dependencies.cpp
+++ b/test/control_dependencies.cpp
@@ -162,7 +162,7 @@ TEST(control_dependencies, clone_function_cdop_abs)
     }
 }
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 TEST(control_dependencies, serialize_cdop)
 {
     auto A = make_shared<op::Parameter>(element::f32, Shape{});

--- a/test/core_fusion.cpp
+++ b/test/core_fusion.cpp
@@ -62,7 +62,7 @@ TEST(core_fusion, core_fusion_pass_basic)
     ASSERT_NE(std::dynamic_pointer_cast<op::Relu>(graph->get_argument(0)), nullptr);
 }
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 TEST(core_fusion, sigmoid_fprop_fusion)
 {
     pass::Manager pass_manager;

--- a/test/cpu_fusion.cpp
+++ b/test/cpu_fusion.cpp
@@ -3607,7 +3607,7 @@ TEST(cpu_quant_fusion, qconvba)
     EXPECT_TRUE(test::all_close(cpu1_results.at(0), cpu2_results.at(0)));
 }
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 // Tests that rely on deserializing json files
 TEST(cpu_fusion, fuse_conv_bias)
 {
@@ -3973,7 +3973,7 @@ TEST(cpu_fusion, validate_fuse_gru_inputs)
     }
 }
 
-#if defined(AUTODIFF_BACKEND_CPU) && defined(NGRAPH_JSON_ENABLE)
+#if defined(AUTODIFF_BACKEND_CPU) && !defined(NGRAPH_JSON_DISABLE)
 NGRAPH_TEST(cpu_fusion, backwards_batchmatmultranspose_tensor2_tensor2)
 {
     auto backend = runtime::Backend::create("CPU");

--- a/test/gpu_fusion.cpp
+++ b/test/gpu_fusion.cpp
@@ -128,7 +128,7 @@ TEST(gpu_fusion, rnn_fprop_1_lstm_cell)
 }
 #endif
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 TEST(gpu_fusion, fuse_lstm_cells)
 {
     pass::Manager pass_manager;
@@ -421,7 +421,7 @@ TEST(gpu_fusion, fuse_2_layer_rnn_1lstm_analytic)
     EXPECT_TRUE(test::all_close(std::vector<float>{ct_val_second}, read_vector<float>(result_ct)));
 }
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 TEST(gpu_fusion, rnn_fusion_inter_vs_gpu_1lstm_cell)
 {
     const std::string file_name("mxnet/1_lstm_cell_forward.json");

--- a/test/reshape_elimination.cpp
+++ b/test/reshape_elimination.cpp
@@ -44,7 +44,7 @@
 using namespace ngraph;
 using namespace std;
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 TEST(reshape_elimination, remove_reshape)
 {
     pass::Manager pass_manager;

--- a/test/reshape_sinking.cpp
+++ b/test/reshape_sinking.cpp
@@ -110,7 +110,7 @@ TEST(reshape_sinking, broadcast_swimming)
     ASSERT_EQ(add->get_argument(1), conv);
 }
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 TEST(reshape_sinking, mnist_conv)
 {
     const string json_path = file_util::path_join(SERIALIZED_ZOO, "tf_conv_mnist_nhwc.json");

--- a/test/util/test_tools.cpp
+++ b/test/util/test_tools.cpp
@@ -303,7 +303,7 @@ string get_results_str(const std::vector<char>& ref_data,
     return ss.str();
 }
 
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 std::shared_ptr<Function> make_function_from_file(const std::string& file_name)
 {
     const string json_path = file_util::path_join(SERIALIZED_ZOO, file_name);

--- a/test/util/test_tools.hpp
+++ b/test/util/test_tools.hpp
@@ -40,7 +40,7 @@ namespace ngraph
 
 bool validate_list(const std::list<std::shared_ptr<ngraph::Node>>& nodes);
 std::shared_ptr<ngraph::Function> make_test_graph();
-#ifdef NGRAPH_JSON_ENABLE
+#ifndef NGRAPH_JSON_DISABLE
 std::shared_ptr<ngraph::Function> make_function_from_file(const std::string& file_name);
 #endif
 


### PR DESCRIPTION
Code on master requires users that are in external repos to define the NGRAPH_JSON_ENABLE flag as a compiler definition in order to use json. This is not the desired behavior.

This PR changes it so that doing nothing allows you to use the json library, just as it was before the json disable feature was added. The cmake option is unchanged.