### PR TITLE
[MLIR] Enable clang-format on comments in contrib folder

### DIFF
--- a/src/contrib/.clang-format
+++ b/src/contrib/.clang-format
@@ -1,0 +1,52 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+Language: Cpp
+Standard: Cpp11
+
+AccessModifierOffset: -4
+
+AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: false
+AlignTrailingComments: true
+
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BreakBeforeBraces: Allman
+BreakConstructorInitializersBeforeComma: true
+
+ColumnLimit: 100
+
+IndentCaseLabels: false
+IndentWrappedFunctionNames: true
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: All
+
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+SortIncludes: false
+ReflowComments: true
+
+IncludeCategories:
+  - Regex:           '^".*'
+    Priority:        3
+  - Regex:           '^<.*'
+    Priority:        2
+SortIncludes: true

--- a/src/contrib/mlir/lowerer.cpp
+++ b/src/contrib/mlir/lowerer.cpp
@@ -285,10 +285,12 @@ namespace
         // TODO:
         // Enable dynamic memref allocation via call-back to nGraph allocator
         // We should create a list of Values representing each dynamic dim
-        // The values would be computed based on the shape of the input to the ng op we are lowering.
+        // The values would be computed based on the shape of the input to the ng op we are
+        // lowering.
         // E.g. If lowering concat, Value for dynamic concat axis will be the sum of input dims.
         // The lowerer will generate code to compute the dims.
-        // This is better be done via std.AllocOp but we need to make it hookable to nGraph allocator call-back.
+        // This is better be done via std.AllocOp but we need to make it hookable to nGraph
+        // allocator call-back.
 
         return alloc;
     }
@@ -749,7 +751,8 @@ namespace
         // ...
         //               for I_(M-1):0 -> indices.dim[M-1]
         //                 res[P_0, P_1, .. P_(A-1), I_0, .., I_(M-1), P_(A+1), ... P_(N-1)] =
-        //                   params[P_0, P_1, .. P_(A-1), indices[I_0, .., I_(M-1)], P_(A+1), ... P_(N-1)];
+        //                   params[P_0, P_1, .. P_(A-1), indices[I_0, .., I_(M-1)],
+        //                          P_(A+1), ... P_(N-1)];
 
         LoopNestBuilder(paramsIVPtrs, paramsLbs, paramsUbs, paramsSteps)([&] {
             LoopNestBuilder(indicesIVPtrs, indicesLbs, indicesUbs, indicesSteps)([&] {

--- a/src/contrib/mlir/pass/mlir_subgraph_extraction.cpp
+++ b/src/contrib/mlir/pass/mlir_subgraph_extraction.cpp
@@ -101,12 +101,15 @@ void MLIRSubgraphExtractionPass::MLIRSubgraph::merge(MLIRSubgraph& sg2)
 
 // The sub-graph construction algorithm is as follows
 // For each node, check its predecessors, if
-// - all predecessors in sub-graphs belong to the same sub-graph (graph ID), then extend the sub-graph to include the current node.
+// - all predecessors in sub-graphs belong to the same sub-graph (graph ID), then extend the
+//   sub-graph to include the current node.
 //   Predecessors outside sub-graphs are marked as input to the sub-graph.
-// - predecessors in sub-graphs belong to different sub-graphs, then merge all the sub-graphs into one, and add current node to it.
-//   Predecessors outside sub-graphs are marked as input to the sub-graph.
+// - predecessors in sub-graphs belong to different sub-graphs, then merge all the sub-graphs into
+//   one, and add current node to it. Predecessors outside sub-graphs are marked as input to the
+//   sub-graph.
 //
-// If the node has any external inputs, then it's possible that the input may come from one of the predecessor sub-graphs (cycle).
+// If the node has any external inputs, then it's possible that the input may come from one of the
+// predecessor sub-graphs (cycle).
 // If a cycle is found, always start a new sub-graph.
 //
 // For each sub-graph found build a CompiledKernel(CK) node around it as follows
@@ -380,7 +383,8 @@ bool MLIRSubgraphExtractionPass::check_cycles(std::shared_ptr<Node> node,
     {
         if (subgraph_ids.find(get_subgraph_id(node)) != subgraph_ids.end())
         {
-            // This node is inside a sub-graph. If we are coming from outside the sub-graphs, then we formed a cycle.
+            // This node is inside a sub-graph. If we are coming from outside the sub-graphs, then
+            // we formed a cycle.
             if (!inside_subgraphs)
             {
                 return true;

--- a/src/contrib/mlir/pass/mlir_subgraph_extraction.hpp
+++ b/src/contrib/mlir/pass/mlir_subgraph_extraction.hpp
@@ -25,7 +25,8 @@ namespace ngraph
 {
     namespace pass
     {
-        /// This pass creates CompiledKernel ops enclosing maximal sub-graphs of ops that are supported by MLIR
+        /// This pass creates CompiledKernel ops enclosing maximal sub-graphs of ops that are
+        /// supported by MLIR
         class MLIRSubgraphExtractionPass : public ngraph::pass::FunctionPass
         {
             using NodeSet = std::unordered_set<std::shared_ptr<Node>>;
@@ -104,8 +105,8 @@ namespace ngraph
             /// Checks if adding a node to an extracted sub-graph will cause a DAG cycle
             /// inputs: the list of input nodes outside sub-graphs to the node we want to add.
             /// subgraph_ids: the sub-graphs the predecessor nodes belong to.
-            /// It traverses backwards from all input nodes and checks if we left the to-be-merged sub-graphs
-            /// and entered again. If so, we have a cycle.
+            /// It traverses backwards from all input nodes and checks if we left the to-be-merged
+            /// sub-graphs and entered again. If so, we have a cycle.
             ///
             /// Example:
             /// A(1)
@@ -114,7 +115,8 @@ namespace ngraph
             /// |  /
             /// D
             /// we want to add D to sub-graph 1. C is an input to D. sugraph_ids are 1
-            /// we traverse backwards C->A(1) and find 1, then we cannot add D since we will form a cycle
+            /// we traverse backwards C->A(1) and find 1, then we cannot add D since we will form a
+            /// cycle
             bool check_cycles(std::shared_ptr<Node> node,
                               std::unordered_set<int>& subgraph_ids,
                               bool inside_subgraphs = true,


### PR DESCRIPTION
This PR starts the modular approach that we discussed to enable
clang-format on comments so that they are automatically formatted
instead of having to do that manually. It only covers the src/contrib
directory.