### PR TITLE
TensorIterator: align the number of inputs.

### DIFF
--- a/src/ngraph/op/tensor_iterator.cpp
+++ b/src/ngraph/op/tensor_iterator.cpp
@@ -141,13 +141,6 @@ shared_ptr<op::TensorIterator::OutputDescription>
 
 Input<Node> op::TensorIterator::input_for_value(const Output<Node>& value)
 {
-    for (auto input : inputs())
-    {
-        if (input.get_source_output() == value)
-        {
-            return input;
-        }
-    }
     auto input_index = get_input_size();
     set_argument(input_index, value);
     return Input<Node>(this, input_index);


### PR DESCRIPTION
Previously, we didn't insert duplicate inputs and returned existed id, but unfortunately, it doesn't work for some networks, e.g. GNMT. For GNMT we have connections from one TI input to several layers of the body, so the check get_input_size() == m_input_descriptions.size() fails, also there are some reshape issues. I suggest inserting all inputs to align it with m_input_descriptions.size().

All dldt tests passed with these changes with the current master.