### PR TITLE
Implements proveance tag propagation for reshape sinking pass

### DIFF
--- a/src/ngraph/pass/reshape_sinking.cpp
+++ b/src/ngraph/pass/reshape_sinking.cpp
@@ -116,7 +116,8 @@ static void delete_reshape(shared_ptr<Node> reshape)
     NGRAPH_DEBUG << "Removing reshape " << reshape->get_name();
     if (!reshape->get_users().empty())
     {
-        ngraph::replace_node(reshape, reshape->input(0).get_source_output().get_node_shared_ptr(), true);
+        ngraph::replace_node(
+            reshape, reshape->input(0).get_source_output().get_node_shared_ptr(), true);
     }
 }
 

--- a/src/ngraph/pass/reshape_sinking.cpp
+++ b/src/ngraph/pass/reshape_sinking.cpp
@@ -116,7 +116,7 @@ static void delete_reshape(shared_ptr<Node> reshape)
     NGRAPH_DEBUG << "Removing reshape " << reshape->get_name();
     if (!reshape->get_users().empty())
     {
-        ngraph::replace_node(reshape, reshape->get_argument(0), true);
+        ngraph::replace_node(reshape, reshape->input(0).get_source_output().get_node_shared_ptr(), true);
     }
 }
 


### PR DESCRIPTION
Adds some special case handling for provenance tag propagation for reshape sinking.

There are two cases where nodes are inserted or graph is modified that do not use replace_node() function where provenance is normally handled. These cases are node insertion and calling replace_source_output() directly (which is what replace_node call does normally).

Also the delete_node function does not need to do anything for provenance.