### PR TITLE
Added aliases for v0 ops that are compatible v1

### DIFF
--- a/src/ngraph/op/abs.hpp
+++ b/src/ngraph/op/abs.hpp
@@ -50,5 +50,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Abs;
+        }
     }
 }

--- a/src/ngraph/op/acos.hpp
+++ b/src/ngraph/op/acos.hpp
@@ -49,5 +49,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Acos;
+        }
     }
 }

--- a/src/ngraph/op/add.hpp
+++ b/src/ngraph/op/add.hpp
@@ -56,6 +56,11 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Add;
+        }
     }
 
     std::shared_ptr<Node> operator+(const Output<Node>& arg0, const Output<Node>& arg1);

--- a/src/ngraph/op/asin.hpp
+++ b/src/ngraph/op/asin.hpp
@@ -50,5 +50,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Asin;
+        }
     }
 }

--- a/src/ngraph/op/atan.hpp
+++ b/src/ngraph/op/atan.hpp
@@ -51,5 +51,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Atan;
+        }
     }
 }

--- a/src/ngraph/op/batch_norm.hpp
+++ b/src/ngraph/op/batch_norm.hpp
@@ -200,5 +200,10 @@ namespace ngraph
 
             double m_epsilon;
         };
+
+        namespace v1
+        {
+            using op::BatchNormInference;
+        }
     }
 }

--- a/src/ngraph/op/concat.hpp
+++ b/src/ngraph/op/concat.hpp
@@ -61,5 +61,10 @@ namespace ngraph
                                            const NodeVector& deltas) override;
             size_t m_axis;
         };
+
+        namespace v1
+        {
+            using op::Concat;
+        }
     }
 }

--- a/src/ngraph/op/cos.hpp
+++ b/src/ngraph/op/cos.hpp
@@ -43,5 +43,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Cos;
+        }
     }
 }

--- a/src/ngraph/op/cosh.hpp
+++ b/src/ngraph/op/cosh.hpp
@@ -43,5 +43,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Cosh;
+        }
     }
 }

--- a/src/ngraph/op/divide.hpp
+++ b/src/ngraph/op/divide.hpp
@@ -62,6 +62,11 @@ namespace ngraph
         protected:
             bool m_pythondiv{true};
         };
+
+        namespace v1
+        {
+            using op::Divide;
+        }
     }
 
     std::shared_ptr<Node> operator/(const Output<Node>& arg0, const Output<Node>& arg1);

--- a/src/ngraph/op/exp.hpp
+++ b/src/ngraph/op/exp.hpp
@@ -42,5 +42,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Exp;
+        }
     }
 }

--- a/src/ngraph/op/experimental/layers/detection_output.hpp
+++ b/src/ngraph/op/experimental/layers/detection_output.hpp
@@ -74,5 +74,11 @@ namespace ngraph
         private:
             DetectionOutputAttrs m_attrs;
         };
+
+        namespace v1
+        {
+            using op::DetectionOutput;
+            using op::DetectionOutputAttrs;
+        }
     }
 }

--- a/src/ngraph/op/experimental/layers/interpolate.hpp
+++ b/src/ngraph/op/experimental/layers/interpolate.hpp
@@ -57,5 +57,11 @@ namespace ngraph
         private:
             InterpolateAttrs m_attrs;
         };
+
+        namespace v1
+        {
+            using op::Interpolate;
+            using op::InterpolateAttrs;
+        }
     }
 }

--- a/src/ngraph/op/experimental/layers/prior_box.hpp
+++ b/src/ngraph/op/experimental/layers/prior_box.hpp
@@ -70,5 +70,11 @@ namespace ngraph
         private:
             PriorBoxAttrs m_attrs;
         };
+
+        namespace v1
+        {
+            using op::PriorBox;
+            using op::PriorBoxAttrs;
+        }
     }
 }

--- a/src/ngraph/op/experimental/layers/prior_box_clustered.hpp
+++ b/src/ngraph/op/experimental/layers/prior_box_clustered.hpp
@@ -68,5 +68,11 @@ namespace ngraph
         private:
             PriorBoxClusteredAttrs m_attrs;
         };
+
+        namespace v1
+        {
+            using op::PriorBoxClustered;
+            using op::PriorBoxClusteredAttrs;
+        }
     }
 }

--- a/src/ngraph/op/experimental/layers/proposal.hpp
+++ b/src/ngraph/op/experimental/layers/proposal.hpp
@@ -80,5 +80,11 @@ namespace ngraph
         private:
             ProposalAttrs m_attrs;
         };
+
+        namespace v1
+        {
+            using op::Proposal;
+            using op::ProposalAttrs;
+        }
     }
 }

--- a/src/ngraph/op/experimental/layers/psroi_pooling.hpp
+++ b/src/ngraph/op/experimental/layers/psroi_pooling.hpp
@@ -66,5 +66,10 @@ namespace ngraph
             int m_spatial_bins_y;
             std::string m_mode;
         };
+
+        namespace v1
+        {
+            using op::PSROIPooling;
+        }
     }
 }

--- a/src/ngraph/op/experimental/layers/region_yolo.hpp
+++ b/src/ngraph/op/experimental/layers/region_yolo.hpp
@@ -68,5 +68,10 @@ namespace ngraph
             int m_axis;
             int m_end_axis;
         };
+
+        namespace v1
+        {
+            using op::RegionYolo;
+        }
     }
 }

--- a/src/ngraph/op/experimental/layers/reorg_yolo.hpp
+++ b/src/ngraph/op/experimental/layers/reorg_yolo.hpp
@@ -43,5 +43,10 @@ namespace ngraph
         private:
             Strides m_strides;
         };
+
+        namespace v1
+        {
+            using op::ReorgYolo;
+        }
     }
 }

--- a/src/ngraph/op/experimental/layers/roi_pooling.hpp
+++ b/src/ngraph/op/experimental/layers/roi_pooling.hpp
@@ -54,5 +54,10 @@ namespace ngraph
             float m_spatial_scale;
             std::string m_method;
         };
+
+        namespace v1
+        {
+            using op::ROIPooling;
+        }
     }
 }

--- a/src/ngraph/op/experimental/shape_of.hpp
+++ b/src/ngraph/op/experimental/shape_of.hpp
@@ -38,5 +38,10 @@ namespace ngraph
 
             void validate_and_infer_types() override;
         };
+
+        namespace v1
+        {
+            using op::ShapeOf;
+        }
     }
 }

--- a/src/ngraph/op/experimental/transpose.hpp
+++ b/src/ngraph/op/experimental/transpose.hpp
@@ -50,5 +50,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Transpose;
+        }
     }
 }

--- a/src/ngraph/op/fused/clamp.hpp
+++ b/src/ngraph/op/fused/clamp.hpp
@@ -55,5 +55,10 @@ namespace ngraph
             const double m_min;
             const double m_max;
         };
+
+        namespace v1
+        {
+            using op::Clamp;
+        }
     }
 }

--- a/src/ngraph/op/fused/elu.hpp
+++ b/src/ngraph/op/fused/elu.hpp
@@ -50,5 +50,10 @@ namespace ngraph
         private:
             double m_alpha;
         };
+
+        namespace v1
+        {
+            using op::Elu;
+        }
     } // namespace op
 } // namespace ngraph

--- a/src/ngraph/op/fused/normalize_l2.hpp
+++ b/src/ngraph/op/fused/normalize_l2.hpp
@@ -63,5 +63,10 @@ namespace ngraph
             float m_eps;
             EpsMode m_eps_mode;
         };
+
+        namespace v1
+        {
+            using op::NormalizeL2;
+        }
     }
 }

--- a/src/ngraph/op/fused/prelu.hpp
+++ b/src/ngraph/op/fused/prelu.hpp
@@ -46,5 +46,10 @@ namespace ngraph
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
         };
+
+        namespace v1
+        {
+            using op::PRelu;
+        }
     }
 }

--- a/src/ngraph/op/fused/squeeze.hpp
+++ b/src/ngraph/op/fused/squeeze.hpp
@@ -41,5 +41,10 @@ namespace ngraph
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
         };
+
+        namespace v1
+        {
+            using op::Squeeze;
+        }
     }
 }

--- a/src/ngraph/op/fused/unsqueeze.hpp
+++ b/src/ngraph/op/fused/unsqueeze.hpp
@@ -42,5 +42,10 @@ namespace ngraph
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
         };
+
+        namespace v1
+        {
+            using op::Unsqueeze;
+        }
     }
 }

--- a/src/ngraph/op/log.hpp
+++ b/src/ngraph/op/log.hpp
@@ -42,5 +42,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Log;
+        }
     }
 }

--- a/src/ngraph/op/maximum.hpp
+++ b/src/ngraph/op/maximum.hpp
@@ -48,5 +48,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Maximum;
+        }
     }
 }

--- a/src/ngraph/op/multiply.hpp
+++ b/src/ngraph/op/multiply.hpp
@@ -48,6 +48,11 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Multiply;
+        }
     };
 
     std::shared_ptr<Node> operator*(const Output<Node>& arg0, const Output<Node>& arg1);

--- a/src/ngraph/op/parameter.hpp
+++ b/src/ngraph/op/parameter.hpp
@@ -78,6 +78,11 @@ namespace ngraph
             element::Type m_element_type;
             bool m_is_relevant_to_shapes;
         };
+
+        namespace v1
+        {
+            using op::Parameter;
+        }
     }
     using ParameterVector = std::vector<std::shared_ptr<op::Parameter>>;
 }

--- a/src/ngraph/op/power.hpp
+++ b/src/ngraph/op/power.hpp
@@ -61,5 +61,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Power;
+        }
     }
 }

--- a/src/ngraph/op/relu.hpp
+++ b/src/ngraph/op/relu.hpp
@@ -64,5 +64,10 @@ namespace ngraph
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
         };
+
+        namespace v1
+        {
+            using op::Relu;
+        }
     }
 }

--- a/src/ngraph/op/result.hpp
+++ b/src/ngraph/op/result.hpp
@@ -57,7 +57,6 @@ namespace ngraph
         {
             using op::Result;
         }
-
     }
     using ResultVector = std::vector<std::shared_ptr<op::Result>>;
 }

--- a/src/ngraph/op/result.hpp
+++ b/src/ngraph/op/result.hpp
@@ -52,6 +52,12 @@ namespace ngraph
         private:
             bool m_needs_default_layout{false};
         };
+
+        namespace v1
+        {
+            using op::Result;
+        }
+
     }
     using ResultVector = std::vector<std::shared_ptr<op::Result>>;
 }

--- a/src/ngraph/op/sigmoid.hpp
+++ b/src/ngraph/op/sigmoid.hpp
@@ -56,5 +56,10 @@ namespace ngraph
             virtual std::shared_ptr<Node>
                 copy_with_new_args(const NodeVector& new_args) const override;
         };
+
+        namespace v1
+        {
+            using op::Sigmoid;
+        }
     }
 }

--- a/src/ngraph/op/sin.hpp
+++ b/src/ngraph/op/sin.hpp
@@ -56,5 +56,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Sin;
+        }
     }
 }

--- a/src/ngraph/op/sinh.hpp
+++ b/src/ngraph/op/sinh.hpp
@@ -42,5 +42,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Sinh;
+        }
     }
 }

--- a/src/ngraph/op/sqrt.hpp
+++ b/src/ngraph/op/sqrt.hpp
@@ -56,5 +56,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Sqrt;
+        }
     }
 }

--- a/src/ngraph/op/tan.hpp
+++ b/src/ngraph/op/tan.hpp
@@ -56,5 +56,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Tan;
+        }
     }
 }

--- a/src/ngraph/op/tanh.hpp
+++ b/src/ngraph/op/tanh.hpp
@@ -42,5 +42,10 @@ namespace ngraph
             virtual void generate_adjoints(autodiff::Adjoints& adjoints,
                                            const NodeVector& deltas) override;
         };
+
+        namespace v1
+        {
+            using op::Tanh;
+        }
     }
 }


### PR DESCRIPTION
In this PR I've made an aliases for v0 ops that are compatible with v1. That will help us to divide operation between v0 and v1 more transparently.
This PR affects ops that are currently supported by IE. So for other ops I want you guys to divide them to v0 and v1.