### PR TITLE
MSVC build error in ONNX OneHot

### DIFF
--- a/src/ngraph/frontend/onnx_import/op/onehot.cpp
+++ b/src/ngraph/frontend/onnx_import/op/onehot.cpp
@@ -42,9 +42,9 @@ namespace ngraph
                     auto off_on_values =
                         std::make_shared<default_opset::Split>(values, split_axis, 2);
                     auto off_value =
-                        reshape::interpret_as_scalar(get_output_element(off_on_values, 0ul));
+                        reshape::interpret_as_scalar(get_output_element(off_on_values, size_t{0}));
                     auto on_value =
-                        reshape::interpret_as_scalar(get_output_element(off_on_values, 1ul));
+                        reshape::interpret_as_scalar(get_output_element(off_on_values, size_t{1}));
 
                     auto axis = node.get_attribute_value<std::int64_t>("axis", -1);
 


### PR DESCRIPTION
This fixes the `ambiguous call to overloaded function` error in MSVC build.  VS couldn't select an overload: `get_output_element(const Output<Node>&, bool)` and `get_output_element(const Output<Node>&, size_t)`