### PR TITLE
LSTM Cell operation accordingly to v10 specification

### DIFF
--- a/src/ngraph/op/fused/lstm_cell.cpp
+++ b/src/ngraph/op/fused/lstm_cell.cpp
@@ -52,6 +52,28 @@ op::LSTMCell::LSTMCell(const Output<Node>& X,
 }
 
 op::LSTMCell::LSTMCell(const Output<Node>& X,
+                       const Output<Node>& H_t,
+                       const Output<Node>& C_t,
+                       const Output<Node>& W,
+                       const Output<Node>& R,
+                       const Output<Node>& B,
+                       size_t hidden_size,
+                       const vector<string>& activations,
+                       const vector<float>& activation_alpha,
+                       const vector<float>& activation_beta,
+                       float clip)
+    : FusedOp({X, W, R, H_t, C_t, B})
+    , RNNCellBase(hidden_size, clip, activations, activation_alpha, activation_beta)
+    , m_activation_f{get_activation_function(0)}
+    , m_activation_g{get_activation_function(1)}
+    , m_activation_h{get_activation_function(2)}
+    , m_input_forget{false}
+{
+    add_default_peepholes_input();
+    constructor_validate_and_infer_types();
+}
+
+op::LSTMCell::LSTMCell(const Output<Node>& X,
                        const Output<Node>& W,
                        const Output<Node>& R,
                        const Output<Node>& H_t,

--- a/src/ngraph/op/fused/lstm_cell.hpp
+++ b/src/ngraph/op/fused/lstm_cell.hpp
@@ -49,6 +49,42 @@ namespace ngraph
             /// \brief      Constructs LSTMCell node.
             ///
             /// \param[in]  X            The input tensor with shape: [batch_size, input_size].
+            /// \param[in]  H_t          The hidden state tensor at current time step with shape:
+            ///                             [batch_size, hidden_size].
+            /// \param[in]  C_t          The cell state tensor at current time step with shape:
+            ///                             [batch_size, hidden_size].
+            /// \param[in]  W            The weight tensor with shape: [4*hidden_size, input_size].
+            /// \param[in]  R            The recurrence weight tensor with shape:
+            ///                             [4*hidden_size, hidden_size].
+            /// \param[in]  B            The bias tensor for input gate with shape:
+            ///                             [4*hidden_size].
+            /// \param[in]  hidden_size  The number of hidden units for recurrent cell.
+            ///
+            /// \param[in]  activations       The vector of activation functions used inside
+            ///                               recurrent cell.
+            /// \param[in]  activation_alpha  The vector of alpha parameters for activation
+            ///                               functions in order respective to activation list.
+            /// \param[in]  activation_beta   The vector of beta parameters for activation functions
+            ///                               in order respective to activation list.
+            /// \param[in]  clip              The value defining clipping range [-clip, clip] on
+            ///                               input of activation functions.
+            LSTMCell(const Output<Node>& X,
+                     const Output<Node>& H_t,
+                     const Output<Node>& C_t,
+                     const Output<Node>& W,
+                     const Output<Node>& R,
+                     const Output<Node>& B,
+                     size_t hidden_size,
+                     const std::vector<std::string>& activations =
+                         std::vector<std::string>{"sigmoid", "tanh", "tanh"},
+                     const std::vector<float>& activation_alpha = {},
+                     const std::vector<float>& activation_beta = {},
+                     float clip = 0.f);
+
+            ///
+            /// \brief      Constructs LSTMCell node.
+            ///
+            /// \param[in]  X            The input tensor with shape: [batch_size, input_size].
             /// \param[in]  W            The weight tensor with shape: [4*hidden_size, input_size].
             /// \param[in]  R            The recurrence weight tensor with shape:
             ///                             [4*hidden_size, hidden_size].


### PR DESCRIPTION
Added an additional constructor for LSTM Cell operation to make it according to v10 specification, since this blocks TensorIterator support.
