### PR TITLE
[DRAFT] Proposition of adjust gather by new constructor introduction

### DIFF
--- a/src/ngraph/op/gather.cpp
+++ b/src/ngraph/op/gather.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 
 #include "ngraph/op/gather.hpp"
+#include "ngraph/op/constant.hpp"
 #include "ngraph/shape.hpp"
 
 using namespace std;
@@ -22,17 +23,51 @@ using namespace ngraph;
 
 static int PARAMS = 0;
 static int INDICES = 1;
+static int AXIS = 2;
 
 const string op::Gather::type_name{"Gather"};
+
+op::Gather::Gather(const Output<Node>& params, const Output<Node>& indices, size_t axis)
+    : Op({params, indices, op::Constant::create(element::i64, Shape{1}, {axis})})
+{
+}
+
+op::Gather::Gather(const Output<Node>& params,
+                   const Output<Node>& indices,
+                   const Output<Node>& axis)
+    : Op({params, indices, axis})
+{
+    constructor_validate_and_infer_types();
+}
+
+size_t op::Gather::get_axis() const
+{
+    AxisVector axes;
+    auto axes_input_node = input_value(AXIS).get_node_shared_ptr();
+    if (auto const_op = dynamic_pointer_cast<op::Constant>(axes_input_node))
+    {
+        axes = const_op->get_axis_vector_val();
+    }
+    NODE_VALIDATION_CHECK(
+        this, axes.size() == 1, "Axes must have 1 element (axes.size: ", axes.size(), ").");
+    return axes.front();
+}
 
 shared_ptr<Node> op::Gather::copy_with_new_args(const NodeVector& new_args) const
 {
     check_new_args_count(this, new_args);
-    return make_shared<Gather>(new_args.at(PARAMS), new_args.at(INDICES), m_axis);
+    return make_shared<Gather>(new_args.at(PARAMS), new_args.at(INDICES), new_args.at(AXIS));
 }
 
 void op::Gather::validate_and_infer_types()
 {
+    const auto& axis_shape = get_input_partial_shape(AXIS);
+    NODE_VALIDATION_CHECK(this,
+                          static_cast<size_t>(axis_shape.rank()) == 1,
+                          "Axis for padding value is not a scalar (shape: ",
+                          axis_shape,
+                          ").");
+
     element::Type result_et = get_input_element_type(PARAMS);
     element::Type indices_et = get_input_element_type(INDICES);
 
@@ -46,10 +81,10 @@ void op::Gather::validate_and_infer_types()
     // params rank must be at least (axis + 1)
     // indices value must be in range [0, params.shape[axis]).
     // output rank is rank(params) + rank(indices) - 1
+    const auto axis = get_axis();
     NODE_VALIDATION_CHECK(this,
                           params_shape.rank().is_dynamic() ||
-                              static_cast<size_t>(params_shape.rank()) >
-                                  static_cast<size_t>(m_axis),
+                              static_cast<size_t>(params_shape.rank()) > static_cast<size_t>(axis),
                           "params rank is expected to be at least axis + 1");
 
     PartialShape result_shape;
@@ -58,7 +93,7 @@ void op::Gather::validate_and_infer_types()
         std::vector<Dimension> result_dims(static_cast<size_t>(params_shape.rank()) +
                                            static_cast<size_t>(indices_shape.rank()) - 1);
         size_t i = 0;
-        for (; i < static_cast<size_t>(m_axis); i++)
+        for (; i < static_cast<size_t>(axis); i++)
         {
             result_dims[i] = params_shape[i];
         }
@@ -66,8 +101,7 @@ void op::Gather::validate_and_infer_types()
         {
             result_dims[i] = indices_shape[j];
         }
-        for (size_t j = static_cast<size_t>(m_axis) + 1;
-             j < static_cast<size_t>(params_shape.rank());
+        for (size_t j = static_cast<size_t>(axis) + 1; j < static_cast<size_t>(params_shape.rank());
              i++, j++)
         {
             result_dims[i] = params_shape[j];

--- a/src/ngraph/op/gather.hpp
+++ b/src/ngraph/op/gather.hpp
@@ -33,12 +33,14 @@ namespace ngraph
             /// \param params The tensor from which slices are gathered
             /// \param indices Index tensor: Data type must be `element::i32` or `element::i64`
             /// \param axis Axis in params to gather
-            Gather(const Output<Node>& params, const Output<Node>& indices, size_t axis = 0)
-                : Op({params, indices})
-                , m_axis(axis)
-            {
-                constructor_validate_and_infer_types();
-            }
+            Gather(const Output<Node>& params, const Output<Node>& indices, size_t axis = 0);
+
+            /// \param params The tensor from which slices are gathered
+            /// \param indices Index tensor: Data type must be `element::i32` or `element::i64`
+            /// \param axis The tensor which determines axis of Gather
+            Gather(const Output<Node>& params,
+                   const Output<Node>& indices,
+                   const Output<Node>& axis);
 
             void validate_and_infer_types() override;
 
@@ -47,13 +49,9 @@ namespace ngraph
                 throw ngraph_error("Not yet implemented");
             }
 
-            size_t get_axis() const { return m_axis; }
-            void set_axis(size_t axis) { m_axis = axis; }
+            size_t get_axis() const;
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
-
-        protected:
-            size_t m_axis;
         };
     }
 }


### PR DESCRIPTION
Optional version of `Gather` adjustment to specification from: https://github.com/NervanaSystems/ngraph/pull/3590

In such solution I'm not sure how to handle serialization:
```
    case OP_TYPEID::Gather:
    {
        auto tmp = dynamic_cast<const op::Gather*>(&n);
        node["axis"] = tmp->get_axis();
        break;
    }
```
Due to the fact that we have two version of constructor `axis` should be serialized still as attribute?