### PR TITLE
Use correct call to get input's node

### DIFF
--- a/src/ngraph/op/util/arithmetic_reduction.cpp
+++ b/src/ngraph/op/util/arithmetic_reduction.cpp
@@ -42,13 +42,13 @@ op::util::ArithmeticReduction::ArithmeticReduction(const Output<Node>& arg,
 
 bool op::util::ArithmeticReduction::reduction_axes_constant() const
 {
-    return dynamic_pointer_cast<op::Constant>(get_argument(1)) != nullptr;
+    return dynamic_pointer_cast<op::Constant>(input_value(1).get_node()) != nullptr;
 }
 
 const AxisSet op::util::ArithmeticReduction::get_reduction_axes() const
 {
     AxisSet axes;
-    if (auto const_op = dynamic_pointer_cast<op::Constant>(get_argument(1)))
+    if (auto const_op = dynamic_pointer_cast<op::Constant>(input_value(1).get_node()))
     {
         axes = const_op->get_axis_set_val();
     }


### PR DESCRIPTION
Sum currently does not validate if input node has more than one output.