### PR TITLE
Fix Python CI build break

### DIFF
--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -6,4 +6,4 @@ flake8-commas
 flake8-comprehensions
 flake8-docstrings
 flake8-quotes
-
+zipp==0.5.0


### PR DESCRIPTION
New version of `zipp` library is causing problems with our Python CI.