### PR TITLE
cmake and documentation build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -648,10 +648,11 @@ if (NGRAPH_TEST_UTIL_ENABLE)
 endif()
 
 add_subdirectory(test)
-add_subdirectory(doc/examples)
 
 if (NGRAPH_DOC_BUILD_ENABLE)
     add_subdirectory(doc)
+else()
+    add_subdirectory(doc/examples)
 endif()
 
 if (NGRAPH_PYTHON_BUILD_ENABLE)


### PR DESCRIPTION
*   Issue:
     The CMakelists.txt specifies that the examples/doc should be created but when the 
     NGRAPH_DOC_BUILD_ENABLE=ON the CMakelists.txt instructs that doc be created
     but given that doc/examples exists, an error is generated

*   Instructions to Duplicate:
    Executing the following:
    cmake .. -DNGRAPH_DOC_BUILD_ENABLE=ON -DNGRAPH_UNIT_TEST_ENABLE=ON -DNGRAPH_DEBUG_ENABLE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../ng_install
    
    Will generate the following error:
    
    ```
    CMake Error at doc/CMakeLists.txt:17 (add_subdirectory):
      The binary directory

        /nfs/pdx/home/sssimoni/ng/task_1/ngraph/build/doc/examples

      is already used to build a source directory.  It cannot be used to build
      source directory

        /nfs/pdx/home/sssimoni/ng/task_1/ngraph/doc/examples

      Specify a unique binary directory name.
    ```

*   Fix:
    The following change to CMakeLists.txt fixes this as either doc or doc/examples 
    are created but not both
    ```
     add_subdirectory(test)
    -add_subdirectory(doc/examples)

     if (NGRAPH_DOC_BUILD_ENABLE)
         add_subdirectory(doc)
    +else()
    +    add_subdirectory(doc/examples)
    ```
