### PR TITLE
Update plaidml_translate.cpp to include bfloat16

### DIFF
--- a/src/ngraph/runtime/plaidml/plaidml_translate.cpp
+++ b/src/ngraph/runtime/plaidml/plaidml_translate.cpp
@@ -117,6 +117,7 @@ std::string ngraph::runtime::plaidml::tile_converter(const std::string& tensor_n
     case PLAIDML_DATA_FLOAT16: return "as_float(" + tensor_name + ", 16)";
     case PLAIDML_DATA_FLOAT32: return "as_float(" + tensor_name + ", 32)";
     case PLAIDML_DATA_FLOAT64: return "as_float(" + tensor_name + ", 64)";
+    case PLAIDML_DATA_BFLOAT16: return "as_bfloat16(" + tensor_name + ", 16)";
     case PLAIDML_DATA_INVALID:
     case PLAIDML_DATA_INT128:
     case PLAIDML_DATA_PRNG: throw std::runtime_error{"Unsupported type conversion"};


### PR DESCRIPTION
ngraph-tensorflow-bridge fails to build with plaidml backend unless case PLAIDML_DATA_BFLOAT16 is included in switch (dt).