### PR TITLE
Add second decompose pass to INTERPRETER backend

### DIFF
--- a/src/ngraph/runtime/interpreter/int_executable.cpp
+++ b/src/ngraph/runtime/interpreter/int_executable.cpp
@@ -25,7 +25,6 @@
 #include "ngraph/pass/like_replacement.hpp"
 #include "ngraph/pass/liveness.hpp"
 #include "ngraph/pass/manager.hpp"
-#include "ngraph/pass/memory_layout.hpp"
 #include "ngraph/pass/opset0_downgrade.hpp"
 #include "ngraph/runtime/backend_manager.hpp"
 #include "ngraph/runtime/chrome_trace.hpp"
@@ -69,6 +68,8 @@ runtime::interpreter::INTExecutable::INTExecutable(const shared_ptr<Function>& f
     pass_manager.register_pass<pass::LikeReplacement>();
     pass_manager.register_pass<pass::FusedOpDecomposition>();
     pass_manager.register_pass<pass::Opset0Downgrade>();
+    // Need to decompose any v0 fused ops, which were produced by the downgrade pass
+    pass_manager.register_pass<pass::FusedOpDecomposition>();
     pass_manager.register_pass<pass::AssignLayout<DenseTensorLayout>>();
     pass_manager.register_pass<pass::Liveness>();
     pass_manager.run_passes(m_function);

--- a/src/ngraph/runtime/interpreter/unit_test.manifest
+++ b/src/ngraph/runtime/interpreter/unit_test.manifest
@@ -22,8 +22,3 @@ top_k_opset_11_const_k_smallest
 # Tile op case that the number of elements in "repeats" and shape of "data" are different
 tile_3d_small_data_rank
 tile_3d_few_repeats
-
-# Another fused op decomposition pass required after the downgrade pass
-model_split_equal_parts_default
-model_split_equal_parts_2d
-model_split_variable_parts_2d


### PR DESCRIPTION
In order for the INTERPRETER backend to work properly, we need to decompose any `v0` fused ops, which were produced by the `v1->v0` downgrade pass.