### PR TITLE
Undo GetOutputElement creations during cloning

### DIFF
--- a/src/ngraph/node.cpp
+++ b/src/ngraph/node.cpp
@@ -142,6 +142,14 @@ std::shared_ptr<Node>
             }
         }
         clone = copy_with_new_args(args);
+        // Remove the inserted GOEs
+        for (size_t i = 0; i < inputs.size(); ++i)
+        {
+            if (clone->input_value(i) != inputs.at(i))
+            {
+                clone->set_argument(i, inputs.at(i));
+            }
+        }
     }
     for (auto& cdep : control_dependencies)
     {


### PR DESCRIPTION
Because `copy_with_new_args` has a `NodeVector` argument, `GetOutputElement` can be created by `copy_with_new_inputs`. This replaces those `GetOutputElement`s. This should be removed when there is time to change `copy_with_new_args` to take an `OutputVector` instead of a `NodeVector`.