### PR TITLE
Partially fixed visibility for symbols:

### DIFF
--- a/src/ngraph/CMakeLists.txt
+++ b/src/ngraph/CMakeLists.txt
@@ -601,7 +601,6 @@ target_compile_definitions(ngraph
     PRIVATE
         SHARED_LIB_PREFIX="${CMAKE_SHARED_LIBRARY_PREFIX}"
         SHARED_LIB_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}"
-        NGRAPH_DLL_EXPORTS
 )
 if(NGRAPH_LIB_VERSIONING_ENABLE)
     set_target_properties(ngraph PROPERTIES

--- a/src/ngraph/function.hpp
+++ b/src/ngraph/function.hpp
@@ -30,7 +30,7 @@
 namespace ngraph
 {
     /// A user-defined function.
-    class Function
+    class NGRAPH_API Function
     {
     public:
         Function(const NodeVector& results,

--- a/src/ngraph/ngraph_visibility.hpp
+++ b/src/ngraph/ngraph_visibility.hpp
@@ -20,8 +20,8 @@
 // NGRAPH_API is used for the public API symbols. It either DLL imports or DLL exports
 //    (or does nothing for static build)
 
-#ifdef NGRAPH_DLL_EXPORTS // defined if we are building the NGRAPH DLL (instead of using it)
+#ifdef ngraph_EXPORTS // defined if we are building the NGRAPH DLL (instead of using it)
 #define NGRAPH_API NGRAPH_HELPER_DLL_EXPORT
 #else
 #define NGRAPH_API NGRAPH_HELPER_DLL_IMPORT
-#endif // NGRAPH_DLL_EXPORTS
+#endif // ngraph_EXPORTS

--- a/src/ngraph/node.hpp
+++ b/src/ngraph/node.hpp
@@ -87,7 +87,7 @@ namespace ngraph
     /// Nodes are the backbone of the graph of Value dataflow. Every node has
     /// zero or more nodes as arguments and one value, which is either a tensor
     /// or a (possibly empty) tuple of values.
-    class Node : public std::enable_shared_from_this<Node>
+    class NGRAPH_API Node : public std::enable_shared_from_this<Node>
     {
         // For access to generate_adjoints.
         friend class autodiff::Adjoints;

--- a/src/ngraph/op/abs.hpp
+++ b/src/ngraph/op/abs.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Elementwise absolute value operation.
         ///
-        class Abs : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Abs : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/acos.hpp
+++ b/src/ngraph/op/acos.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Elementwise inverse cosine (arccos) operation.
         ///
-        class Acos : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Acos : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/add.hpp
+++ b/src/ngraph/op/add.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Elementwise addition operation.
         ///
-        class Add : public util::BinaryElementwiseArithmetic
+        class NGRAPH_API Add : public util::BinaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/all.hpp
+++ b/src/ngraph/op/all.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Logical "all" reduction operation.
-        class All : public util::LogicalReduction
+        class NGRAPH_API All : public util::LogicalReduction
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/allreduce.hpp
+++ b/src/ngraph/op/allreduce.hpp
@@ -23,7 +23,7 @@ namespace ngraph
 {
     namespace op
     {
-        class AllReduce : public Op
+        class NGRAPH_API AllReduce : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/and.hpp
+++ b/src/ngraph/op/and.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Elementwise logical-and operation.
         ///
-        class And : public util::BinaryElementwiseLogical
+        class NGRAPH_API And : public util::BinaryElementwiseLogical
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/any.hpp
+++ b/src/ngraph/op/any.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Logical "any" reduction operation.
-        class Any : public util::LogicalReduction
+        class NGRAPH_API Any : public util::LogicalReduction
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/argmax.hpp
+++ b/src/ngraph/op/argmax.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Computes minimum index along a specified axis for a given tensor
-        class ArgMax : public op::util::IndexReduction
+        class NGRAPH_API ArgMax : public op::util::IndexReduction
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/argmin.hpp
+++ b/src/ngraph/op/argmin.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Computes minimum index along a specified axis for a given tensor
-        class ArgMin : public op::util::IndexReduction
+        class NGRAPH_API ArgMin : public op::util::IndexReduction
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/asin.hpp
+++ b/src/ngraph/op/asin.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Elementwise inverse sine (arcsin) operation.
         ///
-        class Asin : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Asin : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/atan.hpp
+++ b/src/ngraph/op/atan.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Elementwise inverse tangent (arctan) operation.
         ///
-        class Atan : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Atan : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/avg_pool.hpp
+++ b/src/ngraph/op/avg_pool.hpp
@@ -27,7 +27,7 @@ namespace ngraph
         {
             /// \brief Batched average pooling operation, with optional padding and window stride.
             ///
-            class AvgPool : public Op
+            class NGRAPH_API AvgPool : public Op
             {
             public:
                 NGRAPH_API
@@ -171,7 +171,7 @@ namespace ngraph
                 bool m_ceil_mode{false};
             };
 
-            class AvgPoolBackprop : public Op
+            class NGRAPH_API AvgPoolBackprop : public Op
             {
             public:
                 NGRAPH_API
@@ -219,7 +219,7 @@ namespace ngraph
         {
             /// \brief Batched average pooling operation.
             ///
-            class AvgPool : public Op
+            class NGRAPH_API AvgPool : public Op
             {
             public:
                 NGRAPH_API
@@ -320,7 +320,7 @@ namespace ngraph
                 op::RoundingType m_rounding_type{op::RoundingType::FLOOR};
             };
 
-            class AvgPoolBackprop : public Op
+            class NGRAPH_API AvgPoolBackprop : public Op
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/batch_norm.hpp
+++ b/src/ngraph/op/batch_norm.hpp
@@ -27,7 +27,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Batchnorm for training operation
-        class BatchNormTraining : public Op
+        class NGRAPH_API BatchNormTraining : public Op
         {
         public:
             NGRAPH_API
@@ -88,7 +88,7 @@ namespace ngraph
             double m_epsilon;
         };
 
-        class BatchNormInference : public Op
+        class NGRAPH_API BatchNormInference : public Op
         {
         public:
             NGRAPH_API
@@ -158,7 +158,7 @@ namespace ngraph
             double m_epsilon;
         };
 
-        class BatchNormTrainingBackprop : public Op
+        class NGRAPH_API BatchNormTrainingBackprop : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/broadcast.hpp
+++ b/src/ngraph/op/broadcast.hpp
@@ -25,7 +25,7 @@ namespace ngraph
     {
         /// \brief Operation which "adds" axes to an input tensor, replicating elements from the
         ///        input as needed along the new axes.
-        class Broadcast : public Op
+        class NGRAPH_API Broadcast : public Op
         {
         public:
             NGRAPH_API
@@ -67,7 +67,7 @@ namespace ngraph
         };
 
         /// \brief Broadcast arg to the same shape as like_arg.
-        class BroadcastLike : public Broadcast
+        class NGRAPH_API BroadcastLike : public Broadcast
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/broadcast_distributed.hpp
+++ b/src/ngraph/op/broadcast_distributed.hpp
@@ -24,7 +24,7 @@ namespace ngraph
 {
     namespace op
     {
-        class BroadcastDistributed : public Op
+        class NGRAPH_API BroadcastDistributed : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/ceiling.hpp
+++ b/src/ngraph/op/ceiling.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise ceiling operation.
-        class Ceiling : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Ceiling : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/concat.hpp
+++ b/src/ngraph/op/concat.hpp
@@ -25,7 +25,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Concatenation operation.
-        class Concat : public Op
+        class NGRAPH_API Concat : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/constant.hpp
+++ b/src/ngraph/op/constant.hpp
@@ -30,7 +30,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Class for constants.
-        class Constant : public Node
+        class NGRAPH_API Constant : public Node
         {
         public:
             NGRAPH_API
@@ -347,7 +347,7 @@ namespace ngraph
             Constant operator=(const Constant&) = delete;
         };
 
-        class ScalarConstantLikeBase : public Constant
+        class NGRAPH_API ScalarConstantLikeBase : public Constant
         {
         public:
             NGRAPH_API
@@ -363,7 +363,7 @@ namespace ngraph
         };
 
         /// \brief A scalar constant whose element type is the same as like.
-        class ScalarConstantLike : public ScalarConstantLikeBase
+        class NGRAPH_API ScalarConstantLike : public ScalarConstantLikeBase
         {
         public:
             /// \brief A scalar constant whose element type is the same as like.

--- a/src/ngraph/op/convert.hpp
+++ b/src/ngraph/op/convert.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise type conversion operation.
-        class Convert : public Op
+        class NGRAPH_API Convert : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/convolution.hpp
+++ b/src/ngraph/op/convolution.hpp
@@ -28,7 +28,7 @@ namespace ngraph
         {
             /// \brief Batched convolution operation, with optional window dilation and stride.
             ///
-            class Convolution : public Op
+            class NGRAPH_API Convolution : public Op
             {
             public:
                 NGRAPH_API
@@ -98,7 +98,7 @@ namespace ngraph
             };
 
             /// \brief Data batch backprop for batched convolution operation.
-            class ConvolutionBackpropData : public Op
+            class NGRAPH_API ConvolutionBackpropData : public Op
             {
             public:
                 NGRAPH_API
@@ -162,7 +162,7 @@ namespace ngraph
             };
 
             /// \brief Filters backprop for batched convolution operation.
-            class ConvolutionBackpropFilters : public Op
+            class NGRAPH_API ConvolutionBackpropFilters : public Op
             {
             public:
                 NGRAPH_API
@@ -224,7 +224,7 @@ namespace ngraph
         {
             /// \brief Batched convolution operation, with optional window dilation and stride.
             ///
-            class Convolution : public Op
+            class NGRAPH_API Convolution : public Op
             {
             public:
                 NGRAPH_API
@@ -399,7 +399,7 @@ namespace ngraph
             };
 
             /// \brief Data batch backprop for batched convolution operation.
-            class ConvolutionBackpropData : public Op
+            class NGRAPH_API ConvolutionBackpropData : public Op
             {
             public:
                 NGRAPH_API
@@ -504,7 +504,7 @@ namespace ngraph
             };
 
             /// \brief Filters backprop for batched convolution operation.
-            class ConvolutionBackpropFilters : public Op
+            class NGRAPH_API ConvolutionBackpropFilters : public Op
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/cos.hpp
+++ b/src/ngraph/op/cos.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise cosine operation.
-        class Cos : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Cos : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/cosh.hpp
+++ b/src/ngraph/op/cosh.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise hyperbolic cosine (cosh) operation.
-        class Cosh : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Cosh : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/divide.hpp
+++ b/src/ngraph/op/divide.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise division operation.
-        class Divide : public util::BinaryElementwiseArithmetic
+        class NGRAPH_API Divide : public util::BinaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/dot.hpp
+++ b/src/ngraph/op/dot.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Generalized dot product operation, including scalar-tensor product, matrix-vector
         ///        product, and matrix multiplication.
-        class Dot : public Op
+        class NGRAPH_API Dot : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/embedding_lookup.hpp
+++ b/src/ngraph/op/embedding_lookup.hpp
@@ -24,7 +24,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Returns embeddings for given indices
-        class EmbeddingLookup : public Op
+        class NGRAPH_API EmbeddingLookup : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/equal.hpp
+++ b/src/ngraph/op/equal.hpp
@@ -39,7 +39,7 @@ namespace ngraph
         /// | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
         /// | \f$\texttt{bool}[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = 1\text{ if }\texttt{arg0}[i_1,\dots,i_n] = \texttt{arg1}[i_1,\dots,i_n]\text{, else } 0\f$ |
         // clang-format on
-        class Equal : public util::BinaryElementwiseComparison
+        class NGRAPH_API Equal : public util::BinaryElementwiseComparison
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/erf.hpp
+++ b/src/ngraph/op/erf.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace op
     {
-        class Erf : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Erf : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/exp.hpp
+++ b/src/ngraph/op/exp.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise natural exponential (exp) operation.
-        class Exp : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Exp : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/batch_mat_mul.hpp
+++ b/src/ngraph/op/experimental/batch_mat_mul.hpp
@@ -29,7 +29,7 @@ namespace ngraph
         /// For example, for `a` with shape `(batch_size, n, k)`, and `b` with
         /// shape `(batch_size, k, m)`, the result of BatchMatMul will have shape
         /// `(batch_size, n, m)`, and `BatchMatMul(a, b)[i] = Dot(a[i], b[i])`.
-        class BatchMatMul : public Op
+        class NGRAPH_API BatchMatMul : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/compiled_kernel.cpp
+++ b/src/ngraph/op/experimental/compiled_kernel.cpp
@@ -71,7 +71,7 @@ shared_ptr<Node> ngraph::op::CompiledKernel::copy_with_new_args(const NodeVector
     {
         ck->insert_to_input_map(it.first, it.second);
     }
-    return ck;
+    return std::move(ck);
 }
 
 ngraph::op::CompiledKernel::CompiledKernel(const OutputVector& node_list,

--- a/src/ngraph/op/experimental/compiled_kernel.hpp
+++ b/src/ngraph/op/experimental/compiled_kernel.hpp
@@ -28,7 +28,7 @@ namespace ngraph
         /// This op can be used to delimit sub-graphs that with special compilation requirements
         /// within a function. For example, we currently use it to delimit sub-graphs that will be
         /// independently compiled and executed by MLIR backend.
-        class CompiledKernel : public ngraph::op::Op
+        class NGRAPH_API CompiledKernel : public ngraph::op::Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/dyn_broadcast.hpp
+++ b/src/ngraph/op/experimental/dyn_broadcast.hpp
@@ -27,7 +27,7 @@ namespace ngraph
         ///        input as needed along the new axes.
         ///
         /// This is basically the "dynamic shape" version of the static Broadcast op.
-        class DynBroadcast : public Op
+        class NGRAPH_API DynBroadcast : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/dyn_pad.hpp
+++ b/src/ngraph/op/experimental/dyn_pad.hpp
@@ -24,7 +24,7 @@ namespace ngraph
     {
         /// \brief Generic padding operation which takes padding below and above as dynamic shapes.
         /// This is similar to existing Pad operation except padding values are dynamic.
-        class DynPad : public Op
+        class NGRAPH_API DynPad : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/dyn_replace_slice.hpp
+++ b/src/ngraph/op/experimental/dyn_replace_slice.hpp
@@ -25,7 +25,7 @@ namespace ngraph
     {
         /// \brief Takes a slice of an input tensor, i.e., the sub-tensor that resides within a
         ///        bounding box, optionally with stride.
-        class DynReplaceSlice : public Op
+        class NGRAPH_API DynReplaceSlice : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/dyn_reshape.hpp
+++ b/src/ngraph/op/experimental/dyn_reshape.hpp
@@ -30,7 +30,7 @@ namespace ngraph
             /// "Converts" an input tensor into a new shape with the same number of elements.
             /// This op does not touch the actual data. If needed, use Transpose for that purpose.
             ///
-            class DynReshape : public Op
+            class NGRAPH_API DynReshape : public Op
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/experimental/dyn_slice.hpp
+++ b/src/ngraph/op/experimental/dyn_slice.hpp
@@ -25,7 +25,7 @@ namespace ngraph
     {
         /// \brief Takes a slice of an input tensor, i.e., the sub-tensor that resides within a
         ///        bounding box, optionally with stride.
-        class DynSlice : public Op
+        class NGRAPH_API DynSlice : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/generate_mask.hpp
+++ b/src/ngraph/op/experimental/generate_mask.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief GenerateMask
         ///
-        class GenerateMask : public op::Op
+        class NGRAPH_API GenerateMask : public op::Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/ctc_greedy_decoder.hpp
+++ b/src/ngraph/op/experimental/layers/ctc_greedy_decoder.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace op
     {
-        class CTCGreedyDecoder : public Op
+        class NGRAPH_API CTCGreedyDecoder : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/detection_output.hpp
+++ b/src/ngraph/op/experimental/layers/detection_output.hpp
@@ -44,7 +44,7 @@ namespace ngraph
 
         /// \brief Layer which performs non-max suppression to
         /// generate detection output using location and confidence predictions
-        class DetectionOutput : public Op
+        class NGRAPH_API DetectionOutput : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/interpolate.hpp
+++ b/src/ngraph/op/experimental/layers/interpolate.hpp
@@ -33,7 +33,7 @@ namespace ngraph
         } InterpolateAttrs;
 
         /// \brief Layer which performs bilinear interpolation
-        class Interpolate : public Op
+        class NGRAPH_API Interpolate : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/prior_box.hpp
+++ b/src/ngraph/op/experimental/layers/prior_box.hpp
@@ -46,7 +46,7 @@ namespace ngraph
 
         /// \brief Layer which generates prior boxes of specified sizes
         /// normalized to input image size
-        class PriorBox : public Op
+        class NGRAPH_API PriorBox : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/prior_box_clustered.hpp
+++ b/src/ngraph/op/experimental/layers/prior_box_clustered.hpp
@@ -44,7 +44,7 @@ namespace ngraph
 
         /// \brief Layer which generates prior boxes of specified sizes
         /// normalized to input image size
-        class PriorBoxClustered : public Op
+        class NGRAPH_API PriorBoxClustered : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/proposal.hpp
+++ b/src/ngraph/op/experimental/layers/proposal.hpp
@@ -54,7 +54,7 @@ namespace ngraph
             std::string framework;
         };
 
-        class Proposal : public Op
+        class NGRAPH_API Proposal : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/psroi_pooling.hpp
+++ b/src/ngraph/op/experimental/layers/psroi_pooling.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace op
     {
-        class PSROIPooling : public Op
+        class NGRAPH_API PSROIPooling : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/region_yolo.hpp
+++ b/src/ngraph/op/experimental/layers/region_yolo.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace op
     {
-        class RegionYolo : public Op
+        class NGRAPH_API RegionYolo : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/reorg_yolo.hpp
+++ b/src/ngraph/op/experimental/layers/reorg_yolo.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace op
     {
-        class ReorgYolo : public Op
+        class NGRAPH_API ReorgYolo : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/layers/roi_pooling.hpp
+++ b/src/ngraph/op/experimental/layers/roi_pooling.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace op
     {
-        class ROIPooling : public Op
+        class NGRAPH_API ROIPooling : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/quantized_conv_bias.hpp
+++ b/src/ngraph/op/experimental/quantized_conv_bias.hpp
@@ -24,7 +24,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Convolution + bias forward prop for batched convolution operation.
-        class QuantizedConvolutionBias : public Op
+        class NGRAPH_API QuantizedConvolutionBias : public Op
         {
         public:
             NGRAPH_API
@@ -63,7 +63,7 @@ namespace ngraph
             bool m_with_relu;
         };
 
-        class QuantizedConvolutionBiasAdd : public Op
+        class NGRAPH_API QuantizedConvolutionBiasAdd : public Op
         {
         public:
             NGRAPH_API
@@ -103,7 +103,7 @@ namespace ngraph
             bool m_with_relu;
         };
 
-        class QuantizedConvolutionBiasSignedAdd : public Op
+        class NGRAPH_API QuantizedConvolutionBiasSignedAdd : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/quantized_conv_relu.hpp
+++ b/src/ngraph/op/experimental/quantized_conv_relu.hpp
@@ -24,7 +24,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Relu(Convolution) forward prop for batched convolution operation.
-        class QuantizedConvolutionRelu : public Op
+        class NGRAPH_API QuantizedConvolutionRelu : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/quantized_dot_bias.hpp
+++ b/src/ngraph/op/experimental/quantized_dot_bias.hpp
@@ -24,7 +24,7 @@ namespace ngraph
 {
     namespace op
     {
-        class QuantizedDotBias : public Op
+        class NGRAPH_API QuantizedDotBias : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/range.hpp
+++ b/src/ngraph/op/experimental/range.hpp
@@ -24,7 +24,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Range operation, analogous to `range()` in Python.
-        class Range : public Op
+        class NGRAPH_API Range : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/shape_of.hpp
+++ b/src/ngraph/op/experimental/shape_of.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Operation that returns the shape of its input argument as a tensor.
-        class ShapeOf : public Op
+        class NGRAPH_API ShapeOf : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/tile.hpp
+++ b/src/ngraph/op/experimental/tile.hpp
@@ -24,7 +24,7 @@ namespace ngraph
     {
         /// \brief Dynamic Tiling operation which repeats a tensor multiple times
         ///        along each dimension
-        class Tile : public Op
+        class NGRAPH_API Tile : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/experimental/transpose.hpp
+++ b/src/ngraph/op/experimental/transpose.hpp
@@ -25,7 +25,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Tensor transpose operation.
-        class Transpose : public Op
+        class NGRAPH_API Transpose : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/floor.hpp
+++ b/src/ngraph/op/floor.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise floor operation.
-        class Floor : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Floor : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/clamp.hpp
+++ b/src/ngraph/op/fused/clamp.hpp
@@ -29,7 +29,7 @@ namespace ngraph
         /// All input values that are outside of the <min;max> range are set to 'min' or 'max'
         /// depending on which side of the <min;max> range they are. The values that fall into
         /// this range remain unchanged.
-        class Clamp : public ngraph::op::util::FusedOp
+        class NGRAPH_API Clamp : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/conv_fused.hpp
+++ b/src/ngraph/op/fused/conv_fused.hpp
@@ -25,7 +25,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Convolution + bias forward prop for batched convolution operation.
-        class ConvolutionBias : public ngraph::op::util::FusedOp
+        class NGRAPH_API ConvolutionBias : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API
@@ -80,7 +80,7 @@ namespace ngraph
 
         /// \brief Filters and bias backprop for batched convolution operation. Data backprop is
         /// the same as regular convolution backprop for data.
-        class ConvolutionBiasBackpropFiltersBias : public ngraph::op::util::FusedOp
+        class NGRAPH_API ConvolutionBiasBackpropFiltersBias : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API
@@ -174,7 +174,7 @@ namespace ngraph
             Strides m_data_dilation_strides_backward;
         };
 
-        class ConvolutionBiasAdd : public ngraph::op::util::FusedOp
+        class NGRAPH_API ConvolutionBiasAdd : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/depth_to_space.hpp
+++ b/src/ngraph/op/fused/depth_to_space.hpp
@@ -32,7 +32,7 @@ namespace ngraph
         ///
         ///        Output node produces a tensor with shape:
         ///        [N, C/(blocksize * blocksize), H * blocksize, W * blocksize]
-        class DepthToSpace : public ngraph::op::util::FusedOp
+        class NGRAPH_API DepthToSpace : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/elu.hpp
+++ b/src/ngraph/op/fused/elu.hpp
@@ -28,7 +28,7 @@ namespace ngraph
         /// x <  0 => f(x) = alpha * (exp(x) - 1.)
         /// x >= 0 => f(x) = x
         ///
-        class Elu : public ngraph::op::util::FusedOp
+        class NGRAPH_API Elu : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/fake_quantize.hpp
+++ b/src/ngraph/op/fused/fake_quantize.hpp
@@ -37,7 +37,7 @@ namespace ngraph
         ///                 (levels-1) * (output_high - output_low) + output_low
         ///
         ///
-        class FakeQuantize : public ngraph::op::util::FusedOp
+        class NGRAPH_API FakeQuantize : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/gelu.hpp
+++ b/src/ngraph/op/fused/gelu.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Gaussian Error Linear Unit
         /// f(x) = 0.5 * x * (1 + erf( x / sqrt(2) )
-        class Gelu : public ngraph::op::util::FusedOp
+        class NGRAPH_API Gelu : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API
@@ -51,7 +51,7 @@ namespace ngraph
         };
 
         /// \brief Backprop for Gelu(x) is GeluBackprop(x) * delta
-        class GeluBackpropFactor : public util::FusedOp
+        class NGRAPH_API GeluBackpropFactor : public util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/gemm.hpp
+++ b/src/ngraph/op/fused/gemm.hpp
@@ -34,7 +34,7 @@ namespace ngraph
         ///
         /// Compute Y = alpha * A' * B' + beta * C
         ///
-        class Gemm : public ngraph::op::util::FusedOp
+        class NGRAPH_API Gemm : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/grn.hpp
+++ b/src/ngraph/op/fused/grn.hpp
@@ -27,7 +27,7 @@ namespace ngraph
     {
         /// \brief  Global Response Normalization with L2 norm (across channels only).
         ///
-        class GRN : public ngraph::op::util::FusedOp
+        class NGRAPH_API GRN : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/group_conv.hpp
+++ b/src/ngraph/op/fused/group_conv.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Group Convolution
-        class GroupConvolution : public ngraph::op::util::FusedOp
+        class NGRAPH_API GroupConvolution : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/group_conv_transpose.hpp
+++ b/src/ngraph/op/fused/group_conv_transpose.hpp
@@ -32,7 +32,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Group Transpose Convolution (Deconvolution)
-        class GroupConvolutionTranspose : public util::FusedOp
+        class NGRAPH_API GroupConvolutionTranspose : public util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/gru_cell.hpp
+++ b/src/ngraph/op/fused/gru_cell.hpp
@@ -38,7 +38,7 @@ namespace ngraph
         ///
         ///             Note this class represents only single *cell* and not whole GRU *layer*.
         ///
-        class GRUCell : public util::FusedOp, public util::RNNCellBase
+        class NGRAPH_API GRUCell : public util::FusedOp, public util::RNNCellBase
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/hard_sigmoid.hpp
+++ b/src/ngraph/op/fused/hard_sigmoid.hpp
@@ -27,7 +27,7 @@ namespace ngraph
         /// \brief      Parameterized, bounded sigmoid-like, piecewise linear
         ///             function. min(max(alpha*x + beta, 0), 1)
         ///
-        class HardSigmoid : public ngraph::op::util::FusedOp
+        class NGRAPH_API HardSigmoid : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/lstm_cell.hpp
+++ b/src/ngraph/op/fused/lstm_cell.hpp
@@ -39,7 +39,7 @@ namespace ngraph
         ///
         ///             Note this class represents only single *cell* and not whole LSTM *layer*.
         ///
-        class LSTMCell : public util::FusedOp, public util::RNNCellBase
+        class NGRAPH_API LSTMCell : public util::FusedOp, public util::RNNCellBase
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/matmul.hpp
+++ b/src/ngraph/op/fused/matmul.hpp
@@ -25,7 +25,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Operator performing Matrix Multiplication.
-        class MatMul : public ngraph::op::util::FusedOp
+        class NGRAPH_API MatMul : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/mvn.hpp
+++ b/src/ngraph/op/fused/mvn.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Operator performing Mean Variance Normalization
         ///
-        class MVN : public ngraph::op::util::FusedOp
+        class NGRAPH_API MVN : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/normalize_l2.hpp
+++ b/src/ngraph/op/fused/normalize_l2.hpp
@@ -28,7 +28,7 @@ namespace ngraph
     {
         /// \brief  Normalization input tensor with L2 norm.
         ///
-        class NormalizeL2 : public ngraph::op::util::FusedOp
+        class NGRAPH_API NormalizeL2 : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/prelu.hpp
+++ b/src/ngraph/op/fused/prelu.hpp
@@ -28,7 +28,7 @@ namespace ngraph
         /// x <  0 => f(x) = x * slope
         /// x >= 0 => f(x) = x
         ///
-        class PRelu : public ngraph::op::util::FusedOp
+        class NGRAPH_API PRelu : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/rnn_cell.hpp
+++ b/src/ngraph/op/fused/rnn_cell.hpp
@@ -38,7 +38,7 @@ namespace ngraph
         ///
         ///             Note this class represents only single *cell* and not whole RNN *layer*.
         ///
-        class RNNCell : public util::FusedOp, public util::RNNCellBase
+        class NGRAPH_API RNNCell : public util::FusedOp, public util::RNNCellBase
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/scale_shift.hpp
+++ b/src/ngraph/op/fused/scale_shift.hpp
@@ -28,7 +28,7 @@ namespace ngraph
         ///
         /// Y = Scale * Data + Shift
         ///
-        class ScaleShift : public ngraph::op::util::FusedOp
+        class NGRAPH_API ScaleShift : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/shuffle_channels.hpp
+++ b/src/ngraph/op/fused/shuffle_channels.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Permutes data in the channel dimension of the input
-        class ShuffleChannels : public ngraph::op::util::FusedOp
+        class NGRAPH_API ShuffleChannels : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/space_to_depth.hpp
+++ b/src/ngraph/op/fused/space_to_depth.hpp
@@ -29,7 +29,7 @@ namespace ngraph
         ///
         ///        Output node produces a tensor with shape:
         ///        [N, C * blocksize * blocksize, H / blocksize, W / blocksize]
-        class SpaceToDepth : public ngraph::op::util::FusedOp
+        class NGRAPH_API SpaceToDepth : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/split.hpp
+++ b/src/ngraph/op/fused/split.hpp
@@ -27,7 +27,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Splits the input tensor into a list of smaller tensors ("pieces")
-        class Split : public ngraph::op::util::FusedOp
+        class NGRAPH_API Split : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/squared_difference.hpp
+++ b/src/ngraph/op/fused/squared_difference.hpp
@@ -27,7 +27,7 @@ namespace ngraph
         /// \brief Calculates an element-wise squared difference between two tensors
         ///
         /// y[i] = (x1[i] - x2[i])^2
-        class SquaredDifference : public ngraph::op::util::FusedOp
+        class NGRAPH_API SquaredDifference : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/squeeze.hpp
+++ b/src/ngraph/op/fused/squeeze.hpp
@@ -27,7 +27,7 @@ namespace ngraph
 {
     namespace op
     {
-        class Squeeze : public ngraph::op::util::FusedOp
+        class NGRAPH_API Squeeze : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/fused/unsqueeze.hpp
+++ b/src/ngraph/op/fused/unsqueeze.hpp
@@ -27,7 +27,7 @@ namespace ngraph
 {
     namespace op
     {
-        class Unsqueeze : public ngraph::op::util::FusedOp
+        class NGRAPH_API Unsqueeze : public ngraph::op::util::FusedOp
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/gather.hpp
+++ b/src/ngraph/op/gather.hpp
@@ -25,7 +25,7 @@ namespace ngraph
         namespace v0
         {
             /// \brief Gather slices from axis of params according to indices
-            class Gather : public Op
+            class NGRAPH_API Gather : public Op
             {
             public:
                 NGRAPH_API
@@ -55,7 +55,7 @@ namespace ngraph
         namespace v1
         {
             /// \brief Gather slices from axis of params according to indices
-            class Gather : public Op
+            class NGRAPH_API Gather : public Op
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/gather_nd.hpp
+++ b/src/ngraph/op/gather_nd.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Gather slices from params with shapes given by indices
-        class GatherND : public Op
+        class NGRAPH_API GatherND : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/get_output_element.hpp
+++ b/src/ngraph/op/get_output_element.hpp
@@ -25,7 +25,7 @@ namespace ngraph
         NodeVector get_output_elements(const std::shared_ptr<Node>& mon);
 
         /// \brief Operation to get an output from a node.
-        class GetOutputElement : public Op
+        class NGRAPH_API GetOutputElement : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/greater.hpp
+++ b/src/ngraph/op/greater.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise greater-than operation.
-        class Greater : public util::BinaryElementwiseComparison
+        class NGRAPH_API Greater : public util::BinaryElementwiseComparison
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/greater_eq.hpp
+++ b/src/ngraph/op/greater_eq.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise greater-than-or-equal operation.
-        class GreaterEq : public util::BinaryElementwiseComparison
+        class NGRAPH_API GreaterEq : public util::BinaryElementwiseComparison
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/less.hpp
+++ b/src/ngraph/op/less.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise less-than operation.
-        class Less : public util::BinaryElementwiseComparison
+        class NGRAPH_API Less : public util::BinaryElementwiseComparison
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/less_eq.hpp
+++ b/src/ngraph/op/less_eq.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise less-than-or-equal operation.
-        class LessEq : public util::BinaryElementwiseComparison
+        class NGRAPH_API LessEq : public util::BinaryElementwiseComparison
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/log.hpp
+++ b/src/ngraph/op/log.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise natural log operation.
-        class Log : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Log : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/lrn.hpp
+++ b/src/ngraph/op/lrn.hpp
@@ -37,7 +37,7 @@ namespace ngraph
         /// | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
         /// | \f$N[n, c, d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[n, c, d_1,\dots,d_n] = \frac{N[n,i,d_1,\dots,d_n]}{ (bias + alpha * (\sum_{i=max(0,(nsize-1)/2)}^{min(C, (nsize-1)/2)+1} N[n,i,d_1,\dots,d_n]^{2}) ^ {2})}\f$ |
         // clang-format on
-        class LRN : public Op
+        class NGRAPH_API LRN : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/max.hpp
+++ b/src/ngraph/op/max.hpp
@@ -26,7 +26,7 @@ namespace ngraph
         namespace v0
         {
             /// \brief Max-reduction operation.
-            class Max : public util::ArithmeticReduction
+            class NGRAPH_API Max : public util::ArithmeticReduction
             {
             public:
                 NGRAPH_API
@@ -58,7 +58,7 @@ namespace ngraph
 
         namespace v1
         {
-            class ReduceMax : public util::ArithmeticReductionKeepDims
+            class NGRAPH_API ReduceMax : public util::ArithmeticReductionKeepDims
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/max_pool.hpp
+++ b/src/ngraph/op/max_pool.hpp
@@ -26,7 +26,7 @@ namespace ngraph
         namespace v0
         {
             /// \brief Batched max pooling operation, with optional padding and window stride.
-            class MaxPool : public Op
+            class NGRAPH_API MaxPool : public Op
             {
             public:
                 NGRAPH_API
@@ -147,7 +147,7 @@ namespace ngraph
                 bool m_ceil_mode{false};
             };
 
-            class MaxPoolBackprop : public Op
+            class NGRAPH_API MaxPoolBackprop : public Op
             {
             public:
                 NGRAPH_API
@@ -207,7 +207,7 @@ namespace ngraph
         namespace v1
         {
             /// \brief Batched max pooling operation.
-            class MaxPool : public Op
+            class NGRAPH_API MaxPool : public Op
             {
             public:
                 NGRAPH_API
@@ -292,7 +292,7 @@ namespace ngraph
                 op::RoundingType m_rounding_type{op::RoundingType::FLOOR};
             };
 
-            class MaxPoolBackprop : public Op
+            class NGRAPH_API MaxPoolBackprop : public Op
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/maximum.hpp
+++ b/src/ngraph/op/maximum.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise maximum operation.
-        class Maximum : public util::BinaryElementwiseArithmetic
+        class NGRAPH_API Maximum : public util::BinaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/min.hpp
+++ b/src/ngraph/op/min.hpp
@@ -26,7 +26,7 @@ namespace ngraph
         namespace v0
         {
             /// \brief Min-reduction operation.
-            class Min : public util::ArithmeticReduction
+            class NGRAPH_API Min : public util::ArithmeticReduction
             {
             public:
                 NGRAPH_API
@@ -58,7 +58,7 @@ namespace ngraph
 
         namespace v1
         {
-            class ReduceMin : public util::ArithmeticReductionKeepDims
+            class NGRAPH_API ReduceMin : public util::ArithmeticReductionKeepDims
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/minimum.hpp
+++ b/src/ngraph/op/minimum.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise minimum operation.
-        class Minimum : public util::BinaryElementwiseArithmetic
+        class NGRAPH_API Minimum : public util::BinaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/multiply.hpp
+++ b/src/ngraph/op/multiply.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise multiplication operation.
-        class Multiply : public util::BinaryElementwiseArithmetic
+        class NGRAPH_API Multiply : public util::BinaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/negative.hpp
+++ b/src/ngraph/op/negative.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise negative operation.
-        class Negative : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Negative : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/not.hpp
+++ b/src/ngraph/op/not.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise logical negation operation.
-        class Not : public Op
+        class NGRAPH_API Not : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/not_equal.hpp
+++ b/src/ngraph/op/not_equal.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise not-equal operation.
-        class NotEqual : public util::BinaryElementwiseComparison
+        class NGRAPH_API NotEqual : public util::BinaryElementwiseComparison
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/one_hot.hpp
+++ b/src/ngraph/op/one_hot.hpp
@@ -44,7 +44,7 @@ namespace ngraph
         /// | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
         /// | \f$E[d_1,\dots,d_n]\f$ | The tensor \f$T'\f$, where \f$T'[i_1,\dots,i_{m-1},i_m,i_{m+1},\dots,i_n] = 1\f$ if \f$T[i_1,\dots,i_{m-1},i_{m+1},\dots,i_n] = i_m\f$, else \f$0\f$. However, \f$T'\f$ is undefined if any non-integral value or any out-of-bounds value is detected in the input tensor. |
         // clang-format on
-        class OneHot : public Op
+        class NGRAPH_API OneHot : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/op.hpp
+++ b/src/ngraph/op/op.hpp
@@ -27,7 +27,7 @@ namespace ngraph
     namespace op
     {
         /// Root of all actual ops
-        class Op : public Node
+        class NGRAPH_API Op : public Node
         {
         public:
             void set_op_annotations(std::shared_ptr<ngraph::op::util::OpAnnotations> op_annotations)

--- a/src/ngraph/op/or.hpp
+++ b/src/ngraph/op/or.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Elementwise logical-or operation.
         ///
-        class Or : public util::BinaryElementwiseLogical
+        class NGRAPH_API Or : public util::BinaryElementwiseLogical
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/pad.hpp
+++ b/src/ngraph/op/pad.hpp
@@ -27,7 +27,7 @@ namespace ngraph
         namespace v0
         {
             /// \brief Generic padding operation.
-            class Pad : public Op
+            class NGRAPH_API Pad : public Op
             {
             public:
                 NGRAPH_API
@@ -89,7 +89,7 @@ namespace ngraph
         namespace v1
         {
             /// \brief Generic padding operation.
-            class Pad : public Op
+            class NGRAPH_API Pad : public Op
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/parameter.hpp
+++ b/src/ngraph/op/parameter.hpp
@@ -20,7 +20,7 @@
 
 namespace ngraph
 {
-    class Function;
+    class NGRAPH_API Function;
     namespace op
     {
         /// \brief A function parameter.
@@ -28,7 +28,7 @@ namespace ngraph
         /// Parameters are nodes that represent the arguments that will be passed to user-defined
         /// functions. Function creation requires a sequence of parameters. Basic graph operations
         /// do not need parameters attached to a function.
-        class Parameter : public op::Op
+        class NGRAPH_API Parameter : public op::Op
         {
         protected:
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,

--- a/src/ngraph/op/passthrough.hpp
+++ b/src/ngraph/op/passthrough.hpp
@@ -31,11 +31,11 @@ namespace ngraph
         /// N.B. Not all backends support all operation languages; a
         /// given backend might only support a given passthrough
         /// operation language in certain modes.
-        class Passthrough;
+        class NGRAPH_API Passthrough;
     }
 }
 
-class ngraph::op::Passthrough final : public Op
+class NGRAPH_API ngraph::op::Passthrough final : public Op
 {
 public:
     NGRAPH_API

--- a/src/ngraph/op/power.hpp
+++ b/src/ngraph/op/power.hpp
@@ -38,7 +38,7 @@ namespace ngraph
         /// | ---------------------- | -------------------------------------------------------------------------------------------------------------- |
         /// | \f$N[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \texttt{arg0}[i_1,\dots,i_n]^{\texttt{arg1}[i_1,\dots,i_n]}\f$ |
         // clang-format on
-        class Power : public util::BinaryElementwiseArithmetic
+        class NGRAPH_API Power : public util::BinaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/product.hpp
+++ b/src/ngraph/op/product.hpp
@@ -27,7 +27,7 @@ namespace ngraph
             /// \brief Product reduction operation.
             ///
             /// Reduces the tensor, eliminating the specified reduction axes by taking the product.
-            class Product : public util::ArithmeticReduction
+            class NGRAPH_API Product : public util::ArithmeticReduction
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/quantize.hpp
+++ b/src/ngraph/op/quantize.hpp
@@ -27,7 +27,7 @@ namespace ngraph
         /// \brief Quantize operation
         ///        Maps real input (r) to quantized output (q) using scale (s), zero point (z) and
         ///        round mode: q = ROUND(r / s) + o
-        class Quantize : public ngraph::op::Op
+        class NGRAPH_API Quantize : public ngraph::op::Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/quantized_convolution.hpp
+++ b/src/ngraph/op/quantized_convolution.hpp
@@ -23,7 +23,7 @@ namespace ngraph
 {
     namespace op
     {
-        class QuantizedConvolution : public Op
+        class NGRAPH_API QuantizedConvolution : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/quantized_dot.hpp
+++ b/src/ngraph/op/quantized_dot.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace op
     {
-        class QuantizedDot : public Op
+        class NGRAPH_API QuantizedDot : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/recv.hpp
+++ b/src/ngraph/op/recv.hpp
@@ -24,7 +24,7 @@ namespace ngraph
 {
     namespace op
     {
-        class Recv : public Op
+        class NGRAPH_API Recv : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/relu.hpp
+++ b/src/ngraph/op/relu.hpp
@@ -29,7 +29,7 @@ namespace ngraph
     {
         /// \brief Elementwise Relu operation.
         ///
-        class Relu : public ngraph::op::util::UnaryElementwiseArithmetic
+        class NGRAPH_API Relu : public ngraph::op::util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API
@@ -50,7 +50,7 @@ namespace ngraph
 
         /// \brief Elementwise ReluBackprop operation.
         ///
-        class ReluBackprop : public ngraph::op::util::BinaryElementwiseArithmetic
+        class NGRAPH_API ReluBackprop : public ngraph::op::util::BinaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/replace_slice.hpp
+++ b/src/ngraph/op/replace_slice.hpp
@@ -50,7 +50,7 @@ namespace ngraph
         /// | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
         /// | \f$E[d_1,\dots,d_n]\f$ | The tensor \f$T\f$ where \f$T[i_1,\dots,i_n] = \texttt{arg1}[j_1,\dots,j_n]\f$ if \f$j_1,\dots,j_n\f$ is in bounds for `arg1` and for all \f$m\f$, \f$i_m = l_m + j_m s_m\f$, otherwise \f$\texttt{arg0}[i_1,\dots,i_n]\f$. |
         // clang-format on
-        class ReplaceSlice : public Op
+        class NGRAPH_API ReplaceSlice : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/reshape.hpp
+++ b/src/ngraph/op/reshape.hpp
@@ -62,7 +62,7 @@ namespace ngraph
         /// | ------------------------ | ------------------------------------------------------------------------------------------------------ |
         /// | \f$E[d'_1,\dots,d'_m]\f$ | The tensor \f$T\f$, where \f$T\f$ is the input tensor with its elements rearranged as described above. |
         // clang-format on
-        class Reshape : public Op
+        class NGRAPH_API Reshape : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/result.hpp
+++ b/src/ngraph/op/result.hpp
@@ -24,7 +24,7 @@ namespace ngraph
 {
     namespace op
     {
-        class Result : public Op
+        class NGRAPH_API Result : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/reverse.hpp
+++ b/src/ngraph/op/reverse.hpp
@@ -46,7 +46,7 @@ namespace ngraph
         /// | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
         /// | \f$E[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \texttt{arg}[j_1,\dots,j_n]\f$ and \f$j_k = d_k - i_k - 1\f$ if axis \f$k\f$ is in the reverse set; else \f$j_k = i_k\f$. |
         // clang-format on
-        class Reverse : public Op
+        class NGRAPH_API Reverse : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/reverse_sequence.hpp
+++ b/src/ngraph/op/reverse_sequence.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace op
     {
-        class ReverseSequence : public Op
+        class NGRAPH_API ReverseSequence : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/scatter_add.hpp
+++ b/src/ngraph/op/scatter_add.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Add updates to slices from inputs addressed by indices
-        class ScatterAdd : public Op
+        class NGRAPH_API ScatterAdd : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/scatter_nd_add.hpp
+++ b/src/ngraph/op/scatter_nd_add.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Add updates to slices from inputs addressed by indices
-        class ScatterNDAdd : public Op
+        class NGRAPH_API ScatterNDAdd : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/select.hpp
+++ b/src/ngraph/op/select.hpp
@@ -39,7 +39,7 @@ namespace ngraph
         /// | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
         /// | \f$E[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \texttt{arg1}[i_1,\dots,i_n]\text{ if }\texttt{arg0}[i_1,\dots,i_n] \neq 0\text{, else }\texttt{arg2}[i_1,\dots,i_n]\f$ |
         // clang-format on
-        class Select : public Op
+        class NGRAPH_API Select : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/send.hpp
+++ b/src/ngraph/op/send.hpp
@@ -24,7 +24,7 @@ namespace ngraph
 {
     namespace op
     {
-        class Send : public Op
+        class NGRAPH_API Send : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/sigmoid.hpp
+++ b/src/ngraph/op/sigmoid.hpp
@@ -25,7 +25,7 @@ namespace ngraph
 {
     namespace op
     {
-        class Sigmoid : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Sigmoid : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API
@@ -41,7 +41,7 @@ namespace ngraph
 
         /// \brief Elementwise SigmoidBackprop operation.
         ///
-        class SigmoidBackprop : public util::BinaryElementwiseArithmetic
+        class NGRAPH_API SigmoidBackprop : public util::BinaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/sign.hpp
+++ b/src/ngraph/op/sign.hpp
@@ -24,7 +24,7 @@ namespace ngraph
     {
         /// \brief Elementwise sign operation.
         ///
-        class Sign : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Sign : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/sin.hpp
+++ b/src/ngraph/op/sin.hpp
@@ -37,7 +37,7 @@ namespace ngraph
         /// | ---------------------- | ------------------------------------------------------------------------------------ |
         /// | \f$N[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \sin(\texttt{arg}[i_1,\dots,i_n])\f$ |
         // clang-format on
-        class Sin : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Sin : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/sinh.hpp
+++ b/src/ngraph/op/sinh.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise hyperbolic sine (sinh) operation.
-        class Sinh : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Sinh : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/slice.hpp
+++ b/src/ngraph/op/slice.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Takes a slice of an input tensor, i.e., the sub-tensor that resides within a
         ///        bounding box, optionally with stride.
-        class Slice : public Op
+        class NGRAPH_API Slice : public Op
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/softmax.hpp
+++ b/src/ngraph/op/softmax.hpp
@@ -26,7 +26,7 @@ namespace ngraph
         {
             /// \brief Softmax operation.
             ///
-            class Softmax : public Op
+            class NGRAPH_API Softmax : public Op
             {
             public:
                 NGRAPH_API
@@ -59,7 +59,7 @@ namespace ngraph
 
         namespace v1
         {
-            class Softmax : public Op
+            class NGRAPH_API Softmax : public Op
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/sqrt.hpp
+++ b/src/ngraph/op/sqrt.hpp
@@ -37,7 +37,7 @@ namespace ngraph
         /// | ---------------------- | ------------------------------------------------------------------------------------- |
         /// | \f$N[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \sqrt{\texttt{arg}[i_1,\dots,i_n]}\f$ |
         // clang-format on
-        class Sqrt : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Sqrt : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/stop_gradient.hpp
+++ b/src/ngraph/op/stop_gradient.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief create StopGrdient op
-        class StopGradient : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API StopGradient : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/subtract.hpp
+++ b/src/ngraph/op/subtract.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise subtraction operation.
-        class Subtract : public util::BinaryElementwiseArithmetic
+        class NGRAPH_API Subtract : public util::BinaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/sum.hpp
+++ b/src/ngraph/op/sum.hpp
@@ -74,7 +74,7 @@ namespace ngraph
             /// | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
             /// | \f$N[\textit{delete}(A,d_1,\dots,d_n)]\f$ | The tensor \f$T\f$, where \f$T\f$ is the input tensor with the `reduction_axes` \f$A\f$ eliminated by summation. |
             // clang-format off
-            class Sum : public util::ArithmeticReduction
+            class NGRAPH_API Sum : public util::ArithmeticReduction
             {
             public:
                 NGRAPH_API

--- a/src/ngraph/op/tan.hpp
+++ b/src/ngraph/op/tan.hpp
@@ -37,7 +37,7 @@ namespace ngraph
         /// | ---------------------- | ------------------------------------------------------------------------------------ |
         /// | \f$N[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \tan(\texttt{arg}[i_1,\dots,i_n])\f$ |
         // clang-format on
-        class Tan : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Tan : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/tanh.hpp
+++ b/src/ngraph/op/tanh.hpp
@@ -23,7 +23,7 @@ namespace ngraph
     namespace op
     {
         /// \brief Elementwise hyperbolic tangent operation.
-        class Tanh : public util::UnaryElementwiseArithmetic
+        class NGRAPH_API Tanh : public util::UnaryElementwiseArithmetic
         {
         public:
             NGRAPH_API

--- a/src/ngraph/op/topk.hpp
+++ b/src/ngraph/op/topk.hpp
@@ -27,7 +27,7 @@ namespace ngraph
     {
         // \brief Computes indices of top k maximum/minimum index along a specified axis for a
         //        given tensor
-        class TopK : public Op
+        class NGRAPH_API TopK : public Op
         {
         public:
             enum class SortType

--- a/src/ngraph/op/util/activation_functions.hpp
+++ b/src/ngraph/op/util/activation_functions.hpp
@@ -78,7 +78,7 @@ namespace ngraph
             ///
             /// \brief      Class representing activation function used in RNN cells.
             ///
-            class ActivationFunction
+            class NGRAPH_API ActivationFunction
             {
             public:
                 ActivationFunction(ActivationFunctionType f, float alpha, float beta);

--- a/src/ngraph/op/util/arithmetic_reduction.hpp
+++ b/src/ngraph/op/util/arithmetic_reduction.hpp
@@ -27,7 +27,7 @@ namespace ngraph
             /// \brief Abstract base class for arithmetic reduction operations, i.e., operations
             ///        where chosen axes of the input tensors are eliminated (reduced out) by
             ///        repeated application of a particular binary arithmetic operation.
-            class ArithmeticReduction : public Op
+            class NGRAPH_API ArithmeticReduction : public Op
             {
             protected:
                 /// \brief Constructs an arithmetic reduction operation.

--- a/src/ngraph/op/util/binary_elementwise_arithmetic.hpp
+++ b/src/ngraph/op/util/binary_elementwise_arithmetic.hpp
@@ -51,7 +51,7 @@ namespace ngraph
             /// | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
             /// | \f$N[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \mathit{op}(\texttt{arg0}[i_1,\dots,i_n],\texttt{arg1}[i_1,\dots,i_n])\f$. This will always have the same shape and element type as the input tensors (after auto broadcasting). |
             // clang-format on
-            class BinaryElementwiseArithmetic : public Op
+            class NGRAPH_API BinaryElementwiseArithmetic : public Op
             {
             protected:
                 /// \brief Constructs a binary elementwise arithmetic operation.

--- a/src/ngraph/op/util/binary_elementwise_comparison.hpp
+++ b/src/ngraph/op/util/binary_elementwise_comparison.hpp
@@ -51,7 +51,7 @@ namespace ngraph
             /// | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
             /// | \f$\texttt{bool}[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \mathit{op}(\texttt{arg0}[i_1,\dots,i_n],\texttt{arg1}[i_1,\dots,i_n])\f$. This will always have the same shape as the input tensors, and the element type `bool`. |
             // clang-format on
-            class BinaryElementwiseComparison : public Op
+            class NGRAPH_API BinaryElementwiseComparison : public Op
             {
             protected:
                 /// \brief Constructs a binary elementwise comparison operation.

--- a/src/ngraph/op/util/binary_elementwise_logical.hpp
+++ b/src/ngraph/op/util/binary_elementwise_logical.hpp
@@ -50,7 +50,7 @@ namespace ngraph
             /// | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
             /// | \f$\texttt{bool}[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \mathit{op}(\texttt{arg0}[i_1,\dots,i_n],\texttt{arg1}[i_1,\dots,i_n])\f$. This will always have the same shape as the input tensors, and the element type `bool`. |
             // clang-format on
-            class BinaryElementwiseLogical : public Op
+            class NGRAPH_API BinaryElementwiseLogical : public Op
             {
             protected:
                 BinaryElementwiseLogical();

--- a/src/ngraph/op/util/fused_op.hpp
+++ b/src/ngraph/op/util/fused_op.hpp
@@ -27,7 +27,7 @@ namespace ngraph
             /// \brief Abstract base class for fused ops, i.e ops that can be broken down into core
             ///        ngraph ops
             ///
-            class FusedOp : public Op
+            class NGRAPH_API FusedOp : public Op
             {
             public:
                 bool supports_decompose() const override { return true; }

--- a/src/ngraph/op/util/index_reduction.hpp
+++ b/src/ngraph/op/util/index_reduction.hpp
@@ -29,7 +29,7 @@ namespace ngraph
     {
         namespace util
         {
-            class IndexReduction : public Op
+            class NGRAPH_API IndexReduction : public Op
             {
             protected:
                 IndexReduction();

--- a/src/ngraph/op/util/logical_reduction.hpp
+++ b/src/ngraph/op/util/logical_reduction.hpp
@@ -27,7 +27,7 @@ namespace ngraph
             /// \brief Abstract base class for logical reduction operations, i.e., operations where
             ///        chosen axes of the input tensors are eliminated (reduced out) by repeated
             ///        application of a particular binary logical operation.
-            class LogicalReduction : public Op
+            class NGRAPH_API LogicalReduction : public Op
             {
             protected:
                 /// \brief Constructs a logical reduction operation.

--- a/src/ngraph/op/util/op_annotations.hpp
+++ b/src/ngraph/op/util/op_annotations.hpp
@@ -34,7 +34,7 @@ namespace ngraph
             };
 
             /// \brief Base class for annotations added to graph ops
-            class OpAnnotations
+            class NGRAPH_API OpAnnotations
             {
             public:
                 virtual ~OpAnnotations() = default;

--- a/src/ngraph/op/util/rnn_cell_base.hpp
+++ b/src/ngraph/op/util/rnn_cell_base.hpp
@@ -34,7 +34,7 @@ namespace ngraph
             ///
             /// \note       It holds all common attributes.
             ///
-            class RNNCellBase
+            class NGRAPH_API RNNCellBase
             {
             public:
                 ///

--- a/src/ngraph/op/util/unary_elementwise_arithmetic.hpp
+++ b/src/ngraph/op/util/unary_elementwise_arithmetic.hpp
@@ -45,7 +45,7 @@ namespace ngraph
             /// | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
             /// | \f$N[d_1,\dots,d_n]\f$ | The tensor \f$T\f$, where \f$T[i_1,\dots,i_n] = \mathit{op}(\texttt{arg}[i_1,\dots,i_n])\f$. This will always have the same shape and element type as the input tensor. |
             // clang-format on
-            class UnaryElementwiseArithmetic : public Op
+            class NGRAPH_API UnaryElementwiseArithmetic : public Op
             {
             protected:
                 /// \brief Constructs a unary elementwise arithmetic operation.

--- a/src/ngraph/op/xor.hpp
+++ b/src/ngraph/op/xor.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     {
         /// \brief Elementwise logical-xor operation.
         ///
-        class Xor : public util::BinaryElementwiseLogical
+        class NGRAPH_API Xor : public util::BinaryElementwiseLogical
         {
         public:
             NGRAPH_API

--- a/src/ngraph/pass/algebraic_simplification.hpp
+++ b/src/ngraph/pass/algebraic_simplification.hpp
@@ -27,7 +27,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::AlgebraicSimplification : public FunctionPass
+class NGRAPH_API ngraph::pass::AlgebraicSimplification : public FunctionPass
 {
 public:
     AlgebraicSimplification()

--- a/src/ngraph/pass/batch_fusion.hpp
+++ b/src/ngraph/pass/batch_fusion.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace pass
     {
-        class BatchFusion : public ngraph::pass::FunctionPass
+        class NGRAPH_API BatchFusion : public ngraph::pass::FunctionPass
         {
         public:
             BatchFusion(FusionTypeMask type = FusionType::ALL_FUSIONS)

--- a/src/ngraph/pass/common_function_collection.hpp
+++ b/src/ngraph/pass/common_function_collection.hpp
@@ -29,7 +29,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::CommonFunctionCollection : public ModulePass
+class NGRAPH_API ngraph::pass::CommonFunctionCollection : public ModulePass
 {
 public:
     /// \brief Create the CommonFunctionCollection pass

--- a/src/ngraph/pass/concat_fusion.hpp
+++ b/src/ngraph/pass/concat_fusion.hpp
@@ -31,7 +31,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::ConcatElimination : public ngraph::pass::GraphRewrite
+class NGRAPH_API ngraph::pass::ConcatElimination : public ngraph::pass::GraphRewrite
 {
 public:
     ConcatElimination()
@@ -44,7 +44,7 @@ private:
     void construct_concat_elimination();
 };
 
-class ngraph::pass::SelfConcatFusion : public ngraph::pass::FunctionPass
+class NGRAPH_API ngraph::pass::SelfConcatFusion : public ngraph::pass::FunctionPass
 {
 public:
     SelfConcatFusion() { set_property(PassProperty::REQUIRE_STATIC_SHAPE, true); }

--- a/src/ngraph/pass/constant_folding.hpp
+++ b/src/ngraph/pass/constant_folding.hpp
@@ -28,7 +28,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::ConstantFolding : public ngraph::pass::GraphRewrite
+class NGRAPH_API ngraph::pass::ConstantFolding : public ngraph::pass::GraphRewrite
 {
 public:
     enum class CFTransformations

--- a/src/ngraph/pass/constant_to_broadcast.hpp
+++ b/src/ngraph/pass/constant_to_broadcast.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::ConstantToBroadcast : public NodePass
+class NGRAPH_API ngraph::pass::ConstantToBroadcast : public NodePass
 {
 public:
     bool run_on_node(std::shared_ptr<ngraph::Node>) override;

--- a/src/ngraph/pass/core_fusion.hpp
+++ b/src/ngraph/pass/core_fusion.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::CoreFusion : public ngraph::pass::GraphRewrite
+class NGRAPH_API ngraph::pass::CoreFusion : public ngraph::pass::GraphRewrite
 {
 public:
     CoreFusion(FusionTypeMask fusions = FusionType::REGULAR_FUSIONS)

--- a/src/ngraph/pass/dump_sorted.hpp
+++ b/src/ngraph/pass/dump_sorted.hpp
@@ -28,7 +28,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::DumpSorted : public ModulePass
+class NGRAPH_API ngraph::pass::DumpSorted : public ModulePass
 {
 public:
     DumpSorted(const std::string& output_file);

--- a/src/ngraph/pass/dyn_elimination.hpp
+++ b/src/ngraph/pass/dyn_elimination.hpp
@@ -23,7 +23,7 @@ namespace ngraph
 {
     namespace pass
     {
-        class DynElimination : public GraphRewrite
+        class NGRAPH_API DynElimination : public GraphRewrite
         {
         public:
             DynElimination();

--- a/src/ngraph/pass/fused_op_decomposition.hpp
+++ b/src/ngraph/pass/fused_op_decomposition.hpp
@@ -25,7 +25,7 @@ namespace ngraph
 {
     namespace pass
     {
-        class FusedOpDecomposition : public NodePass
+        class NGRAPH_API FusedOpDecomposition : public NodePass
         {
         public:
             /// \brief  Function signature type for callback used to check whether provided node

--- a/src/ngraph/pass/get_output_element_elimination.hpp
+++ b/src/ngraph/pass/get_output_element_elimination.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::GetOutputElementElimination : public NodePass
+class NGRAPH_API ngraph::pass::GetOutputElementElimination : public NodePass
 {
 public:
     bool run_on_node(std::shared_ptr<Node> node) override;

--- a/src/ngraph/pass/graph_rewrite.hpp
+++ b/src/ngraph/pass/graph_rewrite.hpp
@@ -46,7 +46,7 @@ namespace ngraph
 /// Patterns can be added by using \sa add_matcher
 /// Callbacks should use \sa replace_node to transform matched sub graphs
 
-class ngraph::pass::GraphRewrite : public FunctionPass
+class NGRAPH_API ngraph::pass::GraphRewrite : public FunctionPass
 {
 public:
     GraphRewrite()
@@ -81,7 +81,7 @@ private:
     std::vector<MatchClosure> m_matchers;
 };
 
-class ngraph::pass::RecurrentGraphRewrite : public FunctionPass
+class NGRAPH_API ngraph::pass::RecurrentGraphRewrite : public FunctionPass
 {
 public:
     RecurrentGraphRewrite(size_t num_iters = 10)

--- a/src/ngraph/pass/implicit_broadcast_elimination.hpp
+++ b/src/ngraph/pass/implicit_broadcast_elimination.hpp
@@ -49,7 +49,7 @@ namespace ngraph
             return rc;
         }
 
-        class ImplicitBroadcastElimination : public NodePass
+        class NGRAPH_API ImplicitBroadcastElimination : public NodePass
         {
         public:
             bool run_on_node(std::shared_ptr<ngraph::Node> node) override;

--- a/src/ngraph/pass/like_replacement.hpp
+++ b/src/ngraph/pass/like_replacement.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace pass
     {
-        class LikeReplacement : public FunctionPass
+        class NGRAPH_API LikeReplacement : public FunctionPass
         {
         public:
             bool run_on_function(std::shared_ptr<ngraph::Function> function) override;

--- a/src/ngraph/pass/liveness.hpp
+++ b/src/ngraph/pass/liveness.hpp
@@ -27,7 +27,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::Liveness : public FunctionPass
+class NGRAPH_API ngraph::pass::Liveness : public FunctionPass
 {
 public:
     bool run_on_function(std::shared_ptr<ngraph::Function>) override;

--- a/src/ngraph/pass/memory_visualize.hpp
+++ b/src/ngraph/pass/memory_visualize.hpp
@@ -30,7 +30,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::MemoryVisualize : public ModulePass
+class NGRAPH_API ngraph::pass::MemoryVisualize : public ModulePass
 {
 public:
     MemoryVisualize(const std::string& filename);

--- a/src/ngraph/pass/nop_elimination.hpp
+++ b/src/ngraph/pass/nop_elimination.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace pass
     {
-        class NopElimination : public FunctionPass
+        class NGRAPH_API NopElimination : public FunctionPass
         {
         public:
             NopElimination() { set_property(PassProperty::REQUIRE_STATIC_SHAPE, true); }

--- a/src/ngraph/pass/opset1_upgrade.hpp
+++ b/src/ngraph/pass/opset1_upgrade.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace pass
     {
-        class Opset1Upgrade : public NodePass
+        class NGRAPH_API Opset1Upgrade : public NodePass
         {
         public:
             ///

--- a/src/ngraph/pass/pass.cpp
+++ b/src/ngraph/pass/pass.cpp
@@ -51,3 +51,10 @@ void pass::PassBase::set_property(const PassPropertyMask& prop, bool value)
         m_property.clear(prop);
     }
 }
+
+// RTTI
+
+pass::ModulePass::~ModulePass() {}
+pass::FunctionPass::~FunctionPass() {}
+pass::NodePass::~NodePass() {}
+pass::CallGraphPass::~CallGraphPass() {}

--- a/src/ngraph/pass/pass.hpp
+++ b/src/ngraph/pass/pass.hpp
@@ -60,7 +60,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::PassBase
+class NGRAPH_API ngraph::pass::PassBase
 {
     friend class Manager;
 
@@ -80,30 +80,30 @@ private:
     ManagerState* m_state{nullptr};
 };
 
-class ngraph::pass::ModulePass : public PassBase
+class NGRAPH_API ngraph::pass::ModulePass : public PassBase
 {
 public:
-    virtual ~ModulePass() {}
+    virtual ~ModulePass();
     virtual bool run_on_module(std::vector<std::shared_ptr<ngraph::Function>>&) = 0;
 };
 
-class ngraph::pass::FunctionPass : public PassBase
+class NGRAPH_API ngraph::pass::FunctionPass : public PassBase
 {
 public:
-    virtual ~FunctionPass() {}
+    virtual ~FunctionPass();
     virtual bool run_on_function(std::shared_ptr<ngraph::Function>) = 0;
 };
 
-class ngraph::pass::NodePass : public PassBase
+class NGRAPH_API ngraph::pass::NodePass : public PassBase
 {
 public:
-    virtual ~NodePass() {}
+    virtual ~NodePass();
     virtual bool run_on_node(std::shared_ptr<ngraph::Node>) = 0;
 };
 
-class ngraph::pass::CallGraphPass : public PassBase
+class NGRAPH_API ngraph::pass::CallGraphPass : public PassBase
 {
 public:
-    virtual ~CallGraphPass() {}
+    virtual ~CallGraphPass();
     virtual bool run_on_call_graph(const std::list<std::shared_ptr<ngraph::Node>>&) = 0;
 };

--- a/src/ngraph/pass/propagate_cacheability.hpp
+++ b/src/ngraph/pass/propagate_cacheability.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::PropagateCacheability : public FunctionPass
+class NGRAPH_API ngraph::pass::PropagateCacheability : public FunctionPass
 {
 public:
     PropagateCacheability()

--- a/src/ngraph/pass/reshape_elimination.hpp
+++ b/src/ngraph/pass/reshape_elimination.hpp
@@ -28,7 +28,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::ReshapeElimination : public ngraph::pass::GraphRewrite
+class NGRAPH_API ngraph::pass::ReshapeElimination : public ngraph::pass::GraphRewrite
 {
 public:
     ReshapeElimination()
@@ -45,7 +45,7 @@ private:
     void construct_reshapex2_pattern();
 };
 
-class ngraph::pass::RecurrentReshapeElimination : public ngraph::pass::RecurrentGraphRewrite
+class NGRAPH_API ngraph::pass::RecurrentReshapeElimination : public ngraph::pass::RecurrentGraphRewrite
 {
 public:
     RecurrentReshapeElimination()

--- a/src/ngraph/pass/reshape_sinking.hpp
+++ b/src/ngraph/pass/reshape_sinking.hpp
@@ -23,7 +23,7 @@ namespace ngraph
 {
     namespace pass
     {
-        class ReshapeSinking : public ngraph::pass::FunctionPass
+        class NGRAPH_API ReshapeSinking : public ngraph::pass::FunctionPass
         {
         public:
             ReshapeSinking() { set_property(PassProperty::REQUIRE_STATIC_SHAPE, true); }

--- a/src/ngraph/pass/serialize.hpp
+++ b/src/ngraph/pass/serialize.hpp
@@ -28,7 +28,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::Serialization : public ModulePass
+class NGRAPH_API ngraph::pass::Serialization : public ModulePass
 {
 public:
     Serialization(const std::string& name);

--- a/src/ngraph/pass/shape_relevance.hpp
+++ b/src/ngraph/pass/shape_relevance.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace pass
     {
-        class ShapeRelevance : public FunctionPass
+        class NGRAPH_API ShapeRelevance : public FunctionPass
         {
         public:
             ShapeRelevance()

--- a/src/ngraph/pass/validate.hpp
+++ b/src/ngraph/pass/validate.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace pass
     {
-        class Validate : public FunctionPass
+        class NGRAPH_API Validate : public FunctionPass
         {
         public:
             Validate()

--- a/src/ngraph/pass/validate_graph.hpp
+++ b/src/ngraph/pass/validate_graph.hpp
@@ -28,7 +28,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::ValidateGraph : public ModulePass
+class NGRAPH_API ngraph::pass::ValidateGraph : public ModulePass
 {
 public:
     bool run_on_module(std::vector<std::shared_ptr<ngraph::Function>>&) override;

--- a/src/ngraph/pass/visualize_tree.hpp
+++ b/src/ngraph/pass/visualize_tree.hpp
@@ -38,7 +38,7 @@ namespace ngraph
 
 class HeightMap;
 
-class ngraph::pass::VisualizeTree : public ModulePass
+class NGRAPH_API ngraph::pass::VisualizeTree : public ModulePass
 {
 public:
     using node_modifiers_t =

--- a/src/ngraph/pass/zero_dim_tensor_elimination.hpp
+++ b/src/ngraph/pass/zero_dim_tensor_elimination.hpp
@@ -26,7 +26,7 @@ namespace ngraph
     }
 }
 
-class ngraph::pass::ZeroDimTensorElimination : public FunctionPass
+class NGRAPH_API ngraph::pass::ZeroDimTensorElimination : public FunctionPass
 {
 public:
     ZeroDimTensorElimination()

--- a/src/ngraph/pattern/matcher.cpp
+++ b/src/ngraph/pattern/matcher.cpp
@@ -28,6 +28,16 @@ namespace ngraph
 {
     namespace pattern
     {
+        namespace op
+        {
+            // The symbols are requiered to be in cpp file to workaround RTTI issue on Android LLVM
+            const NodeTypeInfo& Any::get_type_info() const { return type_info; }
+            const NodeTypeInfo& AnyOf::get_type_info() const { return type_info; }
+            const NodeTypeInfo& Label::get_type_info() const { return type_info; }
+            const NodeTypeInfo& Skip::get_type_info() const { return type_info; }
+            Predicate Pattern::get_predicate() const { return m_predicate; }
+        }
+
         constexpr NodeTypeInfo op::AnyOf::type_info;
         constexpr NodeTypeInfo op::Any::type_info;
         constexpr NodeTypeInfo op::Label::type_info;

--- a/src/ngraph/pattern/matcher.hpp
+++ b/src/ngraph/pattern/matcher.hpp
@@ -52,7 +52,7 @@ namespace ngraph
 
         /// \brief Matcher matches (compares) two graphs
         ///
-        class Matcher
+        class NGRAPH_API Matcher
         {
         public:
             using PatternMap = std::map<std::shared_ptr<op::Label>, std::shared_ptr<Node>>;
@@ -90,6 +90,7 @@ namespace ngraph
             }
 
             virtual ~Matcher() {}
+
             /// \brief Matches a pattern to \p graph_node
             ///
             /// \param graph_node is an input graph to be matched against

--- a/src/ngraph/pattern/op/any.hpp
+++ b/src/ngraph/pattern/op/any.hpp
@@ -26,12 +26,12 @@ namespace ngraph
         namespace op
         {
             /// \brief Anys are used in patterns to express arbitrary queries on a node
-            class Any : public Pattern
+            class NGRAPH_API Any : public Pattern
             {
             public:
                 NGRAPH_API
                 static constexpr NodeTypeInfo type_info{"patternAny", 0};
-                const NodeTypeInfo& get_type_info() const override { return type_info; }
+                const NodeTypeInfo& get_type_info() const override;
                 /// \brief creates a Any node containing a sub-pattern described by \sa type and \sa
                 ///        shape.
                 Any(const element::Type& type,

--- a/src/ngraph/pattern/op/any_of.hpp
+++ b/src/ngraph/pattern/op/any_of.hpp
@@ -32,12 +32,12 @@ namespace ngraph
             /// This is useful for nodes with variable number of arguments such as Concat
             /// AnyOf enables on to specify one single branch/chain. The remaining arguments
             /// can be discovered (in a callback) by simply inspecting matched node's argument.
-            class AnyOf : public Pattern
+            class NGRAPH_API AnyOf : public Pattern
             {
             public:
                 NGRAPH_API
                 static constexpr NodeTypeInfo type_info{"patternAnyOf", 0};
-                const NodeTypeInfo& get_type_info() const override { return type_info; }
+                const NodeTypeInfo& get_type_info() const override;
                 /// \brief creates a AnyOf node containing a sub-pattern described by \sa type and
                 ///        \sa shape.
                 AnyOf(const element::Type& type,

--- a/src/ngraph/pattern/op/label.hpp
+++ b/src/ngraph/pattern/op/label.hpp
@@ -28,12 +28,12 @@ namespace ngraph
             /// \brief Labels are used in patterns to express repeating nodes in an input graph
             /// and bind them to specific nodes from the graph
             ///
-            class Label : public Pattern
+            class NGRAPH_API Label : public Pattern
             {
             public:
                 NGRAPH_API
                 static constexpr NodeTypeInfo type_info{"patternLabel", 0};
-                const NodeTypeInfo& get_type_info() const override { return type_info; }
+                const NodeTypeInfo& get_type_info() const override;
                 /// \brief creates a Label node containing a sub-pattern described by \sa type and
                 ///        \sa shape.
                 ///

--- a/src/ngraph/pattern/op/pattern.hpp
+++ b/src/ngraph/pattern/op/pattern.hpp
@@ -28,7 +28,7 @@ namespace ngraph
         {
             using Predicate = std::function<bool(std::shared_ptr<Node>)>;
 
-            class Pattern : public Node
+            class NGRAPH_API Pattern : public Node
             {
             public:
                 /// \brief \p a base class for \sa Skip and \sa Label
@@ -45,7 +45,7 @@ namespace ngraph
                     throw ngraph_error("Uncopyable");
                 }
 
-                Predicate get_predicate() const { return m_predicate; }
+                Predicate get_predicate() const;
             protected:
                 std::function<bool(std::shared_ptr<Node>)> m_predicate;
             };

--- a/src/ngraph/pattern/op/skip.hpp
+++ b/src/ngraph/pattern/op/skip.hpp
@@ -28,12 +28,12 @@ namespace ngraph
             /// \brief \p Skip allows users to specify unexpected nodes in a pattern
             /// and skip them if a predicate condition is satisfied.
             ///
-            class Skip : public Pattern
+            class NGRAPH_API Skip : public Pattern
             {
             public:
                 NGRAPH_API
                 static constexpr NodeTypeInfo type_info{"patternSkip", 0};
-                const NodeTypeInfo& get_type_info() const override { return type_info; }
+                const NodeTypeInfo& get_type_info() const override;
                 Skip(const std::shared_ptr<Node>& arg, Predicate predicate = nullptr)
                     : Pattern(NodeVector{arg}, predicate)
                 {

--- a/src/ngraph/type/element_type.cpp
+++ b/src/ngraph/type/element_type.cpp
@@ -24,20 +24,20 @@
 using namespace ngraph;
 using namespace std;
 
-NGRAPH_API const element::Type element::dynamic(element::Type_t::dynamic);
-NGRAPH_API const element::Type element::boolean(element::Type_t::boolean);
-NGRAPH_API const element::Type element::bf16(element::Type_t::bf16);
-NGRAPH_API const element::Type element::f16(element::Type_t::f16);
-NGRAPH_API const element::Type element::f32(element::Type_t::f32);
-NGRAPH_API const element::Type element::f64(element::Type_t::f64);
-NGRAPH_API const element::Type element::i8(element::Type_t::i8);
-NGRAPH_API const element::Type element::i16(element::Type_t::i16);
-NGRAPH_API const element::Type element::i32(element::Type_t::i32);
-NGRAPH_API const element::Type element::i64(element::Type_t::i64);
-NGRAPH_API const element::Type element::u8(element::Type_t::u8);
-NGRAPH_API const element::Type element::u16(element::Type_t::u16);
-NGRAPH_API const element::Type element::u32(element::Type_t::u32);
-NGRAPH_API const element::Type element::u64(element::Type_t::u64);
+const element::Type element::dynamic(element::Type_t::dynamic);
+const element::Type element::boolean(element::Type_t::boolean);
+const element::Type element::bf16(element::Type_t::bf16);
+const element::Type element::f16(element::Type_t::f16);
+const element::Type element::f32(element::Type_t::f32);
+const element::Type element::f64(element::Type_t::f64);
+const element::Type element::i8(element::Type_t::i8);
+const element::Type element::i16(element::Type_t::i16);
+const element::Type element::i32(element::Type_t::i32);
+const element::Type element::i64(element::Type_t::i64);
+const element::Type element::u8(element::Type_t::u8);
+const element::Type element::u16(element::Type_t::u16);
+const element::Type element::u32(element::Type_t::u32);
+const element::Type element::u64(element::Type_t::u64);
 
 class TypeInfo
 {

--- a/src/ngraph/visibility.hpp
+++ b/src/ngraph/visibility.hpp
@@ -20,7 +20,7 @@
 #define NGRAPH_HELPER_DLL_IMPORT __declspec(dllimport)
 #define NGRAPH_HELPER_DLL_EXPORT __declspec(dllexport)
 #define NGRAPH_HELPER_DLL_LOCAL
-#elif defined NGRAPH_LINUX_VISIBILITY_ENABLE && __GNUC__ >= 4
+#elif defined(__GNUC__) && __GNUC__ >= 4
 #define NGRAPH_HELPER_DLL_IMPORT __attribute__((visibility("default")))
 #define NGRAPH_HELPER_DLL_EXPORT __attribute__((visibility("default")))
 #define NGRAPH_HELPER_DLL_LOCAL __attribute__((visibility("hidden")))


### PR DESCRIPTION
* Partially resolved issues with RTTI and AppleClang
* Exports most of ngraph Ops which allows to use them from OpenCV, IE.

**Note:** it does not solve all the issues since we need to review NGraph API more carefully. I will submit more MR related to this topic after. 

CC @ilyachur 