### PR TITLE
clang-format comments: /src/ngraph/runtime/interpreter etc.

### DIFF
--- a/src/ngraph/runtime/dynamic/.clang-format
+++ b/src/ngraph/runtime/dynamic/.clang-format
@@ -1,0 +1,56 @@
+#
+# OVERRIDE TO STYLE: Comments wrap.
+#
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+Language: Cpp
+Standard: Cpp11
+
+AccessModifierOffset: -4
+
+AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: false
+AlignTrailingComments: true
+
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BreakBeforeBraces: Allman
+BreakConstructorInitializersBeforeComma: true
+
+ColumnLimit: 100
+#CommentPragmas: '.*'
+
+IndentCaseLabels: false
+IndentWrappedFunctionNames: true
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: All
+
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+SortIncludes: false
+ReflowComments: true
+
+IncludeCategories:
+  - Regex:           '^".*'
+    Priority:        3
+  - Regex:           '^<.*'
+    Priority:        2
+SortIncludes: true

--- a/src/ngraph/runtime/generic_cpu/.clang-format
+++ b/src/ngraph/runtime/generic_cpu/.clang-format
@@ -1,0 +1,56 @@
+#
+# OVERRIDE TO STYLE: Comments wrap.
+#
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+Language: Cpp
+Standard: Cpp11
+
+AccessModifierOffset: -4
+
+AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: false
+AlignTrailingComments: true
+
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BreakBeforeBraces: Allman
+BreakConstructorInitializersBeforeComma: true
+
+ColumnLimit: 100
+#CommentPragmas: '.*'
+
+IndentCaseLabels: false
+IndentWrappedFunctionNames: true
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: All
+
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+SortIncludes: false
+ReflowComments: true
+
+IncludeCategories:
+  - Regex:           '^".*'
+    Priority:        3
+  - Regex:           '^<.*'
+    Priority:        2
+SortIncludes: true

--- a/src/ngraph/runtime/generic_cpu/kernel/dot.hpp
+++ b/src/ngraph/runtime/generic_cpu/kernel/dot.hpp
@@ -56,8 +56,8 @@ namespace ngraph
                     }
                     else
                     {
-                        // Get the sizes of the dot axes. It's easiest to pull them from arg1 because they're
-                        // right up front.
+                        // Get the sizes of the dot axes. It's easiest to pull them from arg1
+                        // because they're right up front.
                         Shape dot_axis_sizes(reduction_axes_count);
                         std::copy(arg1_shape.begin(),
                                   arg1_shape.begin() + reduction_axes_count,
@@ -67,7 +67,8 @@ namespace ngraph
                         CoordinateTransform arg1_transform(arg1_shape);
                         CoordinateTransform output_transform(out_shape);
 
-                        // Create coordinate transforms for arg0 and arg1 that throw away the dotted axes.
+                        // Create coordinate transforms for arg0 and arg1 that throw away the dotted
+                        // axes.
                         size_t arg0_projected_rank = arg0_shape.size() - reduction_axes_count;
                         size_t arg1_projected_rank = arg1_shape.size() - reduction_axes_count;
 
@@ -84,15 +85,16 @@ namespace ngraph
                         CoordinateTransform arg0_projected_transform(arg0_projected_shape);
                         CoordinateTransform arg1_projected_transform(arg1_projected_shape);
 
-                        // Create a coordinate transform that allows us to iterate over all possible values
-                        // for the dotted axes.
+                        // Create a coordinate transform that allows us to iterate over all possible
+                        // values for the dotted axes.
                         CoordinateTransform dot_axes_transform(dot_axis_sizes);
 
                         for (const Coordinate& arg0_projected_coord : arg0_projected_transform)
                         {
                             for (const Coordinate& arg1_projected_coord : arg1_projected_transform)
                             {
-                                // The output coordinate is just the concatenation of the projected coordinates.
+                                // The output coordinate is just the concatenation of the projected
+                                // coordinates.
                                 Coordinate out_coord(arg0_projected_coord.size() +
                                                      arg1_projected_coord.size());
 
@@ -116,8 +118,9 @@ namespace ngraph
                                                          arg0_coord.begin());
                                 for (const Coordinate& dot_axis_positions : dot_axes_transform)
                                 {
-                                    // In order to find the points to multiply together, we need to inject our current
-                                    // positions along the dotted axes back into the projected arg0 and arg1 coordinates.
+                                    // In order to find the points to multiply together, we need to
+                                    // inject our current positions along the dotted axes back into
+                                    // the projected arg0 and arg1 coordinates.
                                     std::copy(dot_axis_positions.begin(),
                                               dot_axis_positions.end(),
                                               arg0_it);

--- a/src/ngraph/runtime/gpuh/.clang-format
+++ b/src/ngraph/runtime/gpuh/.clang-format
@@ -1,0 +1,56 @@
+#
+# OVERRIDE TO STYLE: Comments wrap.
+#
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+Language: Cpp
+Standard: Cpp11
+
+AccessModifierOffset: -4
+
+AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: false
+AlignTrailingComments: true
+
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BreakBeforeBraces: Allman
+BreakConstructorInitializersBeforeComma: true
+
+ColumnLimit: 100
+#CommentPragmas: '.*'
+
+IndentCaseLabels: false
+IndentWrappedFunctionNames: true
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: All
+
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+SortIncludes: false
+ReflowComments: true
+
+IncludeCategories:
+  - Regex:           '^".*'
+    Priority:        3
+  - Regex:           '^<.*'
+    Priority:        2
+SortIncludes: true

--- a/src/ngraph/runtime/interpreter/.clang-format
+++ b/src/ngraph/runtime/interpreter/.clang-format
@@ -1,0 +1,56 @@
+#
+# OVERRIDE TO STYLE: Comments wrap.
+#
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+Language: Cpp
+Standard: Cpp11
+
+AccessModifierOffset: -4
+
+AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: false
+AlignTrailingComments: true
+
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BreakBeforeBraces: Allman
+BreakConstructorInitializersBeforeComma: true
+
+ColumnLimit: 100
+#CommentPragmas: '.*'
+
+IndentCaseLabels: false
+IndentWrappedFunctionNames: true
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: All
+
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+SortIncludes: false
+ReflowComments: true
+
+IncludeCategories:
+  - Regex:           '^".*'
+    Priority:        3
+  - Regex:           '^<.*'
+    Priority:        2
+SortIncludes: true

--- a/src/ngraph/runtime/interpreter/int_visibility.hpp
+++ b/src/ngraph/runtime/interpreter/int_visibility.hpp
@@ -38,7 +38,8 @@
 // INTERPRETER_LOCAL is used for non-api symbols.
 
 // #ifdef INTERPRETER_DLL         // defined if INTERPRETER is compiled as a DLL
-#ifdef INTERPRETER_DLL_EXPORTS // defined if we are building the INTERPRETER DLL (instead of using it)
+#ifdef INTERPRETER_DLL_EXPORTS // defined if we are building the INTERPRETER DLL (instead of using
+                               // it)
 #define INTERPRETER_API INTERPRETER_HELPER_DLL_EXPORT
 #else
 #define INTERPRETER_API INTERPRETER_HELPER_DLL_IMPORT

--- a/src/ngraph/runtime/nop/.clang-format
+++ b/src/ngraph/runtime/nop/.clang-format
@@ -1,0 +1,56 @@
+#
+# OVERRIDE TO STYLE: Comments wrap.
+#
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+Language: Cpp
+Standard: Cpp11
+
+AccessModifierOffset: -4
+
+AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: false
+AlignTrailingComments: true
+
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BreakBeforeBraces: Allman
+BreakConstructorInitializersBeforeComma: true
+
+ColumnLimit: 100
+#CommentPragmas: '.*'
+
+IndentCaseLabels: false
+IndentWrappedFunctionNames: true
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: All
+
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+SortIncludes: false
+ReflowComments: true
+
+IncludeCategories:
+  - Regex:           '^".*'
+    Priority:        3
+  - Regex:           '^<.*'
+    Priority:        2
+SortIncludes: true


### PR DESCRIPTION
Covers `/src/ngraph/runtime/reference/{dynamic,interpreter,generic_cpu,gpuh,interpreter,nop}`