### PR TITLE
Removed deprecated fusion type constants.

### DIFF
--- a/src/ngraph/pass/pass.hpp
+++ b/src/ngraph/pass/pass.hpp
@@ -48,16 +48,6 @@ namespace ngraph
         };
         typedef EnumMask<FusionType> FusionTypeMask;
 
-        // These constants are for backward compatibility only, will deprecate soon.
-        NGRAPH_DEPRECATED("use FusionType enum class instead")
-        constexpr FusionType DIFFERENTIABLE_FUSIONS = FusionType::DIFFERENTIABLE_FUSIONS;
-        NGRAPH_DEPRECATED("use FusionType enum class instead")
-        constexpr FusionType REGULAR_FUSIONS = FusionType::REGULAR_FUSIONS;
-        NGRAPH_DEPRECATED("use FusionType enum class instead")
-        constexpr FusionType FOP_FUSIONS = FusionType::FOP_FUSIONS;
-        NGRAPH_DEPRECATED("use FusionType enum class instead")
-        constexpr FusionType ALL_FUSIONS = FusionType::ALL_FUSIONS;
-
         enum class PassProperty : uint32_t
         {
             // Pass requires node shapes to be static


### PR DESCRIPTION
Removing pass fusion type constants which were replaced by enum class types. The fusion type macro were deprecated two releases ago.