### PR TITLE
Restrict check to specific input for get_argument.

### DIFF
--- a/src/ngraph/node.cpp
+++ b/src/ngraph/node.cpp
@@ -345,13 +345,10 @@ void Node::merge_provenance_tags_from(const std::shared_ptr<const Node>& source)
 
 std::shared_ptr<Node> Node::get_argument(size_t index) const
 {
-    for (auto& i : m_inputs)
-    {
-        NGRAPH_CHECK(i.get_output().get_node()->get_output_size() == 1,
-                     "child ",
-                     i.get_output().get_node()->get_name(),
-                     " has multiple outputs");
-    }
+    NGRAPH_CHECK(m_inputs.at(index).get_output().get_node()->get_output_size() == 1,
+                 "child ",
+                 m_inputs.at(index).get_output().get_node()->get_name(),
+                 " has multiple outputs");
     return m_inputs.at(index).get_output().get_node();
 }
 


### PR DESCRIPTION
The get_argument(index) checks for all inputs. I am facing an instance where the validation of Sum node[1] is being done for both inputs (output and reduction_axes) while my guess is it should be restircted only to reduction_axes.  I have put more context of the problem in ngraph slack. 

[1]
 Sum(const Output<Node>& arg, const AxisSet& reduction_axes)