### PR TITLE
Fix for Allocator lifetime in CPU backend

### DIFF
--- a/src/ngraph/runtime/allocator.cpp
+++ b/src/ngraph/runtime/allocator.cpp
@@ -32,7 +32,7 @@ void* ngraph::runtime::DefaultAllocator::malloc(size_t size, size_t alignment)
     if (!ptr)
     {
         throw ngraph::ngraph_error("malloc failed to allocate memory of size " +
-                                    std::to_string(size));
+                                   std::to_string(size));
     }
     return ptr;
 }

--- a/src/ngraph/runtime/allocator.hpp
+++ b/src/ngraph/runtime/allocator.hpp
@@ -28,9 +28,6 @@ namespace ngraph
     {
         class Allocator;
         class DefaultAllocator;
-        /// \brief Create a default allocator that calls into system
-        ///        allocation libraries
-        ngraph::runtime::Allocator* get_default_allocator();
     }
 }
 
@@ -47,4 +44,11 @@ public:
     /// \brief deallocates the memory pointed by ptr
     /// \param ptr pointer to the aligned memory to be released
     virtual void free(void* ptr) = 0;
+};
+
+class ngraph::runtime::DefaultAllocator : public ngraph::runtime::Allocator
+{
+public:
+    void* malloc(size_t size, size_t alignment) override;
+    void free(void* ptr) override;
 };

--- a/src/ngraph/runtime/cpu/cpu_backend.cpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.cpp
@@ -185,7 +185,7 @@ runtime::Allocator* runtime::cpu::CPU_Backend::get_host_memory_allocator()
 {
     if (!m_allocator)
     {
-        return runtime::get_default_allocator();
+        return &m_default_allocator;
     }
     return m_allocator.get();
 }

--- a/src/ngraph/runtime/cpu/cpu_backend.hpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.hpp
@@ -77,6 +77,7 @@ namespace ngraph
                 std::unordered_map<std::shared_ptr<Function>, std::shared_ptr<Executable>>
                     m_exec_map;
                 std::unique_ptr<Allocator> m_allocator;
+                DefaultAllocator m_default_allocator;
             };
 
             class CPU_BACKEND_API CPU_Executable : public runtime::Executable


### PR DESCRIPTION
The static DefaultAllocator is being freed before it is done being used. I made the DefaultAllocator a member of CPU_Backend and it uses a pointer to this member to pass around. This way the DefaultAllocator's lifetime is the lifetime of the CPU_Backend and it fixes the segfault in the NNP backend when we use the CPU backend.