### PR TITLE
Update setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -381,7 +381,7 @@ setup(
     packages=packages,
     cmdclass={'build_ext': BuildExt},
     data_files=data_files,
-    setup_requires=['numpy'],
+    setup_requires=['numpy==1.16.4'],
     install_requires=requirements,
     zip_safe=False,
     extras_require={


### PR DESCRIPTION
This is to make sure numpy 1.17.0rc1 does not get installed - before - requirements.txt is checked. That's apparently what happened so far (since numpy 1.17.0rc1 was uploaded to pypi on June 30th). Numpy 1.17.0rc1 does not support python2.7. Not sure if that's for this rc only, or for all upcoming numpy wheels from now on.