### PR TITLE
Fix sum reference to handle corner cases with +-inf

### DIFF
--- a/src/ngraph/runtime/gpu/unit_test.manifest
+++ b/src/ngraph/runtime/gpu/unit_test.manifest
@@ -100,6 +100,9 @@ all_2x2x3_eliminate_dims_1_2
 all_2x2x3_eliminate_dims_0_1_2
 all_dynamic
 
+# Corner-case tests for sum with infs and -infs.
+sum_inf
+
 # GPU backend uses floats to implement these ops for int32
 floor_int32
 divide_int32

--- a/src/ngraph/runtime/reference/sum.hpp
+++ b/src/ngraph/runtime/reference/sum.hpp
@@ -30,13 +30,18 @@ namespace ngraph
             // Windows doesn't seem to like it if we directly use std::isfinite on integer types,
             // so we will roll our own thing here.
             template <typename T>
-            typename std::enable_if<std::is_floating_point<T>::value ||
-                                        std::is_same<T, bfloat16>::value ||
+            typename std::enable_if<std::is_floating_point<T>::value, bool>::type is_finite(T x)
+            {
+                return std::isfinite(x);
+            }
+
+            template <typename T>
+            typename std::enable_if<std::is_same<T, bfloat16>::value ||
                                         std::is_same<T, float16>::value,
                                     bool>::type
                 is_finite(T x)
             {
-                return std::isfinite(x);
+                return std::isfinite(static_cast<float>(x));
             }
 
             template <typename T>

--- a/test/backend/sum.in.cpp
+++ b/test/backend/sum.in.cpp
@@ -740,3 +740,91 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_dynamic)
         ASSERT_TRUE(test::all_close_f(results, expected_results[i], MIN_FLOAT_TOLERANCE_BITS));
     }
 }
+
+NGRAPH_TEST(${BACKEND_NAME}, sum_neg_inf_neg_inf)
+{
+    Shape shape{2};
+    auto A = make_shared<op::Parameter>(element::f32, shape);
+    auto f = make_shared<Function>(make_shared<op::Sum>(A, AxisSet{0}), ParameterVector{A});
+
+    auto backend = runtime::Backend::create("${BACKEND_NAME}");
+
+    // Create some tensors for input/output
+    auto a = backend->create_tensor(element::f32, shape);
+    copy_data(a,
+              vector<float>{-std::numeric_limits<float>::infinity(),
+                            -std::numeric_limits<float>::infinity()});
+    auto result = backend->create_tensor(element::f32, Shape{});
+
+    auto handle = backend->compile(f);
+    handle->call_with_validate({result}, {a});
+    auto r = read_vector<float>(result);
+    ASSERT_EQ(r.size(), 1);
+    EXPECT_TRUE(r[0] < 0 && isinf(r[0])) << "Expected -inf, actual value for r[0]: " << r[0];
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, sum_pos_inf_pos_inf)
+{
+    Shape shape{2};
+    auto A = make_shared<op::Parameter>(element::f32, shape);
+    auto f = make_shared<Function>(make_shared<op::Sum>(A, AxisSet{0}), ParameterVector{A});
+
+    auto backend = runtime::Backend::create("${BACKEND_NAME}");
+
+    // Create some tensors for input/output
+    auto a = backend->create_tensor(element::f32, shape);
+    copy_data(a,
+              vector<float>{std::numeric_limits<float>::infinity(),
+                            std::numeric_limits<float>::infinity()});
+    auto result = backend->create_tensor(element::f32, Shape{});
+
+    auto handle = backend->compile(f);
+    handle->call_with_validate({result}, {a});
+    auto r = read_vector<float>(result);
+    ASSERT_EQ(r.size(), 1);
+    EXPECT_TRUE(r[0] > 0 && isinf(r[0])) << "Expected inf, actual value for r[0]: " << r[0];
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, sum_pos_inf_neg_inf)
+{
+    Shape shape{2};
+    auto A = make_shared<op::Parameter>(element::f32, shape);
+    auto f = make_shared<Function>(make_shared<op::Sum>(A, AxisSet{0}), ParameterVector{A});
+
+    auto backend = runtime::Backend::create("${BACKEND_NAME}");
+
+    // Create some tensors for input/output
+    auto a = backend->create_tensor(element::f32, shape);
+    copy_data(a,
+              vector<float>{std::numeric_limits<float>::infinity(),
+                            -std::numeric_limits<float>::infinity()});
+    auto result = backend->create_tensor(element::f32, Shape{});
+
+    auto handle = backend->compile(f);
+    handle->call_with_validate({result}, {a});
+    auto r = read_vector<float>(result);
+    ASSERT_EQ(r.size(), 1);
+    EXPECT_TRUE(isnan(r[0])) << "Expected nan, actual value for r[0]: " << r[0];
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, sum_neg_inf_pos_inf)
+{
+    Shape shape{2};
+    auto A = make_shared<op::Parameter>(element::f32, shape);
+    auto f = make_shared<Function>(make_shared<op::Sum>(A, AxisSet{0}), ParameterVector{A});
+
+    auto backend = runtime::Backend::create("${BACKEND_NAME}");
+
+    // Create some tensors for input/output
+    auto a = backend->create_tensor(element::f32, shape);
+    copy_data(a,
+              vector<float>{-std::numeric_limits<float>::infinity(),
+                            std::numeric_limits<float>::infinity()});
+    auto result = backend->create_tensor(element::f32, Shape{});
+
+    auto handle = backend->compile(f);
+    handle->call_with_validate({result}, {a});
+    auto r = read_vector<float>(result);
+    ASSERT_EQ(r.size(), 1);
+    EXPECT_TRUE(isnan(r[0])) << "Expected nan, actual value for r[0]: " << r[0];
+}

--- a/test/backend/sum.in.cpp
+++ b/test/backend/sum.in.cpp
@@ -741,90 +741,38 @@ NGRAPH_TEST(${BACKEND_NAME}, sum_dynamic)
     }
 }
 
-NGRAPH_TEST(${BACKEND_NAME}, sum_neg_inf_neg_inf)
+NGRAPH_TEST(${BACKEND_NAME}, sum_inf)
 {
-    Shape shape{2};
+    Shape shape{7, 4};
     auto A = make_shared<op::Parameter>(element::f32, shape);
-    auto f = make_shared<Function>(make_shared<op::Sum>(A, AxisSet{0}), ParameterVector{A});
+    auto f = make_shared<Function>(make_shared<op::Sum>(A, AxisSet{1}), ParameterVector{A});
+
+    auto infi = std::numeric_limits<float>::infinity();
 
     auto backend = runtime::Backend::create("${BACKEND_NAME}");
 
     // Create some tensors for input/output
     auto a = backend->create_tensor(element::f32, shape);
     copy_data(a,
-              vector<float>{-std::numeric_limits<float>::infinity(),
-                            -std::numeric_limits<float>::infinity()});
-    auto result = backend->create_tensor(element::f32, Shape{});
+              test::NDArray<float, 2>({{-infi, 0, 0, infi},
+                                       {infi, 100, -100, -infi},
+                                       {infi, 0, 100, infi},
+                                       {-infi, -100, 0, -infi},
+                                       {infi, infi, infi, infi},
+                                       {infi, infi, infi, -infi},
+                                       {infi, std::nanf(""), 42, infi}})
+                  .get_vector());
+    auto result = backend->create_tensor(element::f32, Shape{7});
 
     auto handle = backend->compile(f);
     handle->call_with_validate({result}, {a});
     auto r = read_vector<float>(result);
-    ASSERT_EQ(r.size(), 1);
-    EXPECT_TRUE(r[0] < 0 && isinf(r[0])) << "Expected -inf, actual value for r[0]: " << r[0];
-}
-
-NGRAPH_TEST(${BACKEND_NAME}, sum_pos_inf_pos_inf)
-{
-    Shape shape{2};
-    auto A = make_shared<op::Parameter>(element::f32, shape);
-    auto f = make_shared<Function>(make_shared<op::Sum>(A, AxisSet{0}), ParameterVector{A});
-
-    auto backend = runtime::Backend::create("${BACKEND_NAME}");
-
-    // Create some tensors for input/output
-    auto a = backend->create_tensor(element::f32, shape);
-    copy_data(a,
-              vector<float>{std::numeric_limits<float>::infinity(),
-                            std::numeric_limits<float>::infinity()});
-    auto result = backend->create_tensor(element::f32, Shape{});
-
-    auto handle = backend->compile(f);
-    handle->call_with_validate({result}, {a});
-    auto r = read_vector<float>(result);
-    ASSERT_EQ(r.size(), 1);
-    EXPECT_TRUE(r[0] > 0 && isinf(r[0])) << "Expected inf, actual value for r[0]: " << r[0];
-}
-
-NGRAPH_TEST(${BACKEND_NAME}, sum_pos_inf_neg_inf)
-{
-    Shape shape{2};
-    auto A = make_shared<op::Parameter>(element::f32, shape);
-    auto f = make_shared<Function>(make_shared<op::Sum>(A, AxisSet{0}), ParameterVector{A});
-
-    auto backend = runtime::Backend::create("${BACKEND_NAME}");
-
-    // Create some tensors for input/output
-    auto a = backend->create_tensor(element::f32, shape);
-    copy_data(a,
-              vector<float>{std::numeric_limits<float>::infinity(),
-                            -std::numeric_limits<float>::infinity()});
-    auto result = backend->create_tensor(element::f32, Shape{});
-
-    auto handle = backend->compile(f);
-    handle->call_with_validate({result}, {a});
-    auto r = read_vector<float>(result);
-    ASSERT_EQ(r.size(), 1);
-    EXPECT_TRUE(isnan(r[0])) << "Expected nan, actual value for r[0]: " << r[0];
-}
-
-NGRAPH_TEST(${BACKEND_NAME}, sum_neg_inf_pos_inf)
-{
-    Shape shape{2};
-    auto A = make_shared<op::Parameter>(element::f32, shape);
-    auto f = make_shared<Function>(make_shared<op::Sum>(A, AxisSet{0}), ParameterVector{A});
-
-    auto backend = runtime::Backend::create("${BACKEND_NAME}");
-
-    // Create some tensors for input/output
-    auto a = backend->create_tensor(element::f32, shape);
-    copy_data(a,
-              vector<float>{-std::numeric_limits<float>::infinity(),
-                            std::numeric_limits<float>::infinity()});
-    auto result = backend->create_tensor(element::f32, Shape{});
-
-    auto handle = backend->compile(f);
-    handle->call_with_validate({result}, {a});
-    auto r = read_vector<float>(result);
-    ASSERT_EQ(r.size(), 1);
-    EXPECT_TRUE(isnan(r[0])) << "Expected nan, actual value for r[0]: " << r[0];
+    ASSERT_EQ(r.size(), 7);
+    EXPECT_TRUE(isnan(r[0]));
+    EXPECT_TRUE(isnan(r[1]));
+    EXPECT_TRUE(r[2] > 0 && isinf(r[2]));
+    EXPECT_TRUE(r[3] < 0 && isinf(r[3]));
+    EXPECT_TRUE(r[4] > 0 && isinf(r[4]));
+    EXPECT_TRUE(isnan(r[5]));
+    EXPECT_TRUE(isnan(r[6]));
 }


### PR DESCRIPTION
Got a report that ConstantFolding (which delegates directly to the reference) was returning nan on [-inf,-inf] and (I think) [+inf,+inf], which is wrong (should be -inf and +inf). I think this boils down to a corner case in our stable sum algorithm.