### PR TITLE
no_fork: Performance issue vector of string to T

### DIFF
--- a/src/ngraph/util.hpp
+++ b/src/ngraph/util.hpp
@@ -29,7 +29,7 @@
 #include <typeinfo>
 #include <unordered_map>
 #include <vector>
-
+#include <algorithm>
 #include "ngraph/axis_vector.hpp"
 #include "ngraph/graph_util.hpp"
 #include "ngraph/node.hpp"
@@ -165,13 +165,11 @@ namespace ngraph
     template <typename T>
     std::vector<T> parse_string(const std::vector<std::string>& ss)
     {
-        std::vector<T> result;
-
-        for (auto s : ss)
-        {
-            result.push_back(parse_string<T>(s));
-        }
-
+        std::vector<T> result(ss.size());
+        std::transform(ss.begin(),ss.end(),result.begin(),
+        [](const std::string& s){
+              return parse_string<T>(s);
+        });
         return result;
     }
 

--- a/src/ngraph/util.hpp
+++ b/src/ngraph/util.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdlib> // llvm 8.1 gets confused about `malloc` otherwise
@@ -29,7 +30,6 @@
 #include <typeinfo>
 #include <unordered_map>
 #include <vector>
-#include <algorithm>
 #include "ngraph/axis_vector.hpp"
 #include "ngraph/graph_util.hpp"
 #include "ngraph/node.hpp"
@@ -166,9 +166,8 @@ namespace ngraph
     std::vector<T> parse_string(const std::vector<std::string>& ss)
     {
         std::vector<T> result(ss.size());
-        std::transform(ss.begin(),ss.end(),result.begin(),
-        [](const std::string& s){
-              return parse_string<T>(s);
+        std::transform(ss.begin(), ss.end(), result.begin(), [](const std::string& s) {
+            return parse_string<T>(s);
         });
         return result;
     }


### PR DESCRIPTION
size of destination equal size of source, prepare destination and reserve memory for desired elements.
In real we have a lot of cases where result is re-allocated, we are working with 4K elements and more.

Duplication issue #3534 : no fork  as @diyessi required.  