### PR TITLE
[MLIR] Disable three more tests with MLIR enabled.

### DIFF
--- a/test/cpu_fusion.cpp
+++ b/test/cpu_fusion.cpp
@@ -3889,7 +3889,7 @@ TEST(cpu_fusion, rnn_fusion_2rnn_layer_3lstm_cell)
     }
 }
 
-TEST(cpu_fusion, validate_fuse_gru_inputs)
+TEST(cpu_fusion, MLIR_DISABLE_TEST(validate_fuse_gru_inputs))
 {
     const std::string file_name("mxnet/gru_debug.json");
     auto cpu_func = make_function_from_file(file_name);

--- a/test/cpu_test.cpp
+++ b/test/cpu_test.cpp
@@ -112,7 +112,7 @@ TEST(cpu_test, trivial_in_place_relu)
 }
 
 #ifndef NGRAPH_HALIDE
-TEST(cpu_test, trivial_in_place_relu_fail)
+TEST(cpu_test, MLIR_DISABLE_TEST(trivial_in_place_relu_fail))
 {
     auto A = make_shared<op::Parameter>(element::f32, Shape{16, 1});
     auto B = make_shared<op::Parameter>(element::f32, Shape{16, 1});
@@ -349,7 +349,7 @@ TEST(cpu_test, reshape_layout_optimizations3)
     }
 }
 
-TEST(cpu_test, reshape_layout_optimizations4)
+TEST(cpu_test, MLIR_DISABLE_TEST(reshape_layout_optimizations4))
 {
     // Squeeze and expand dimensions. Ensure no extra conversions downstream
     auto make_function = []() -> std::shared_ptr<Function> {
@@ -398,7 +398,7 @@ TEST(cpu_test, reshape_layout_optimizations4)
     EXPECT_LE(count_ops_of_type<runtime::cpu::op::ConvertLayout>(cpu_f), 4);
 }
 
-TEST(cpu_test, reshape_layout_optimizations5)
+TEST(cpu_test, MLIR_DISABLE_TEST(reshape_layout_optimizations5))
 {
     auto make_function = []() -> std::shared_ptr<Function> {
         auto A = make_shared<op::Parameter>(element::f32, Shape{1, 16, 1, 8});


### PR DESCRIPTION
This PR disables validate_fuse_gru_inputs, reshape_layout_optimizations4
and reshape_layout_optimizations5:
  1. trivial_in_place_relu_fail: It checks tensors pool offset. There is
     no memory pool in MLIR atm.
  2. validate_fuse_gru_inputs: It creates an infinite cycle in
     MLIR subgraph extraction pass (under investigation).
  3. reshape_layout_optimizations4/5: They fail due to CompiledKernel
     being not expected by CPULayout pass.