### PR TITLE
Exclude CI-failing unit tests for PlaidML

### DIFF
--- a/src/ngraph/runtime/plaidml/unit_test.manifest
+++ b/src/ngraph/runtime/plaidml/unit_test.manifest
@@ -254,6 +254,10 @@ dot_2x0_0
 auto_bcast_binary_elementwise
 max_pool_2d_1channel_1image_overpadded
 
+# passes locally, fails in CI
+numeric_float_nan
+fake_quantize_with_clip_across_channels
+
 # axes input param not supported
 lrn_across_h
 lrn_across_hw


### PR DESCRIPTION
I cleaned up the PlaidML unit test exclude list last week. In doing this, I inadvertently enabled some tests that were passing locally for me but failing nGraph CI on ngpu. This PR puts those tests back on the exclude list.