### PR TITLE
avoid error tautological-constant-out-of-range-compare

### DIFF
--- a/src/ngraph/op/gather.cpp
+++ b/src/ngraph/op/gather.cpp
@@ -130,7 +130,7 @@ void op::v1::Gather::validate_and_infer_types()
                               ").");
     }
 
-    auto axis = get_axis();
+    int64_t axis = get_axis();
     if (input_rank.is_static() && axis != AXIS_NOT_SET_VALUE)
     {
         NODE_VALIDATION_CHECK(this,


### PR DESCRIPTION
During compilation for Android `armeabi-v7a` fixes error:

```
ngraph/src/ngraph/op/gather.cpp:134:40: error: result of comparison of constant 9223372036854775807 with expression of type 'unsigned int' is always true
      [-Werror,-Wtautological-constant-out-of-range-compare]
    if (input_rank.is_static() && axis != AXIS_NOT_SET_VALUE)
                                  ~~~~ ^  ~~~~~~~~~~~~~~~~~~
```