### PR TITLE
[MLIR] Add support for parsing nGraph element types

### DIFF
--- a/src/contrib/mlir/compiler/lowerer.cpp
+++ b/src/contrib/mlir/compiler/lowerer.cpp
@@ -113,15 +113,19 @@ namespace
                 }
             }
 
-            // Convert the original function results.
-            SmallVector<Type, 4> convertedResults;
-            if (failed(converter.convertTypes(type.getResults(), convertedResults)))
+            auto funcTypeResults = type.getResults();
+            if (!funcTypeResults.empty())
             {
-                return matchFailure();
-            }
+                // Convert the original function results.
+                SmallVector<Type, 4> convertedResults;
+                if (failed(converter.convertTypes(funcTypeResults, convertedResults)))
+                {
+                    return matchFailure();
+                }
 
-            // Add result types as input args without mapping
-            result.addInputs(convertedResults);
+                // Add result types as input args without mapping
+                result.addInputs(convertedResults);
+            }
 
             // Create a new function with an updated signature.
             auto newFuncOp = rewriter.cloneWithoutRegions(funcOp);

--- a/test/mlir/affine_conversion/types.mlir
+++ b/test/mlir/affine_conversion/types.mlir
@@ -1,8 +1,6 @@
-// RUN: ngraph-opt %s -split-input-file | FileCheck %s
-// Verify the printed output can be parsed.
-// RUN: ngraph-opt %s -split-input-file | ngraph-opt | FileCheck %s
+// RUN: ngraph-opt %s -convert-ngraph-to-affine -split-input-file | FileCheck %s
 
-// These tests verify parsing and printing of nGraph types.
+// These tests verify that we can parse nGraph dialect types and lower them to affine.
 
 // -----
 
@@ -23,7 +21,7 @@ func @f64(%arg0: f64) {
 // -----
 
 // CHECK-LABEL: func @i8
-// CHECK-SAME: (%{{.*}}: !ng.i8)
+// CHECK-SAME: (%{{.*}}: i8)
 func @i8(%arg0: !ng.i8) {
   "ng.return"() : () -> ()
 }
@@ -31,7 +29,7 @@ func @i8(%arg0: !ng.i8) {
 // -----
 
 // CHECK-LABEL: func @i16
-// CHECK-SAME: (%{{.*}}: !ng.i16)
+// CHECK-SAME: (%{{.*}}: i16)
 func @i16(%arg0: !ng.i16) {
   "ng.return"() : () -> ()
 }
@@ -39,7 +37,7 @@ func @i16(%arg0: !ng.i16) {
 // -----
 
 // CHECK-LABEL: func @i32
-// CHECK-SAME: (%{{.*}}: !ng.i32)
+// CHECK-SAME: (%{{.*}}: i32)
 func @i32(%arg0: !ng.i32) {
   "ng.return"() : () -> ()
 }
@@ -47,7 +45,7 @@ func @i32(%arg0: !ng.i32) {
 // -----
 
 // CHECK-LABEL: func @i64
-// CHECK-SAME: (%{{.*}}: !ng.i64)
+// CHECK-SAME: (%{{.*}}: i64)
 func @i64(%arg0: !ng.i64) {
   "ng.return"() : () -> ()
 }
@@ -55,7 +53,7 @@ func @i64(%arg0: !ng.i64) {
 // -----
 
 // CHECK-LABEL: func @u8
-// CHECK-SAME: (%{{.*}}: !ng.i8)
+// CHECK-SAME: (%{{.*}}: i8)
 func @u8(%arg0: !ng.u8) {
   "ng.return"() : () -> ()
 }
@@ -63,7 +61,7 @@ func @u8(%arg0: !ng.u8) {
 // -----
 
 // CHECK-LABEL: func @u16
-// CHECK-SAME: (%{{.*}}: !ng.i16)
+// CHECK-SAME: (%{{.*}}: i16)
 func @u16(%arg0: !ng.u16) {
   "ng.return"() : () -> ()
 }
@@ -71,7 +69,7 @@ func @u16(%arg0: !ng.u16) {
 // -----
 
 // CHECK-LABEL: func @u32
-// CHECK-SAME: (%{{.*}}: !ng.i32)
+// CHECK-SAME: (%{{.*}}: i32)
 func @u32(%arg0: !ng.u32) {
   "ng.return"() : () -> ()
 }
@@ -79,7 +77,7 @@ func @u32(%arg0: !ng.u32) {
 // -----
 
 // CHECK: func @u64
-// CHECK-SAME (%{{.*}}: !ng.i64)
+// CHECK-SAME (%{{.*}}: i64)
 func @u64(%arg0: !ng.u64) {
   "ng.return"() : () -> ()
 }

--- a/test/mlir/ngraph_dialect/types.mlir
+++ b/test/mlir/ngraph_dialect/types.mlir
@@ -1,73 +1,85 @@
-// RUN: ngraph-opt %s -convert-ngraph-to-affine -split-input-file | FileCheck %s
+// RUN: ngraph-opt %s -split-input-file | FileCheck %s
+// Verify the printed output can be parsed.
+// RUN: ngraph-opt %s -split-input-file | ngraph-opt | FileCheck %s
 
-// These tests verify that we can parse nGraph dialect types and lower them to affine.
+// These tests verify parsing and printing of nGraph types.
 
 // -----
 
-// CHECK: func @f32(%{{.*}}: f32)
+// CHECK-LABEL: func @f32 
+// CHECK-SAME: (%{{.*}}: f32)
 func @f32(%arg0: f32) {
   "ng.return"() : () -> ()
 }
 
 // -----
 
-// CHECK: func @f64(%{{.*}}: f64)
+// CHECK-LABEL: func @f64
+// CHECK-SAME: (%{{.*}}: f64)
 func @f64(%arg0: f64) {
   "ng.return"() : () -> ()
 }
 
 // -----
 
-// CHECK: func @i8(%{{.*}}: i8)
+// CHECK-LABEL: func @i8
+// CHECK-SAME: (%{{.*}}: !ng.i8)
 func @i8(%arg0: !ng.i8) {
   "ng.return"() : () -> ()
 }
 
 // -----
 
-// CHECK: func @i16(%{{.*}}: i16)
+// CHECK-LABEL: func @i16
+// CHECK-SAME: (%{{.*}}: !ng.i16)
 func @i16(%arg0: !ng.i16) {
   "ng.return"() : () -> ()
 }
 
 // -----
 
-// CHECK: func @i32(%{{.*}}: i32)
+// CHECK-LABEL: func @i32
+// CHECK-SAME: (%{{.*}}: !ng.i32)
 func @i32(%arg0: !ng.i32) {
   "ng.return"() : () -> ()
 }
 
 // -----
 
-// CHECK: func @i64(%{{.*}}: i64)
+// CHECK-LABEL: func @i64
+// CHECK-SAME: (%{{.*}}: !ng.i64)
 func @i64(%arg0: !ng.i64) {
   "ng.return"() : () -> ()
 }
 
 // -----
 
-// CHECK: func @u8(%{{.*}}: i8)
+// CHECK-LABEL: func @u8
+// CHECK-SAME: (%{{.*}}: !ng.i8)
 func @u8(%arg0: !ng.u8) {
   "ng.return"() : () -> ()
 }
 
 // -----
 
-// CHECK: func @u16(%{{.*}}: i16)
+// CHECK-LABEL: func @u16
+// CHECK-SAME: (%{{.*}}: !ng.i16)
 func @u16(%arg0: !ng.u16) {
   "ng.return"() : () -> ()
 }
 
 // -----
 
-// CHECK: func @u32(%{{.*}}: i32)
+// CHECK-LABEL: func @u32
+// CHECK-SAME: (%{{.*}}: !ng.i32)
 func @u32(%arg0: !ng.u32) {
   "ng.return"() : () -> ()
 }
 
 // -----
 
-// CHECK: func @u64(%{{.*}}: i64)
+// CHECK: func @u64
+// CHECK-SAME (%{{.*}}: !ng.i64)
 func @u64(%arg0: !ng.u64) {
   "ng.return"() : () -> ()
 }

--- a/test/mlir/ngraph_dialect/types.mlir
+++ b/test/mlir/ngraph_dialect/types.mlir
@@ -1,0 +1,74 @@
+// RUN: ngraph-opt %s -convert-ngraph-to-affine -split-input-file | FileCheck %s
+
+// These tests verify that we can parse nGraph dialect types and lower them to affine.
+
+// -----
+
+// CHECK: func @f32(%{{.*}}: f32)
+func @f32(%arg0: f32) {
+  "ng.return"() : () -> ()
+}
+
+// -----
+
+// CHECK: func @f64(%{{.*}}: f64)
+func @f64(%arg0: f64) {
+  "ng.return"() : () -> ()
+}
+
+// -----
+
+// CHECK: func @i8(%{{.*}}: i8)
+func @i8(%arg0: !ng.i8) {
+  "ng.return"() : () -> ()
+}
+
+// -----
+
+// CHECK: func @i16(%{{.*}}: i16)
+func @i16(%arg0: !ng.i16) {
+  "ng.return"() : () -> ()
+}
+
+// -----
+
+// CHECK: func @i32(%{{.*}}: i32)
+func @i32(%arg0: !ng.i32) {
+  "ng.return"() : () -> ()
+}
+
+// -----
+
+// CHECK: func @i64(%{{.*}}: i64)
+func @i64(%arg0: !ng.i64) {
+  "ng.return"() : () -> ()
+}
+
+// -----
+
+// CHECK: func @u8(%{{.*}}: i8)
+func @u8(%arg0: !ng.u8) {
+  "ng.return"() : () -> ()
+}
+
+// -----
+
+// CHECK: func @u16(%{{.*}}: i16)
+func @u16(%arg0: !ng.u16) {
+  "ng.return"() : () -> ()
+}
+
+// -----
+
+// CHECK: func @u32(%{{.*}}: i32)
+func @u32(%arg0: !ng.u32) {
+  "ng.return"() : () -> ()
+}
+
+// -----
+
+// CHECK: func @u64(%{{.*}}: i64)
+func @u64(%arg0: !ng.u64) {
+  "ng.return"() : () -> ()
+}
+


### PR DESCRIPTION
It introduces initial support for parsing nGraph signed/unsigned
integer and floating point data types.