### PR TITLE
Export get_backend_constructor_pointer as CPU backend API.

### DIFF
--- a/src/ngraph/runtime/cpu/cpu_backend.cpp
+++ b/src/ngraph/runtime/cpu/cpu_backend.cpp
@@ -52,7 +52,7 @@ runtime::BackendConstructor* runtime::cpu::get_backend_constructor_pointer()
 }
 
 #if !defined(NGRAPH_CPU_STATIC_LIB_ENABLE)
-extern "C" runtime::BackendConstructor* get_backend_constructor_pointer()
+extern "C" CPU_BACKEND_API runtime::BackendConstructor* get_backend_constructor_pointer()
 {
     return runtime::cpu::get_backend_constructor_pointer();
 }


### PR DESCRIPTION
onnxruntime with nGraph EP run into run time error because of missing symbol “get_backend_constructor_pointer” in the CPU backend dll.