### PR TITLE
Callback for writing events 

### DIFF
--- a/src/ngraph/event_tracing.cpp
+++ b/src/ngraph/event_tracing.cpp
@@ -29,11 +29,11 @@ static bool read_tracing_env_var()
     return (std::getenv("NGRAPH_ENABLE_TRACING") != nullptr);
 }
 
-mutex ngraph::Event::s_file_mutex;
-ofstream ngraph::Event::s_event_log;
-bool ngraph::Event::s_tracing_enabled = read_tracing_env_var();
-bool ngraph::Event::s_event_writer_registered = false;
-std::function<void(const ngraph::Event& event)> ngraph::Event::s_event_writer;
+NGRAPH_API mutex ngraph::Event::s_file_mutex;
+NGRAPH_API ofstream ngraph::Event::s_event_log;
+NGRAPH_API bool ngraph::Event::s_tracing_enabled = read_tracing_env_var();
+NGRAPH_API bool ngraph::Event::s_event_writer_registered = false;
+NGRAPH_API std::function<void(const ngraph::Event& event)> ngraph::Event::s_event_writer;
 
 void ngraph::Event::write_trace(const ngraph::Event& event)
 {

--- a/src/ngraph/event_tracing.cpp
+++ b/src/ngraph/event_tracing.cpp
@@ -32,13 +32,19 @@ static bool read_tracing_env_var()
 mutex ngraph::Event::s_file_mutex;
 ofstream ngraph::Event::s_event_log;
 bool ngraph::Event::s_tracing_enabled = read_tracing_env_var();
+bool ngraph::Event::s_event_writer_registered = false;
+std::function<void(const ngraph::Event& event)> ngraph::Event::s_event_writer;
 
 void ngraph::Event::write_trace(const ngraph::Event& event)
 {
     if (is_tracing_enabled())
     {
         lock_guard<mutex> lock(s_file_mutex);
-
+        if (s_event_writer_registered)
+        {
+            s_event_writer(event);
+            return;
+        }
         static bool so_initialized = false;
         if (!so_initialized)
         {

--- a/src/ngraph/event_tracing.hpp
+++ b/src/ngraph/event_tracing.hpp
@@ -31,6 +31,7 @@
 #include <unistd.h>
 #endif
 #include <functional>
+#include "ngraph/ngraph_visibility.hpp"
 
 namespace ngraph
 {
@@ -125,11 +126,11 @@ namespace ngraph
         std::string m_category;
         std::string m_args;
 
-        static std::mutex s_file_mutex;
-        static std::ofstream s_event_log;
-        static bool s_tracing_enabled;
-        static std::function<void(const Event& event)> s_event_writer;
-        static bool s_event_writer_registered;
+        NGRAPH_API static std::mutex s_file_mutex;
+        NGRAPH_API static std::ofstream s_event_log;
+        NGRAPH_API static bool s_tracing_enabled;
+        NGRAPH_API static std::function<void(const Event& event)> s_event_writer;
+        NGRAPH_API static bool s_event_writer_registered;
     };
 
 } // namespace ngraph

--- a/src/ngraph/op/softmax.cpp
+++ b/src/ngraph/op/softmax.cpp
@@ -76,11 +76,7 @@ void op::v0::Softmax::set_axes(const AxisSet& axes)
 void op::v0::Softmax::validate_and_infer_types()
 {
     const PartialShape& input_shape = get_input_partial_shape(0);
-    NODE_VALIDATION_CHECK(this,
-                          input_shape.rank().is_static(),
-                          "Input node rank must be static (input_shape=",
-                          input_shape,
-                          ").");
+
     if (input_shape.is_dynamic())
     {
         set_output_type(0, get_input_element_type(0), input_shape);

--- a/test/event_tracing.cpp
+++ b/test/event_tracing.cpp
@@ -67,6 +67,7 @@ TEST(event_tracing, event_writer_callback)
     auto event_writer = [&](const ngraph::Event& event) { event_list.push_back(event); };
 
     map<string, unique_ptr<ngraph::Event>> expected_event_table;
+    mutex expected_event_table_mtx;
 
     ngraph::Event::enable_event_tracing();
     ngraph::Event::register_event_writer(event_writer);
@@ -78,6 +79,8 @@ TEST(event_tracing, event_writer_callback)
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
         event->Stop();
         ngraph::Event::write_trace(*event);
+
+        lock_guard<mutex> lock(expected_event_table_mtx);
         expected_event_table[event->get_name()] = move(event);
     };
 

--- a/test/event_tracing.cpp
+++ b/test/event_tracing.cpp
@@ -29,7 +29,6 @@ using namespace std;
 
 TEST(event_tracing, event_file)
 {
-    // Set the environment variable to ensure logging
     ngraph::Event::enable_event_tracing();
     std::vector<std::thread> threads;
     for (auto i = 0; i < 10; i++)
@@ -39,15 +38,13 @@ TEST(event_tracing, event_file)
             std::ostringstream oss;
             oss << "Event: " << id;
             ngraph::Event event(oss.str(), "Dummy", "none");
-            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
             event.Stop();
             ngraph::Event::write_trace(event);
         });
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
         threads.push_back(std::move(next_thread));
     }
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     for (auto& next : threads)
     {
@@ -61,4 +58,54 @@ TEST(event_tracing, event_file)
     // Validate the JSON objects - there should be 10 of them
     // TODO
     ngraph::Event::disable_event_tracing();
+}
+
+TEST(event_tracing, event_writer_callback)
+{
+    // Create the event writer
+    int event_count = 0;
+    vector<ngraph::Event> event_list;
+    auto event_writer = [&](const ngraph::Event& event) { event_list.push_back(event); };
+
+    map<string, unique_ptr<ngraph::Event>> expected_event_table;
+
+    ngraph::Event::enable_event_tracing();
+    ngraph::Event::register_event_writer(event_writer);
+
+    auto worker = [&](int worker_id) {
+        std::ostringstream oss;
+        oss << "Event: " << worker_id;
+        unique_ptr<ngraph::Event> event(new ngraph::Event(oss.str(), "Dummy", "none"));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        event->Stop();
+        ngraph::Event::write_trace(*event);
+        expected_event_table[event->get_name()] = move(event);
+    };
+
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < 10; i++)
+    {
+        std::thread thread_next(worker, i);
+        threads.push_back(move(thread_next));
+    }
+
+    for (auto& next : threads)
+    {
+        next.join();
+    }
+    ngraph::Event::disable_event_tracing();
+
+    // Now validate the events
+    ASSERT_EQ(10, event_list.size());
+    ASSERT_EQ(10, expected_event_table.size());
+
+    for (const auto& next_event : event_list)
+    {
+        const auto& expected_event_key = expected_event_table.find(next_event.get_name());
+        EXPECT_TRUE(expected_event_key != expected_event_table.end());
+        EXPECT_EQ(expected_event_key->second->get_name(), next_event.get_name());
+        EXPECT_EQ(expected_event_key->second->get_start(), next_event.get_start());
+        EXPECT_EQ(expected_event_key->second->get_stop(), next_event.get_stop());
+    }
 }

--- a/test/event_tracing.cpp
+++ b/test/event_tracing.cpp
@@ -63,7 +63,6 @@ TEST(event_tracing, event_file)
 TEST(event_tracing, event_writer_callback)
 {
     // Create the event writer
-    int event_count = 0;
     vector<ngraph::Event> event_list;
     auto event_writer = [&](const ngraph::Event& event) { event_list.push_back(event); };
 


### PR DESCRIPTION
This PR adds some modifications to the Event class that will allow the client to decide how to use the events. 

For example, for real time inference applications, the event recording can be performed by a low priority thread without affecting the inference timing. Similarly. this is also useful to be able combine framework generated traces with nGraph core/backend generated traces.

Specifically: 

* Adds a callback mechanism so that clients can decide what to do with the events:
  1. For example queue up events and write at a different time/by a different thread. 
  2. Use a different serialization format (e.g., a binary format or Protobuf)
* Added getters for the Events so that they can be corelated programmatically