### PR TITLE
pydocstyle 4.0 breaks flake8-docstrings.

### DIFF
--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -1,5 +1,6 @@
 pytest
 tox
+pydocstyle==3.0.0
 flake8
 flake8-commas
 flake8-comprehensions


### PR DESCRIPTION
#3183 on r0.23