### PR TITLE
pydocstyle 4.0 breaks flake8-docstrings.

### DIFF
--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -1,5 +1,6 @@
 pytest
 tox
+pydocstyle==3.0.0
 flake8
 flake8-commas
 flake8-comprehensions


### PR DESCRIPTION
pydocstyle 4.0.0 (release 7/6/2019) removed tokenize_open 
travis-ci for python 3 fails because of this change to pydocstyle
https://travis-ci.org/NervanaSystems/ngraph/jobs/555082804
https://github.com/PyCQA/pydocstyle/commit/4948f22d962d422733b1edadc0852a53444d8a37