### PR TITLE
[MLIR] Set optimization level for LLVM optimizer and codegen

### DIFF
--- a/src/contrib/mlir/compiler.hpp
+++ b/src/contrib/mlir/compiler.hpp
@@ -161,6 +161,9 @@ namespace ngraph
 
                 // Memory manager for temp allocations inside JIT'ed code
                 MLIRMemMgr m_mem_mgr;
+
+                // Optimization level used by MLIR and LLVM compilers.
+                static unsigned mlir_opt_level;
             };
         }
     }


### PR DESCRIPTION
Now both LLVM optimizer and codegen are aligned with
"NGRAPH_MLIR_OPT_LEVEL" macro.