### PR TITLE
Add get_default_value in Dot op to handle the 0 sized input case

### DIFF
--- a/src/ngraph/op/dot.cpp
+++ b/src/ngraph/op/dot.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include "ngraph/axis_vector.hpp"
+#include "ngraph/graph_util.hpp"
 #include "ngraph/op/broadcast.hpp"
 #include "ngraph/op/dot.hpp"
 #include "ngraph/op/reshape.hpp"
@@ -200,4 +201,9 @@ void op::Dot::generate_adjoints(autodiff::Adjoints& adjoints, const NodeVector& 
     auto x_reshaped = make_reshape_axes_to_front(x, I_shape, J_shape);               // JI
     auto x_reshaped_dot_delta = make_shared<Dot>(x_reshaped, delta, I_shape.size()); // JI.IK->JK
     adjoints.add_delta(y, x_reshaped_dot_delta);
+}
+
+shared_ptr<Node> op::Dot::get_default_value() const
+{
+    return ngraph::make_constant_from_string("0", get_element_type(), get_shape());
 }

--- a/src/ngraph/op/dot.hpp
+++ b/src/ngraph/op/dot.hpp
@@ -60,6 +60,8 @@ namespace ngraph
 
             void validate_and_infer_types() override;
 
+            virtual std::shared_ptr<Node> get_default_value() const override;
+
             size_t get_reduction_axes_count() const { return m_reduction_axes_count; }
             void set_reduction_axes_count(size_t reduction_axes_count)
             {


### PR DESCRIPTION
This change allows the zero tensor elimination for Dot op with input has zero dimension. The unit test cases covered by this change are: dot_0_0, dot_matrix_2x0_0x2, dot_matrix_0x2_2x0, dot_2x0_0.