### PR TITLE
[WIP] Introduce optional MemRefType lowering

### DIFF
--- a/cmake/external_mlir.cmake
+++ b/cmake/external_mlir.cmake
@@ -20,8 +20,8 @@ set(MLIR_LLVM_REPO_URL https://github.com/llvm/llvm-project.git)
 set(MLIR_REPO_URL https://github.com/tensorflow/mlir.git)
 
 # Change these commit IDs to move to latest stable versions
-set(MLIR_LLVM_COMMIT_ID 75990950)
-set(MLIR_COMMIT_ID 5e64e536)
+set(MLIR_LLVM_COMMIT_ID c36773c7)
+set(MLIR_COMMIT_ID 606e96a1)
 
 # MLIR environment variables. Some of them are used by LIT tool.
 

--- a/src/contrib/mlir/CMakeLists.txt
+++ b/src/contrib/mlir/CMakeLists.txt
@@ -24,6 +24,7 @@ add_subdirectory(tools/ngraph-opt)
 
 set(SRC
     backend/cpu/cpu_backend.cpp
+    backend/cpu/cpu_backend_experimental.cpp
     backend/pass/affine_lowerer.cpp
     backend/pass/memory_optimization.cpp
     core/compiler.cpp

--- a/src/contrib/mlir/backend/cpu/cpu_backend_experimental.cpp
+++ b/src/contrib/mlir/backend/cpu/cpu_backend_experimental.cpp
@@ -1,0 +1,163 @@
+//*****************************************************************************
+// Copyright 2017-2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+//
+// This file contains code that is temporarily needed to overcome existing limitations in MLIR.
+//
+// NOTE: This file follows nGraph format style.
+// Follows nGraph naming convention for public APIs only, else MLIR naming convention.
+
+#include "cpu_backend_experimental.hpp"
+
+#include <llvm/Support/CommandLine.h>
+#include <mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h>
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/IR/Function.h>
+#include <mlir/IR/StandardTypes.h>
+
+// *** Experimental flags ***
+
+llvm::cl::opt<bool>
+    clEnableCustomMemRefLowering("ngraph-custom-memref-lowering",
+                                 llvm::cl::init(false),
+                                 llvm::cl::desc("Enable a custom memref lowering to LLVM"));
+
+using namespace ngraph::runtime::ngmlir;
+using namespace mlir;
+
+namespace
+{
+    struct CustomFuncOpConversion : public LLVMOpLowering
+    {
+        CustomFuncOpConversion(LLVMTypeConverter& converter, PatternBenefit benefit)
+            : LLVMOpLowering(FuncOp::getOperationName(),
+                             converter.getDialect()->getContext(),
+                             converter,
+                             benefit)
+        {
+        }
+
+        PatternMatchResult matchAndRewrite(Operation* op,
+                                           ArrayRef<Value*> operands,
+                                           ConversionPatternRewriter& rewriter) const override
+        {
+            auto funcOp = cast<FuncOp>(op);
+
+            // Convert the original function arguments. Struct arguments are promoted to
+            // pointer to struct arguments to allow calling external functions with
+            // various ABIs (e.g. compiled from C/C++ on platform X).
+            auto varargsAttr = funcOp.getAttrOfType<BoolAttr>("std.varargs");
+            TypeConverter::SignatureConversion result(funcOp.getNumArguments());
+            auto llvmType = lowering.convertFunctionSignature(
+                funcOp.getType(), varargsAttr && varargsAttr.getValue(), result);
+
+            // Only retain those attributes that are not constructed by build.
+            SmallVector<NamedAttribute, 4> attributes;
+            for (const auto& attr : funcOp.getAttrs())
+            {
+                if (attr.first.is(SymbolTable::getSymbolAttrName()) ||
+                    attr.first.is(impl::getTypeAttrName()) || attr.first.is("std.varargs"))
+                    continue;
+                attributes.push_back(attr);
+            }
+
+            // Create an LLVM function, use external linkage by default until MLIR
+            // functions have linkage.
+            auto newFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
+                op->getLoc(), funcOp.getName(), llvmType, LLVM::Linkage::External, attributes);
+            rewriter.inlineRegionBefore(funcOp.getBody(), newFuncOp.getBody(), newFuncOp.end());
+
+            // Tell the rewriter to convert the region signature.
+            rewriter.applySignatureConversion(&newFuncOp.getBody(), result);
+
+            rewriter.eraseOp(op);
+            return matchSuccess();
+        }
+    };
+
+} // namespace
+
+/// Custom Std-to-LLVM type converter that overrides `convertType` and `convertFunctionSignature`
+/// taking into account that MemRef type will be lowered to a plain pointer. It falls back to the
+/// standar LLVMTypeConverter for the remaining types.
+Type CustomLLVMTypeConverter::convertType(Type type)
+{
+    if (auto memrefTy = type.dyn_cast<MemRefType>())
+    {
+        return convertMemRefType(memrefTy);
+    }
+
+    // Fall back to the base class.
+    return LLVMTypeConverter::convertType(type);
+}
+
+/// Converts function signature following LLVMTypeConverter approach but lowering
+/// MemRef arguments to plain LLVM pointers to element type.
+LLVM::LLVMType CustomLLVMTypeConverter::convertFunctionSignature(
+    FunctionType type, bool isVariadic, LLVMTypeConverter::SignatureConversion& result)
+{
+    // Convert argument types one by one and check for errors.
+    for (auto& en : llvm::enumerate(type.getInputs()))
+    {
+        Type type = en.value();
+        auto converted = convertType(type).dyn_cast_or_null<LLVM::LLVMType>();
+        if (!converted)
+            return {};
+        result.addInputs(en.index(), converted);
+    }
+
+    SmallVector<LLVM::LLVMType, 8> argTypes;
+    argTypes.reserve(llvm::size(result.getConvertedTypes()));
+    for (Type type : result.getConvertedTypes())
+        argTypes.push_back(unwrap(type));
+
+    // If function does not return anything, create the void result type,
+    // if it returns on element, convert it, otherwise pack the result types into
+    // a struct.
+    LLVM::LLVMType resultType = type.getNumResults() == 0
+                                    ? LLVM::LLVMType::getVoidTy(llvmDialect)
+                                    : unwrap(packFunctionResults(type.getResults()));
+    if (!resultType)
+        return {};
+    return LLVM::LLVMType::getFunctionTy(resultType, argTypes, isVariadic);
+}
+
+/// Converts MemRefType to plain LLVM pointer to element type.
+Type CustomLLVMTypeConverter::convertMemRefType(MemRefType type)
+{
+    int64_t offset;
+    SmallVector<int64_t, 4> strides;
+    bool strideSuccess = succeeded(getStridesAndOffset(type, strides, offset));
+    assert(strideSuccess && "Non-strided layout maps must have been normalized away");
+    (void)strideSuccess;
+
+    LLVM::LLVMType elementType = unwrap(convertType(type.getElementType()));
+    if (!elementType)
+        return {};
+    auto ptrTy = elementType.getPointerTo(type.getMemorySpace());
+    return ptrTy;
+}
+
+/// Populates 'patterns' with default LLVM conversion patterns using CustomLLVMTypeConverter and a
+/// custom conversion pattern for FuncOp which takes into account MemRef custom lowering to plain
+/// LLVM pointer.
+void ngraph::runtime::ngmlir::customPopulateStdToLLVMConversionPatterns(
+    LLVMTypeConverter& converter, OwningRewritePatternList& patterns)
+{
+    mlir::populateStdToLLVMConversionPatterns<CustomMemRefDescriptor>(converter, patterns);
+    // Add custom FuncOp conversion pattern with higher benefit than default FuncOp conversion
+    // pattern (1).
+    patterns.insert<CustomFuncOpConversion>(converter, /*benefit=*/100);
+}

--- a/src/contrib/mlir/backend/cpu/cpu_backend_experimental.hpp
+++ b/src/contrib/mlir/backend/cpu/cpu_backend_experimental.hpp
@@ -1,0 +1,64 @@
+//*****************************************************************************
+// Copyright 2017-2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+//
+// This file contains code that is temporarily needed to overcome existing limitations in MLIR.
+//
+// NOTE: This file follows nGraph format style.
+// Follows nGraph naming convention for public APIs only, else MLIR naming convention.
+
+#pragma once
+
+#include <mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h>
+
+namespace ngraph
+{
+    namespace runtime
+    {
+        namespace ngmlir
+        {
+            /// Custom Std-to-LLVM type converter that overrides `convertType` and
+            /// `convertFunctionSignature` taking into account that MemRef type will be lowered to a
+            /// plain pointer. It falls back to the standar LLVMTypeConverter for the remaining
+            /// types.
+            class CustomLLVMTypeConverter : public mlir::LLVMTypeConverter
+            {
+            public:
+                using LLVMTypeConverter::LLVMTypeConverter;
+
+                /// Converts MemRef type to a plain LLVM pointer to element type. Falls back to
+                /// default LLVMTypeConverter for other types.
+                mlir::Type convertType(mlir::Type type) override;
+
+                /// Converts function signature following LLVMTypeConverter approach but lowering
+                /// MemRef arguments to plain LLVM pointers to element type.
+                mlir::LLVM::LLVMType convertFunctionSignature(
+                    mlir::FunctionType type,
+                    bool isVariadic,
+                    mlir::LLVMTypeConverter::SignatureConversion& result) override;
+
+            private:
+                mlir::Type convertMemRefType(mlir::MemRefType type);
+            };
+
+            /// Populates 'patterns' with default LLVM conversion patterns using
+            /// CustomLLVMTypeConverter and a custom conversion pattern for FuncOp which takes into
+            /// account MemRef custom lowering to plain LLVM pointer.
+            void
+                customPopulateStdToLLVMConversionPatterns(mlir::LLVMTypeConverter& converter,
+                                                          mlir::OwningRewritePatternList& patterns);
+        } // namespace ngmlir
+    }     // namespace runtime
+} // namespace ngraph

--- a/src/contrib/mlir/backend/cpu/cpu_backend_experimental.hpp
+++ b/src/contrib/mlir/backend/cpu/cpu_backend_experimental.hpp
@@ -23,6 +23,11 @@
 
 #include <mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h>
 
+namespace mlir
+{
+    class MemRefDescriptor;
+}
+
 namespace ngraph
 {
     namespace runtime
@@ -48,6 +53,23 @@ namespace ngraph
                     mlir::FunctionType type,
                     bool isVariadic,
                     mlir::LLVMTypeConverter::SignatureConversion& result) override;
+
+                /// Create a DefaultMemRefDescriptor object for 'value'.
+                std::unique_ptr<mlir::MemRefDescriptor>
+                    createMemRefDescriptor(mlir::Value* value) override;
+
+                /// Builds IR creating a nullptr value of the descriptor type.
+                std::unique_ptr<mlir::MemRefDescriptor>
+                    buildMemRefDescriptor(mlir::OpBuilder& builder,
+                                          mlir::Location loc,
+                                          mlir::Type descriptorType) override;
+                /// Builds IR creating a MemRef descriptor that represents `type` and populates it
+                /// with static shape and stride information extracted from the type.
+                std::unique_ptr<mlir::MemRefDescriptor>
+                    buildStaticMemRefDescriptor(mlir::OpBuilder& builder,
+                                                mlir::Location loc,
+                                                mlir::MemRefType type,
+                                                mlir::Value* memory) override;
 
             private:
                 mlir::Type convertMemRefType(mlir::MemRefType type);

--- a/src/contrib/mlir/backend/pass/affine_lowerer.cpp
+++ b/src/contrib/mlir/backend/pass/affine_lowerer.cpp
@@ -202,6 +202,7 @@ namespace
         void insertDeallocs(PatternRewriter& rewriter);
 
         NGraphTypeConverter& getTypeConverter() { return typeConverter; }
+
     private:
         /// Collect a set of patterns to convert from the nGraph dialect to Affine dialect.
         void populateNGraphToAffineConversionPatterns(OwningRewritePatternList& patterns);
@@ -585,7 +586,7 @@ namespace
         auto ubs = vLHS.getUbs();
         // Loop induction vars
         auto ivs = makeIndexHandles(vLHS.rank());
-        auto pivs = makeIndexHandlePointers(ivs);
+        auto pivs = makeHandlePointers(MutableArrayRef<IndexHandle>(ivs));
         // Steps
         auto steps = vLHS.getSteps();
 
@@ -796,14 +797,14 @@ namespace
                      "Incorrect loop nest bounds size for gather params");
 
         paramsIVs = makeIndexHandles(vParams.rank() - 1);
-        paramsIVPtrs = makeIndexHandlePointers(paramsIVs);
+        paramsIVPtrs = makeHandlePointers(MutableArrayRef<IndexHandle>(paramsIVs));
 
         auto indicesLbs = vIndices.getLbs();
         auto indicesUbs = vIndices.getUbs();
         auto indicesSteps = vIndices.getSteps();
 
         auto indicesIVs = makeIndexHandles(vIndices.rank());
-        auto indicesIVPtrs = makeIndexHandlePointers(indicesIVs);
+        auto indicesIVPtrs = makeHandlePointers(MutableArrayRef<IndexHandle>(indicesIVs));
 
         SmallVector<IndexHandle, 8> paramsIndices, resIndices;
 
@@ -958,7 +959,8 @@ namespace
 
         // Result spatial indices and bounds
         auto resSpatialIndices = makeIndexHandles(spatialRank);
-        auto resSpatialIndicesPtrs = makeIndexHandlePointers(resSpatialIndices);
+        auto resSpatialIndicesPtrs =
+            makeHandlePointers(MutableArrayRef<IndexHandle>(resSpatialIndices));
         SmallVector<int64_t, 4> resSteps, filtersSteps;
         SmallVector<int, 4> padBelowIntValues;
         bool withPadding = false;
@@ -997,7 +999,8 @@ namespace
 
         // Filters spatial indices and bounds
         auto filtersSpatialIndices = makeIndexHandles(spatialRank);
-        auto filtersSpatialIndicesPtrs = makeIndexHandlePointers(filtersSpatialIndices);
+        auto filtersSpatialIndicesPtrs =
+            makeHandlePointers(MutableArrayRef<IndexHandle>(filtersSpatialIndices));
 
         for (auto i = 0; i < spatialRank; i++)
         {
@@ -1045,7 +1048,8 @@ namespace
         {
             IndexHandle n, k, c;
             auto resSpatialIndices = makeIndexHandles(spatialRank);
-            auto resSpatialIndicesPtrs = makeIndexHandlePointers(resSpatialIndices);
+            auto resSpatialIndicesPtrs =
+                makeHandlePointers(MutableArrayRef<IndexHandle>(resSpatialIndices));
 
             LoopBuilder::makeAffine(&n, batchLb, batchUb, 1)([&] {
                 LoopBuilder::makeAffine(&k, numFiltersLb, numFiltersUb, 1)([&] {
@@ -1196,7 +1200,7 @@ namespace
         auto ubs = vLHS.getUbs();
         // Loop induction vars
         auto ivs = makeIndexHandles(vLHS.rank());
-        auto pivs = makeIndexHandlePointers(ivs);
+        auto pivs = makeHandlePointers(MutableArrayRef<IndexHandle>(ivs));
         // Steps
         auto steps = vLHS.getSteps();
 
@@ -1242,7 +1246,7 @@ namespace
         auto ubs = vLHS.getUbs();
         // Loop induction vars
         auto ivs = makeIndexHandles(vLHS.rank());
-        auto pivs = makeIndexHandlePointers(ivs);
+        auto pivs = makeHandlePointers(MutableArrayRef<IndexHandle>(ivs));
         // Steps
         auto steps = vLHS.getSteps();
         AffineLoopNestBuilder(pivs, lbs, ubs, steps)(
@@ -1335,7 +1339,7 @@ namespace
         // Generate loop nest that initializes result to lower bound of the axis to be reduced.
         {
             auto ivs = makeIndexHandles(vRes.rank());
-            auto pivs = makeIndexHandlePointers(ivs);
+            auto pivs = makeHandlePointers(MutableArrayRef<IndexHandle>(ivs));
             auto steps = vRes.getSteps();
             auto initVal = vArg.lb(axis);
             AffineLoopNestBuilder(pivs, resLbs, resUbs, steps)(
@@ -1345,7 +1349,7 @@ namespace
         // Generate loop nest that computes the actual index reduction.
         {
             auto allIVs = makeIndexHandles(vArg.rank());
-            auto pAllIVs = makeIndexHandlePointers(allIVs);
+            auto pAllIVs = makeHandlePointers(MutableArrayRef<IndexHandle>(allIVs));
             auto steps = vArg.getSteps();
             SmallVector<IndexHandle, 8> nonRedIVs;
 
@@ -1410,7 +1414,7 @@ namespace
         }
         NGRAPH_UNREACHABLE("Unsupported type");
     }
-}
+} // namespace
 
 namespace mlir
 {

--- a/src/contrib/mlir/runtime/cpu/cpu_runtime.hpp
+++ b/src/contrib/mlir/runtime/cpu/cpu_runtime.hpp
@@ -61,7 +61,7 @@ namespace ngraph
                 llvm::SmallVector<void*, 8> allocateMemrefArgs();
 
                 /// Helper to allocate a mem ref object. Handles static shapes only for now.
-                StaticMemRef* allocateMemrefDescriptor();
+                StaticMemRef* allocateDefaultMemrefDescriptor();
 
             private:
                 // Pointers to externally allocated memory for sub-graph's input and output tensors.


### PR DESCRIPTION
This PR introduces an alternative Std->LLVM lowering for MemRefType. This
lowering converts MemRefType to a plain LLVM pointer instead of to the
struct descriptor that is used by default. This alternative lowering can
be enabled with an experimental flag.