### PR TITLE
Show more info in convert type error

### DIFF
--- a/src/ngraph/runtime/cpu/builder/convert.cpp
+++ b/src/ngraph/runtime/cpu/builder/convert.cpp
@@ -109,7 +109,11 @@ namespace ngraph
                 }
                 else
                 {
-                    throw ngraph_error("Cannot convert from an invalid input element type");
+                    NGRAPH_CHECK(false,
+                                 "Cannot convert from an invalid input element type : ",
+                                 args[0].get_element_type(),
+                                 " -> ",
+                                 out[0].get_element_type());
                 }
 
                 auto functor = [&, kernel, element_count, arg_buffer_index, out_buffer_index](


### PR DESCRIPTION
help debugging in bridge, new error msg:

Cannot convert from an invalid input element type : element::Type{32, 1, 1, 0, "float"} -> element::Type{0, 0, 0, 0, "dynamic"}