### PR TITLE
Fix Node::get_argment() check

### DIFF
--- a/src/ngraph/node.cpp
+++ b/src/ngraph/node.cpp
@@ -420,13 +420,6 @@ void Node::merge_provenance_tags_from(const std::shared_ptr<const Node>& source)
 
 std::shared_ptr<Node> Node::get_argument(size_t index) const
 {
-    for (auto& i : m_inputs)
-    {
-        NGRAPH_CHECK(i.get_output().get_node()->get_output_size() == 1,
-                     "child ",
-                     i.get_output().get_node()->get_name(),
-                     " has multiple outputs");
-    }
     return m_inputs.at(index).get_output().get_node();
 }
 


### PR DESCRIPTION
The check inside this function was incorrect and not needed. With Input<Node> there is no need to check anything in this function for multiple outputs.
This is the r0.26 version of PR #3721 