### PR TITLE
Temporary megalomaniacal CODEOWNERS power grab

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,6 @@
 /.travis.yml                        @aslepko @postrational
 
 /.clang-format                      @rkimballn1
-
 /.gitattributes                     @rkimballn1
 /.gitignore                         @rkimballn1
 /VERSION.in                         @rkimballn1 @silee2

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,10 +12,7 @@
 /contrib/docker/                    @aslepko
 /.travis.yml                        @aslepko @postrational
 
-#/.clang-format                      @rkimballn1
-
-# Temporary while we're bikeshedding the comment flow rules.
-.clang-format                       @aprocter
+/.clang-format                      @rkimballn1
 
 /.gitattributes                     @rkimballn1
 /.gitignore                         @rkimballn1
@@ -69,6 +66,9 @@ project/doc-contributor-README.rst  @indie
 
 # Putting this last so it's not overridden by directory rules
 CMakeLists.txt                      @rkimballn1 @silee2
+
+# Temporary megalomaniacal power grab, while we're bikeshedding the comment flow rules.
+.clang-format                       @aprocter
 
 # Putting this last to make sure nothing else overrides.
 /CODEOWNERS                         @diyessi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,11 @@
 /contrib/docker/                    @aslepko
 /.travis.yml                        @aslepko @postrational
 
-/.clang-format                      @rkimballn1
+#/.clang-format                      @rkimballn1
+
+# Temporary while we're bikeshedding the comment flow rules.
+.clang-format                       @aprocter
+
 /.gitattributes                     @rkimballn1
 /.gitignore                         @rkimballn1
 /VERSION.in                         @rkimballn1 @silee2
@@ -21,7 +25,7 @@
 /doc/examples/mnist_mlp/dist_*      @wenzhe-nrv @indie
 /doc/*/*/frameworks/tensorflow_connect.rst      @shresthamalik @avijit-nervana @sayantan-nervana
 /doc/*/*/backends/plaidml-ng-api/   @flaub @brianretford @dgkutnic
-/doc/*/*/inspection/                @aproctor
+/doc/*/*/inspection/                @aprocter
 /doc/examples/onnx/                 @arogowie-intel @tsocha
 /README.md                          @adstraw
 project/introduction.rst            @adstraw


### PR DESCRIPTION
The final phase of the .clang-format bikeshedding will require every .clang-format file to be touched, which will probably slow down review. Think it's easiest if we put a global override to CODEOWNERS for the moment.