### PR TITLE
Remove raw pointer from OpSet

### DIFF
--- a/src/ngraph/factory.hpp
+++ b/src/ngraph/factory.hpp
@@ -77,7 +77,7 @@ namespace ngraph
         }
 
         /// \brief Create an instance for type_info
-        BASE_TYPE* create(const typename BASE_TYPE::type_info_t& type_info)
+        BASE_TYPE* create(const typename BASE_TYPE::type_info_t& type_info) const
         {
             std::lock_guard<std::mutex> guard(get_registry_mutex());
             auto it = m_factory_map.find(type_info);
@@ -86,7 +86,7 @@ namespace ngraph
 
         /// \brief Create an instance using factory for DERIVED_TYPE
         template <typename DERIVED_TYPE>
-        BASE_TYPE* create()
+        BASE_TYPE* create() const
         {
             return create(DERIVED_TYPE::type_info);
         }

--- a/src/ngraph/opsets/opset.cpp
+++ b/src/ngraph/opsets/opset.cpp
@@ -28,7 +28,7 @@ ngraph::Node* ngraph::OpSet::create(const std::string& name) const
     auto type_info_it = m_name_type_info_map.find(name);
     return type_info_it == m_name_type_info_map.end()
                ? nullptr
-               : m_factory_registry->create(type_info_it->second);
+               : m_factory_registry.create(type_info_it->second);
 }
 
 const ngraph::OpSet& ngraph::get_opset0()

--- a/src/ngraph/opsets/opset.hpp
+++ b/src/ngraph/opsets/opset.hpp
@@ -32,9 +32,7 @@ namespace ngraph
         static std::mutex& get_mutex();
 
     public:
-        OpSet(ngraph::FactoryRegistry<ngraph::Node>* factory_registry =
-                  &ngraph::FactoryRegistry<Node>::get())
-            : m_factory_registry(factory_registry)
+        OpSet()
         {
         }
 
@@ -51,7 +49,7 @@ namespace ngraph
             std::lock_guard<std::mutex> guard(get_mutex());
             m_op_types.insert(type_info);
             m_name_type_info_map[name] = type_info;
-            m_factory_registry->register_factory(type_info, factory);
+            m_factory_registry.register_factory(type_info, factory);
         }
 
         /// \brief Insert OP_TYPE into the opset with a special name and the default factory
@@ -100,14 +98,9 @@ namespace ngraph
             return m_op_types.find(node->get_type_info()) != m_op_types.end();
         }
 
-        void set_factory_registry(ngraph::FactoryRegistry<ngraph::Node>* factory_registry)
-        {
-            m_factory_registry = factory_registry;
-        }
-
-        ngraph::FactoryRegistry<ngraph::Node>* get_factory_registry() { return m_factory_registry; }
+        ngraph::FactoryRegistry<ngraph::Node>& get_factory_registry() { return m_factory_registry; }
     protected:
-        ngraph::FactoryRegistry<ngraph::Node>* m_factory_registry;
+        ngraph::FactoryRegistry<ngraph::Node> m_factory_registry;
         std::set<NodeTypeInfo> m_op_types;
         std::map<std::string, NodeTypeInfo> m_name_type_info_map;
     };

--- a/test/opset1.cpp
+++ b/test/opset1.cpp
@@ -171,9 +171,7 @@ constexpr NodeTypeInfo NewOp::type_info;
 TEST(opset, new_op)
 {
     // Copy opset1; don't bash the real thing in a test
-    FactoryRegistry<Node> ext_factory = FactoryRegistry<Node>::get();
     OpSet opset1_copy(get_opset1());
-    opset1_copy.set_factory_registry(&ext_factory);
     opset1_copy.insert<NewOp>();
     {
         shared_ptr<Node> op(opset1_copy.create(NewOp::type_info.name));


### PR DESCRIPTION
Each opsets insert all operations to factory in the get_opset...() methods.

We do not need to insert operations to global factory.

If user wants to modify Factory, he can use method `get_factory_registry()`