### PR TITLE
Fix ScalarConstantLikeBase

### DIFF
--- a/src/ngraph/op/constant.cpp
+++ b/src/ngraph/op/constant.cpp
@@ -337,6 +337,7 @@ bool op::Constant::are_all_data_elements_bitwise_identical() const
     return rc;
 }
 
+constexpr NodeTypeInfo op::ScalarConstantLikeBase::type_info;
 constexpr NodeTypeInfo op::ScalarConstantLike::type_info;
 
 shared_ptr<op::Constant> op::ScalarConstantLikeBase::as_constant() const

--- a/src/ngraph/op/constant.hpp
+++ b/src/ngraph/op/constant.hpp
@@ -442,6 +442,8 @@ namespace ngraph
         class NGRAPH_API ScalarConstantLikeBase : public Constant
         {
         public:
+            static constexpr NodeTypeInfo type_info{"ScalarConstantLikeBase", 0};
+            const NodeTypeInfo& get_type_info() const override { return type_info; }
             std::shared_ptr<op::Constant> as_constant() const;
             ScalarConstantLikeBase() = default;
 

--- a/src/ngraph/type.hpp
+++ b/src/ngraph/type.hpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 #include "ngraph/ngraph_visibility.hpp"
 
@@ -40,7 +41,11 @@ namespace ngraph
         const char* name;
         uint64_t version;
 
-        bool is_castable(const DiscreteTypeInfo& target_type) const { return *this == target_type; }
+        bool is_castable(const DiscreteTypeInfo& target_type) const
+        {
+            std::cout << __FILE__ << " " << __LINE__ << std::endl;
+            return *this == target_type;
+        }
         // For use as a key
         bool operator<(const DiscreteTypeInfo& b) const
         {
@@ -60,6 +65,7 @@ namespace ngraph
         }
         bool operator==(const DiscreteTypeInfo& b) const
         {
+            std::cout << __FILE__ << " " << __LINE__ << name << ", " << b.name << std::endl;
             return version == b.version && strcmp(name, b.name) == 0;
         }
         bool operator!=(const DiscreteTypeInfo& b) const

--- a/src/ngraph/type.hpp
+++ b/src/ngraph/type.hpp
@@ -23,7 +23,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <iostream>
 
 #include "ngraph/ngraph_visibility.hpp"
 
@@ -41,11 +40,7 @@ namespace ngraph
         const char* name;
         uint64_t version;
 
-        bool is_castable(const DiscreteTypeInfo& target_type) const
-        {
-            std::cout << __FILE__ << " " << __LINE__ << std::endl;
-            return *this == target_type;
-        }
+        bool is_castable(const DiscreteTypeInfo& target_type) const { return *this == target_type; }
         // For use as a key
         bool operator<(const DiscreteTypeInfo& b) const
         {
@@ -65,13 +60,9 @@ namespace ngraph
         }
         bool operator==(const DiscreteTypeInfo& b) const
         {
-            std::cout << __FILE__ << " " << __LINE__ << name << ", " << b.name << std::endl;
             return version == b.version && strcmp(name, b.name) == 0;
         }
-        bool operator!=(const DiscreteTypeInfo& b) const
-        {
-            return version != b.version || strcmp(name, b.name) != 0;
-        }
+        bool operator!=(const DiscreteTypeInfo& b) const { return !(*this == b); }
     };
 
     /// \brief Tests if value is a pointer/shared_ptr that can be statically cast to a

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,6 +106,7 @@ set(SRC
     shape.cpp
     specialize_function.cpp
     tensor.cpp
+    type.cpp
     type_prop/all.cpp
     type_prop/any.cpp
     type_prop/avg_pool.cpp

--- a/test/type.cpp
+++ b/test/type.cpp
@@ -22,6 +22,14 @@
 using namespace std;
 using namespace ngraph;
 
+TEST(type, is_type)
+{
+    Shape shape{2, 2, 2};
+    auto A = op::Constant::create(element::f32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
+
+    EXPECT_FALSE(is_type<op::ScalarConstantLikeBase>(A));
+}
+
 TEST(type, as_type_ptr)
 {
     Shape shape{2, 2, 2};

--- a/test/type.cpp
+++ b/test/type.cpp
@@ -1,0 +1,32 @@
+//*****************************************************************************
+// Copyright 2017-2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include "gtest/gtest.h"
+
+#include "ngraph/ngraph.hpp"
+
+#include <memory>
+using namespace std;
+using namespace ngraph;
+
+TEST(type, as_type_ptr)
+{
+    Shape shape{2, 2, 2};
+    auto A = op::Constant::create(element::f32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
+
+    auto scl = as_type_ptr<op::ScalarConstantLikeBase>(A);
+    EXPECT_EQ(scl, nullptr);
+}

--- a/test/type.cpp
+++ b/test/type.cpp
@@ -28,6 +28,7 @@ TEST(type, is_type)
     auto A = op::Constant::create(element::f32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
 
     EXPECT_FALSE(is_type<op::ScalarConstantLikeBase>(A));
+    EXPECT_TRUE(is_type<op::Constant>(A));
 }
 
 TEST(type, as_type_ptr)
@@ -37,4 +38,7 @@ TEST(type, as_type_ptr)
 
     auto scl = as_type_ptr<op::ScalarConstantLikeBase>(A);
     EXPECT_EQ(scl, nullptr);
+
+    auto c = as_type_ptr<op::Constant>(A);
+    EXPECT_NE(c, nullptr);
 }


### PR DESCRIPTION
ScalarConstantLikeBase did not have a type_info defined and thus a Constant op could be as_type_ptr cast to a ScalarConstantLikeBase since ScalarConstantLikeBase is derived from Constant and thus used Constant's type_info. Confusing enough?

I noticed this because the LikeReplacement pass was taking 52 second to run on bert_squad_training.json and there are no Like ops in that file. The issue was every Constant was treated as a ScalarConstantLikeBase and was therefore replaced with a Constant. Very expensive.

LikeReplacement time went from 52 second to 29 ms or a 1793x speed increase.
NopElimination has the exact same ScalarConstantLikeBase code as LikeReplacement so save another 50 seconds with that pass.