### PR TITLE
Enable floating point Relu

### DIFF
--- a/src/contrib/mlir/lowerer.cpp
+++ b/src/contrib/mlir/lowerer.cpp
@@ -506,9 +506,6 @@ namespace
 
         NGRAPH_CHECK(lhs->getType().isa<MemRefType>());
         Type elemTy = lhs->getType().dyn_cast<MemRefType>().getElementType();
-        NGRAPH_CHECK(!elemTy.isa<FloatType>(),
-                     "NGReluOp with float element type should not be lowered until MLIR supports "
-                     "lowering !std.CmpF");
 
         LoopNestBuilder(pivs, lbs, ubs, steps)([&] {
             ValueHandle val = iLHS(ivs);

--- a/src/contrib/mlir/pass/mlir_subgraph_extraction.cpp
+++ b/src/contrib/mlir/pass/mlir_subgraph_extraction.cpp
@@ -331,19 +331,6 @@ bool MLIRSubgraphExtractionPass::is_supported_mlir_op(std::shared_ptr<Node> node
         }
     }
 
-    // Relu is supported for integer types only until MLIR adds support for lowering !std.CmpF to LLVM dialect
-    if (TI(ngraph::op::Relu) == TI(*node))
-    {
-        if (!node->get_element_type().is_integral())
-        {
-            return false;
-        }
-        else
-        {
-            return true;
-        }
-    }
-
     if (TI(ngraph::op::Negative) == TI(*node))
     {
         return true;


### PR DESCRIPTION
FCmp is now enabled in MLIR. Enable floating point relu in nGraph MLIR backend.

https://github.com/tensorflow/mlir/commit/ee6dbf9f4570869c3356ab5f43524135b480842f
