### PR TITLE
Cyphers/exec can create tensors (#3445)

### DIFF
--- a/src/ngraph/runtime/backend.cpp
+++ b/src/ngraph/runtime/backend.cpp
@@ -169,5 +169,6 @@ bool runtime::Backend::executable_can_create_tensors()
     catch (...)
     {
     }
+    remove_compiled_function(exec);
     return exec_can_create_tensors;
 }


### PR DESCRIPTION
Possible fix so that backend does not keep holding on to the dummy ng_exec