### PR TITLE
Fix corner case for zero-element constant construction

### DIFF
--- a/src/ngraph/op/constant.hpp
+++ b/src/ngraph/op/constant.hpp
@@ -102,10 +102,7 @@ namespace ngraph
                         std::vector<int64_t> dvalues = parse_string<int64_t>(values);
                         if (values.size() == 1 && shape_size(m_shape) != 1)
                         {
-                            for (size_t i = 1; i < shape_size(m_shape); i++)
-                            {
-                                dvalues.push_back(dvalues[0]);
-                            }
+                            dvalues = std::vector<int64_t>(shape_size(m_shape), dvalues[0]);
                         }
                         write_values(dvalues);
                     }
@@ -114,10 +111,7 @@ namespace ngraph
                         std::vector<uint64_t> dvalues = parse_string<uint64_t>(values);
                         if (values.size() == 1 && shape_size(m_shape) != 1)
                         {
-                            for (size_t i = 1; i < shape_size(m_shape); i++)
-                            {
-                                dvalues.push_back(dvalues[0]);
-                            }
+                            dvalues = std::vector<uint64_t>(shape_size(m_shape), dvalues[0]);
                         }
                         write_values(dvalues);
                     }
@@ -127,10 +121,7 @@ namespace ngraph
                     std::vector<double> dvalues = parse_string<double>(values);
                     if (values.size() == 1 && shape_size(m_shape) != 1)
                     {
-                        for (size_t i = 1; i < shape_size(m_shape); i++)
-                        {
-                            dvalues.push_back(dvalues[0]);
-                        }
+                        dvalues = std::vector<double>(shape_size(m_shape), dvalues[0]);
                     }
                     write_values(dvalues);
                 }

--- a/test/type_prop.cpp
+++ b/test/type_prop.cpp
@@ -3635,6 +3635,14 @@ TEST(type_prop, tensor_constant_bad_count)
     }
 }
 
+TEST(type_prop, constant_zero_elements_one_string)
+{
+    auto c =
+        make_shared<op::Constant>(element::i64, Shape{2, 0, 2, 2}, std::vector<std::string>{"42"});
+    ASSERT_EQ(c->get_element_type(), element::i64);
+    ASSERT_EQ(c->get_shape(), (Shape{2, 0, 2, 2}));
+}
+
 TEST(type_prop, replace_slice_deduce_vector)
 {
     auto param0 = make_shared<op::Parameter>(element::f32, Shape{6});


### PR DESCRIPTION
When op::Constant's ctor is called with a zero-element shape and a one-element vector of strings, the logic to "broadcast" the single element fails, resulting in an error in `write_values`. This PR fixes that.