### PR TITLE
Add missing input (#3691)

### DIFF
--- a/src/ngraph/node.cpp
+++ b/src/ngraph/node.cpp
@@ -330,7 +330,13 @@ shared_ptr<Node> Node::add_provenance_group_members_above(const OutputVector& ba
     set<Node*> base_set;
     for (auto& output : base)
     {
-        base_set.insert(output.get_node());
+        Node* node = output.get_node();
+        if (node == this)
+        {
+            // A builder did nothing
+            return shared_from_this();
+        }
+        base_set.insert(node);
     }
     vector<Node*> todo;
     for (auto value : input_values())

--- a/test/provenance.cpp
+++ b/test/provenance.cpp
@@ -377,3 +377,24 @@ TEST(provenance, fused)
         }
     });
 }
+
+TEST(provenance, empty_group)
+{
+    auto p1 = make_shared<op::Parameter>(element::i32, PartialShape{2, 3, 4});
+    p1->add_provenance_tag("P1");
+    auto abs = make_shared<op::Abs>(p1);
+    // Make sure group is empty
+    abs->add_provenance_group_members_above({abs});
+    abs->add_provenance_tag("abs");
+    for (auto node : topological_sort(NodeVector{abs}))
+    {
+        if (node == p1)
+        {
+            EXPECT_EQ(node->get_provenance_tags(), (ProvSet{"P1"}));
+        }
+        else
+        {
+            EXPECT_EQ(node->get_provenance_tags(), (ProvSet{"abs"}));
+        }
+    }
+}


### PR DESCRIPTION
If `add_provenance_group_members_above` is called on a node with the node in the list of "above" nodes, as happens when a builder doesn't need to do anything, don't create a group of all the node's inputs.