### PR TITLE
Make is_commutative method const and override it for some ops

### DIFF
--- a/src/ngraph/node.hpp
+++ b/src/ngraph/node.hpp
@@ -214,7 +214,7 @@ namespace ngraph
         virtual bool is_constant() const;
         virtual bool is_null() const { return false; }
         virtual bool is_op() const { return false; }
-        virtual bool is_commutative() { return false; }
+        virtual bool is_commutative() const { return false; }
         virtual bool is_dynamic() const;
         virtual bool has_state() const { return false; }
         size_t get_instance_id() const { return m_instance_id; }

--- a/src/ngraph/op/add.hpp
+++ b/src/ngraph/op/add.hpp
@@ -51,10 +51,11 @@ namespace ngraph
 
             std::shared_ptr<Node> copy_with_new_args(const NodeVector& new_args) const override;
 
+            virtual bool is_commutative() const override { return true; }
+
         protected:
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
-            virtual bool is_commutative() override { return true; }
         };
     }
 

--- a/src/ngraph/op/and.hpp
+++ b/src/ngraph/op/and.hpp
@@ -51,8 +51,7 @@ namespace ngraph
 
             std::shared_ptr<Node> copy_with_new_args(const NodeVector& new_args) const override;
 
-        protected:
-            virtual bool is_commutative() override { return true; }
+            virtual bool is_commutative() const override { return true; }
         };
     }
 }

--- a/src/ngraph/op/equal.hpp
+++ b/src/ngraph/op/equal.hpp
@@ -56,6 +56,8 @@ namespace ngraph
 
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
+
+            virtual bool is_commutative() const override { return true; }
         };
     }
 }

--- a/src/ngraph/op/maximum.hpp
+++ b/src/ngraph/op/maximum.hpp
@@ -38,7 +38,8 @@ namespace ngraph
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
 
-            virtual bool is_commutative() override { return true; }
+            virtual bool is_commutative() const override { return true; }
+
         protected:
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;

--- a/src/ngraph/op/minimum.hpp
+++ b/src/ngraph/op/minimum.hpp
@@ -38,6 +38,8 @@ namespace ngraph
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
 
+            virtual bool is_commutative() const override { return true; }
+
         protected:
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;

--- a/src/ngraph/op/multiply.hpp
+++ b/src/ngraph/op/multiply.hpp
@@ -38,10 +38,11 @@ namespace ngraph
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
 
+            virtual bool is_commutative() const override { return true; }
+
         protected:
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
-            virtual bool is_commutative() override { return true; }
         };
     };
 

--- a/src/ngraph/op/not_equal.hpp
+++ b/src/ngraph/op/not_equal.hpp
@@ -37,6 +37,8 @@ namespace ngraph
 
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
+
+            virtual bool is_commutative() const override { return true; }
         };
     }
 }

--- a/src/ngraph/op/or.hpp
+++ b/src/ngraph/op/or.hpp
@@ -46,8 +46,7 @@ namespace ngraph
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
 
-        protected:
-            virtual bool is_commutative() override { return true; }
+            virtual bool is_commutative() const override { return true; }
         };
     }
 }


### PR DESCRIPTION
* Qualify `is_commutative` method with `const`
* Override it for `Equal`, `Minumum`, `NotEqual` ops
* Ensure that all overrides of the method are `public`