### PR TITLE
[MLIR] Fix warnings in MLIR code.

### DIFF
--- a/src/contrib/mlir/lowerer.cpp
+++ b/src/contrib/mlir/lowerer.cpp
@@ -350,6 +350,7 @@ namespace
         }
         return callBackFuncPtr;
     }
+
     // NGDialect converters
     Type NGraphTypeConverter::convertType(Type type)
     {
@@ -576,7 +577,6 @@ namespace
         // Create Value for result, and extract type info.
         Value* result = m_pass.buildOutputDefs(op, rewriter)[0];
         NGRAPH_CHECK(result, "Unexpected null result in ConcatOp");
-        auto resultTy = result->getType().cast<MemRefType>();
 
         // Create view to write into result.
         MemRefView vRes(result);
@@ -590,7 +590,6 @@ namespace
         for (auto& operand : operands)
         {
             NGRAPH_CHECK(operand, "Unexpected null operand in ConcatOp");
-            auto operandTy = result->getType().cast<MemRefType>();
 
             // Assuming rank = r, and the concatenation axis is A where A<r, we'll be creating
             // loops of this form:

--- a/src/contrib/mlir/pass/mlir_subgraph_extraction.cpp
+++ b/src/contrib/mlir/pass/mlir_subgraph_extraction.cpp
@@ -74,7 +74,6 @@ void MLIRSubgraphExtractionPass::MLIRSubgraph::merge(MLIRSubgraph& sg2)
 
     // Associate nodes of second sub-graph to first one
     auto sg_nodes = sg2.get_nodes();
-    auto& node_map = m_pass.m_node_to_graph;
     for (auto node : sg_nodes)
     {
         NGRAPH_DEBUG << *node;
@@ -112,7 +111,6 @@ bool MLIRSubgraphExtractionPass::run_on_function(std::shared_ptr<Function> func)
     for (auto op : func->get_ordered_ops())
     {
         NodeVector inputs;
-        int first_graph_id = -1;
         std::unordered_set<int> subgraph_ids;
         // unsupported ops, skip
         if (!is_supported_mlir_op(op))


### PR DESCRIPTION
There are also the following warnings I didn't fix in case functions are needed:
```
/localdisk/dcaballe/ngraph-mlir-pr/src/contrib/mlir/lowerer.cpp:337:21: warning: ‘mlir::Function* {anonymous}::DialectLoweringPass::getCallDecl(llvm::StringRef, llvm
::ArrayRef<mlir::Type>, llvm::ArrayRef<mlir::Type>, mlir::PatternRewriter&)’ defined but not used [-Wunused-function]
     mlir::Function* DialectLoweringPass::getCallDecl(StringRef name,
                     ^~~~~~~~~~~~~~~~~~~
/localdisk/dcaballe/ngraph-mlir-pr/src/contrib/mlir/lowerer.cpp:210:12: warning: ‘mlir::Value* {anonymous}::DialectLoweringPass::insertMemMgrDef(mlir::PatternRewrite
r*)’ defined but not used [-Wunused-function]
     Value* DialectLoweringPass::insertMemMgrDef(PatternRewriter* rewriter)
            ^~~~~~~~~~~~~~~~~~~
```

Please, let me know if that is not the case and I'll remove them.

Thanks!
Diego