### PR TITLE
Update jenkins-trigger.groovy

### DIFF
--- a/.ci/jenkins/jenkins-trigger.groovy
+++ b/.ci/jenkins/jenkins-trigger.groovy
@@ -24,7 +24,7 @@
 // Parameters which ngraph-unittest uses:
 String  PR_URL = CHANGE_URL
 String  PR_COMMIT_AUTHOR = CHANGE_AUTHOR
-String  JENKINS_BRANCH = "master"
+String  JENKINS_BRANCH = "aslepko/r0.21.1"
 Integer TIMEOUTTIME = "3600"
 // BRANCH parameter is no loner needed
 // TRIGGER_URL parameter is no longer needed


### PR DESCRIPTION
Switching jenkins branch from mater to aslepko/r0.21.1 to use older test scripts (from the time r0.20 originated).