### PR TITLE
Fix an error in ONNXRT build

### DIFF
--- a/src/ngraph/op/binary_convolution.hpp
+++ b/src/ngraph/op/binary_convolution.hpp
@@ -99,7 +99,7 @@ namespace ngraph
                 const BinaryConvolutionMode& get_mode() const { return m_mode; }
                 void set_mode(const BinaryConvolutionMode& mode) { m_mode = mode; }
                 /// \return The pad value.
-                const float get_pad_value() const { return m_pad_value; }
+                float get_pad_value() const { return m_pad_value; }
                 void set_pad_value(float pad_value) { m_pad_value = pad_value; }
             protected:
                 BinaryConvolutionMode mode_from_string(const std::string& mode) const;


### PR DESCRIPTION
ONNXRT uses different settings (warnings as errors) and this is what it's complaining about:

https://aipg-rancher.intel.com/jenkins/algo/job/CLX-onnxrt-performance-master/288/console

```
In file included from /onnxruntime/build/Release/external/ngraph/include/ngraph/ngraph.hpp:100:0,
                 from /onnxruntime/onnxruntime/core/providers/ngraph/ngraph_custom_op.h:12,
                 from /onnxruntime/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc:12:
/onnxruntime/build/Release/external/ngraph/include/ngraph/op/binary_convolution.hpp:102:45: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
                 const float get_pad_value() const { return m_pad_value; }
```