### PR TITLE
Added set_parameters() and set_results()

### DIFF
--- a/src/ngraph/runtime/executable.cpp
+++ b/src/ngraph/runtime/executable.cpp
@@ -113,6 +113,16 @@ size_t runtime::Executable::get_preferred_pipeline_depth() const
     return 2;
 }
 
+void runtime::Executable::set_parameters(const ngraph::ParameterVector& params)
+{
+    m_parameters = params;
+}
+
+void runtime::Executable::set_results(const ngraph::ResultVector& results)
+{
+    m_results = results;
+}
+
 void runtime::Executable::set_parameters_and_results(const Function& func)
 {
     m_parameters = func.get_parameters();

--- a/src/ngraph/runtime/executable.hpp
+++ b/src/ngraph/runtime/executable.hpp
@@ -73,6 +73,14 @@ public:
     /// \returns  preferred pipeline_depth
     virtual size_t get_preferred_pipeline_depth() const;
 
+    /// \brief Set the input Parameters
+    /// \param params ngraph::ParameterVector of all input parameters
+    void set_parameters(const ngraph::ParameterVector& params);
+
+    /// \brief Set the output Results
+    /// \param results ngraph::ResultVector of all output results
+    void set_results(const ngraph::ResultVector& results);
+
     /// \brief Save this compiled Executable to an output stream.
     ///    Saved stream may be read with Backend::load
     virtual void save(std::ostream& output_stream);


### PR DESCRIPTION
This is for AOT(Ahead of time compile) use case.
During compile-time, we generate backend blob, so no need to keep the serialized function information other than inputs and outputs (to save space, and also to save time for serialize/deserialize).

During run-time, we don't need function but we still need to set parameters and results, so the front end can create input and output tensors. Ngraph-bridge is using executable->get_parameters(), and executable->get_results(). To support this, I'm adding new api to just set the parameters and results without constructing new function.