### PR TITLE
Improve temporal complexity of shape_util methods.

### DIFF
--- a/src/ngraph/shape_util.cpp
+++ b/src/ngraph/shape_util.cpp
@@ -31,12 +31,13 @@ PartialShape ngraph::project(const PartialShape& shape, const AxisSet& axes)
     {
         std::vector<Dimension> result_dims;
 
-        for (size_t i = 0; i < size_t(shape.rank()); i++)
+        for (size_t const& axe : axes)
         {
-            if (axes.find(i) != axes.end())
+            if (axe >= size_t(shape.rank()))
             {
-                result_dims.push_back(shape[i]);
+                break;
             }
+            result_dims.push_back(shape[axe]);
         }
 
         return PartialShape(result_dims);
@@ -54,11 +55,33 @@ PartialShape ngraph::reduce(const PartialShape& shape, const AxisSet& deleted_ax
     {
         AxisSet axes;
 
-        for (size_t i = 0; i < size_t(shape.rank()); i++)
+        if (deleted_axes.empty())
         {
-            if (deleted_axes.find(i) == deleted_axes.end())
+            for (size_t i = 0; i < size_t(shape.rank()); i++)
             {
                 axes.insert(i);
+            }
+        }
+        else
+        {
+            auto deleted_axes_it = deleted_axes.cbegin();
+            for (size_t i = 0; i < size_t(shape.rank()); ++i)
+            {
+                if (*deleted_axes_it == i)
+                {
+                    if (++deleted_axes_it == deleted_axes.cend())
+                    {
+                        for (i = i + 1; i < size_t(shape.rank()); ++i)
+                        {
+                            axes.insert(i);
+                        }
+                        break;
+                    }
+                }
+                else
+                {
+                    axes.insert(i);
+                }
             }
         }
 

--- a/src/ngraph/shape_util.hpp
+++ b/src/ngraph/shape_util.hpp
@@ -25,12 +25,13 @@ namespace ngraph
     {
         AXIS_VALUES result;
 
-        for (size_t i = 0; i < axis_values.size(); i++)
+        for (size_t const axe : axes)
         {
-            if (axes.find(i) != axes.end())
+            if (axe >= axis_values.size())
             {
-                result.push_back(axis_values[i]);
+                break;
             }
+            result.push_back(axis_values[axe]);
         }
 
         return result;
@@ -45,11 +46,33 @@ namespace ngraph
     {
         AxisSet axes;
 
-        for (size_t i = 0; i < axis_values.size(); i++)
+        if (deleted_axes.empty())
         {
-            if (deleted_axes.find(i) == deleted_axes.end())
+            for (size_t i = 0; i < axis_values.size(); ++i)
             {
                 axes.insert(i);
+            }
+        }
+        else
+        {
+            auto deleted_axes_it = deleted_axes.cbegin();
+            for (size_t i = 0; i < axis_values.size(); ++i)
+            {
+                if (*deleted_axes_it == i)
+                {
+                    if (++deleted_axes_it == deleted_axes.cend())
+                    {
+                        for (i = i + 1; i < axis_values.size(); ++i)
+                        {
+                            axes.insert(i);
+                        }
+                        break;
+                    }
+                }
+                else
+                {
+                    axes.insert(i);
+                }
             }
         }
 


### PR DESCRIPTION
The modified methods were using find (std::set) which can be replaced by an iterator since both the set and the for-loop are traversed in order. This way the complexity goes from _O_(N _log_ M) to _O_(N) being N the number of iterations of the for-loop and M the number of elements in the set.

A **much more** compact (but less efficient) version can be implemented by checking if the iterator points to the end of the set each for-loop iteration (instead of checking it only when the iterator is incremented).

There is no need to check for the existence of smaller values as the for-loops start in 0 and the sets only contain size_t elements (which are unsigned).