### PR TITLE
Fix version number parsing when latest tag is not vxx.yy.zz

### DIFF
--- a/cmake/Modules/git_tags.cmake
+++ b/cmake/Modules/git_tags.cmake
@@ -53,7 +53,7 @@ endfunction()
 function(NGRAPH_GET_MOST_RECENT_TAG)
     find_package(Git REQUIRED)
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+        COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --match v*.*.*
         RESULT_VARIABLE RESULT
         OUTPUT_VARIABLE TAG
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
As of right now the newest tag is called `nbench_db`, which our CMake stuff can't parse when it tries to populate the version number info. This seems to work around it (it finds the most recent tag of the form `v*.*.*`).