### PR TITLE
fix gcc issue non-void return type

### DIFF
--- a/src/ngraph/pass/constant_folding_one_hot.cpp
+++ b/src/ngraph/pass/constant_folding_one_hot.cpp
@@ -86,6 +86,9 @@ shared_ptr<op::Constant> fold_constant_one_hot(const shared_ptr<op::Constant>& i
         return fold_constant_one_hot_ref<uint64_t, OUTPUT_TYPE>(
             indices, on_value, off_value, output_shape, axis);
     }
+#ifdef __GNUC__
+    __builtin_unreachable();
+#endif
 }
 
 void pass::ConstantFolding::construct_constant_one_hot()


### PR DESCRIPTION
I tried to compile ngraph using gcc (8.3.0) and got the following error when compiling `constant_folding_one_hot.cpp`: `error: control reaches end of non-void function [-Werror=return-type]`.

The issue is that unlike clang, gcc's static analyser doesn't detect that all enum values are handled in the switch statement. However, it is possible to tell gcc that the code after the switch is unreachable.

I am not sure if this is the ideal fix, but it is enough to be able compile the unit-tests target with my gcc version. I think this is better than adding a default statement. (I suspect this issue occurs with other gcc versions, but the gcc version in the CI doesn't complain)