### PR TITLE
[ROV4] Adding 3 new attributes to PriorBox op

### DIFF
--- a/src/ngraph/op/experimental/layers/prior_box.cpp
+++ b/src/ngraph/op/experimental/layers/prior_box.cpp
@@ -94,8 +94,10 @@ size_t op::PriorBox::number_of_priors(const PriorBoxAttrs& attrs)
     // plus one box 1x1.
     size_t total_aspect_ratios = normalized_aspect_ratio(attrs.aspect_ratio, attrs.flip).size();
 
-    if (!attrs.min_size.empty())
-        num_priors = total_aspect_ratios * attrs.min_size.size();
+    if (attrs.scale_all_sizes)
+        num_priors = total_aspect_ratios * attrs.min_size.size() + attrs.max_size.size();
+    else
+        num_priors = total_aspect_ratios + attrs.min_size.size() - 1;
 
     if (!attrs.fixed_size.empty())
         num_priors = total_aspect_ratios * attrs.fixed_size.size();
@@ -109,15 +111,6 @@ size_t op::PriorBox::number_of_priors(const PriorBoxAttrs& attrs)
         else
             num_priors += total_aspect_ratios * density_2d;
     }
-
-    // TODO: Check whether attrs.max_size is really should be ignored when attrs.scale_all_size ==
-    // False
-    //       as the spec says or it is done automatically because attrs_max_size is always emtpy in
-    //       this case.
-    //       The following statement is executed unconditionally according to the code in OpenVINO
-    //       Model Optimizer
-    //       that infer shapes for this operation.
-    num_priors += attrs.max_size.size();
 
     return num_priors;
 }

--- a/src/ngraph/op/experimental/layers/prior_box.hpp
+++ b/src/ngraph/op/experimental/layers/prior_box.hpp
@@ -36,6 +36,9 @@ namespace ngraph
             std::vector<float> min_size;
             std::vector<float> max_size;
             std::vector<float> aspect_ratio;
+            std::vector<float> density;
+            std::vector<float> fixed_ratio;
+            std::vector<float> fixed_size;
             bool clip = false;
             bool flip = false;
             float step = 1.0f;
@@ -67,6 +70,11 @@ namespace ngraph
 
                 virtual std::shared_ptr<Node>
                     copy_with_new_args(const NodeVector& new_args) const override;
+
+                static size_t number_of_priors(const PriorBoxAttrs& attrs);
+
+                static std::vector<float>
+                    normalized_aspect_ratio(const std::vector<float>& aspect_ratio, bool flip);
 
                 const PriorBoxAttrs& get_attrs() const { return m_attrs; }
             private:

--- a/test/type_prop_layers.cpp
+++ b/test/type_prop_layers.cpp
@@ -79,7 +79,7 @@ TEST(type_prop_layers, prior_box1)
     auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {32, 32});
     auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
     auto pb = make_shared<op::PriorBox>(layer_shape, image_shape, attrs);
-    ASSERT_EQ(pb->get_shape(), (Shape{2, 32768}));
+    ASSERT_EQ(pb->get_shape(), (Shape{2, 20480}));
 }
 
 TEST(type_prop_layers, prior_box2)
@@ -92,7 +92,7 @@ TEST(type_prop_layers, prior_box2)
     auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {32, 32});
     auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
     auto pb = make_shared<op::PriorBox>(layer_shape, image_shape, attrs);
-    ASSERT_EQ(pb->get_shape(), (Shape{2, 57344}));
+    ASSERT_EQ(pb->get_shape(), (Shape{2, 32768}));
 }
 
 TEST(type_prop_layers, prior_box3)

--- a/test/type_prop_layers.cpp
+++ b/test/type_prop_layers.cpp
@@ -74,25 +74,25 @@ TEST(type_prop_layers, prior_box1)
 {
     op::PriorBoxAttrs attrs;
     attrs.min_size = {2.0f, 3.0f};
-    attrs.aspect_ratio = {1.0f, 2.0f, 0.5f};
+    attrs.aspect_ratio = {1.5f, 2.0f, 2.5f};
 
     auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {32, 32});
     auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
     auto pb = make_shared<op::PriorBox>(layer_shape, image_shape, attrs);
-    ASSERT_EQ(pb->get_shape(), (Shape{2, 16384}));
+    ASSERT_EQ(pb->get_shape(), (Shape{2, 32768}));
 }
 
 TEST(type_prop_layers, prior_box2)
 {
     op::PriorBoxAttrs attrs;
     attrs.min_size = {2.0f, 3.0f};
-    attrs.aspect_ratio = {1.0f, 2.0f, 0.5f};
+    attrs.aspect_ratio = {1.5f, 2.0f, 2.5f};
     attrs.flip = true;
 
     auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {32, 32});
     auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
     auto pb = make_shared<op::PriorBox>(layer_shape, image_shape, attrs);
-    ASSERT_EQ(pb->get_shape(), (Shape{2, 28672}));
+    ASSERT_EQ(pb->get_shape(), (Shape{2, 57344}));
 }
 
 TEST(type_prop_layers, prior_box3)


### PR DESCRIPTION
While preparing the new version of specification we lost 3 new attributes for PriorBox. Now they are restored. Shape inference function is aligned with one that is implemented in OpenVINO ModelOptimizer considering those three attributes. Code that calculates the number of priors is moved to a separate function to be easily re-used in 3rd party code.