### PR TITLE
[SPEC] Add limited support for optional broadcast_axes in DynBroadcast op.

### DIFF
--- a/src/ngraph/op/experimental/dyn_broadcast.cpp
+++ b/src/ngraph/op/experimental/dyn_broadcast.cpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //*****************************************************************************
 
-#include <algorithm>
+#include <numeric>
 
 #include "ngraph/op/experimental/dyn_broadcast.hpp"
 #include "ngraph/op/constant.hpp"

--- a/src/ngraph/op/experimental/dyn_broadcast.cpp
+++ b/src/ngraph/op/experimental/dyn_broadcast.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //*****************************************************************************
 
+#include <algorithm>
+
 #include "ngraph/op/experimental/dyn_broadcast.hpp"
 #include "ngraph/op/constant.hpp"
 

--- a/src/ngraph/op/experimental/dyn_broadcast.hpp
+++ b/src/ngraph/op/experimental/dyn_broadcast.hpp
@@ -38,6 +38,11 @@ namespace ngraph
             ///
             /// \param arg            Node that produces the input tensor to be broadcast.
             /// \param shape          Node that produces shape of the output tensor.
+            DynBroadcast(const Output<Node>& arg, const Output<Node>& shape);
+            /// \brief Constructs a dynamic broadcast operation.
+            ///
+            /// \param arg            Node that produces the input tensor to be broadcast.
+            /// \param shape          Node that produces shape of the output tensor.
             /// \param broadcast_axes Node that produces the axis positions (0-based) in the result
             ///                       that are being broadcast. The remaining axes in shape must be
             ///                       the same as the shape of arg.
@@ -53,6 +58,8 @@ namespace ngraph
         protected:
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
+
+            void add_default_broadcast_axes();
         };
     }
 }


### PR DESCRIPTION
Add support for broadcast_axes as optional input.
Restrictions:
- Input and target shape ranks must be static.
- Broadcasting dimension `1` to `N` is not supported by now.