### PR TITLE
Added set_parameters_and_results with params and results

### DIFF
--- a/src/ngraph/runtime/executable.cpp
+++ b/src/ngraph/runtime/executable.cpp
@@ -119,6 +119,13 @@ void runtime::Executable::set_parameters_and_results(const Function& func)
     m_results = func.get_results();
 }
 
+void runtime::Executable::set_parameters_and_results(const ParameterVector& params,
+                                                     const ResultVector& results)
+{
+    m_parameters = params;
+    m_results = results;
+}
+
 vector<runtime::PerformanceCounter> runtime::Executable::get_performance_data() const
 {
     return vector<PerformanceCounter>();

--- a/src/ngraph/runtime/executable.hpp
+++ b/src/ngraph/runtime/executable.hpp
@@ -112,6 +112,12 @@ protected:
     ///        and get_results
     /// \param func The function with Results fully resolved.
     void set_parameters_and_results(const Function& func);
+    /// \brief Called for AOT(Ahead of time compliation) runtime only operation to set the values to
+    /// be returned by get_parameters
+    ///     and get_results
+    /// \param params The parameters
+    /// \param results The results
+    void set_parameters_and_results(const ParameterVector& param, const ResultVector& results);
 
 private:
     ngraph::ParameterVector m_parameters;


### PR DESCRIPTION
This is for AOT(Ahead of time compile) use case. 
During compile-time, we generate backend blob, so no need to keep the serialized function information other than inputs and outputs (to save space, and also to save time for serialize/deserialize). 

During run-time, we don't need function but we still need to set parameters and results, so the front end can create input and output tensors. Ngraph-bridge is using executable->get_parameters(), and executable->get_results(). To support this, I'm adding new api to just set the parameters and results without constructing new function. 