### PR TITLE
Peg virtualenv to version 16.7.10

### DIFF
--- a/contrib/docker/Dockerfile.ngraph.centos74
+++ b/contrib/docker/Dockerfile.ngraph.centos74
@@ -44,7 +44,7 @@ RUN gcc --version
 RUN c++ --version
 
 RUN easy_install pip
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.10
 
 
 # Install some pip packages

--- a/contrib/docker/Dockerfile.ngraph.centos74_gpu
+++ b/contrib/docker/Dockerfile.ngraph.centos74_gpu
@@ -26,7 +26,7 @@ RUN gcc --version
 RUN c++ --version
 
 RUN easy_install pip
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.10
 
 # Install some pip packages
 

--- a/contrib/docker/Dockerfile.ngraph.ubuntu1604_gpu
+++ b/contrib/docker/Dockerfile.ngraph.ubuntu1604_gpu
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get clean autoclean && \
     apt-get autoremove -y
 RUN pip install --upgrade pip
-RUN pip install virtualenv pytest
+RUN pip install virtualenv==16.7.10 pytest
 
 RUN apt-get update && \
     apt-get install -y python3 python3-pip python3-dev python3-venv && \


### PR DESCRIPTION
With `virtualenv 20.x` and newer we are getting:
```
ImportError: cannot import name 'ContextManager'
```
while creating the environment. This is an attempt to fix it.