### PR TITLE
Revert "Stricter checks on padding attributes for v1::Convolution"

### DIFF
--- a/src/ngraph/op/convolution.cpp
+++ b/src/ngraph/op/convolution.cpp
@@ -42,24 +42,6 @@ op::v1::Convolution::Convolution(const Output<Node>& data_batch,
     , m_pads_end(pads_end)
     , m_auto_pad(auto_pad)
 {
-    if (auto_pad != PadType::EXPLICIT)
-    {
-        NODE_VALIDATION_CHECK(this,
-                              std::all_of(pads_begin.begin(),
-                                          pads_begin.end(),
-                                          [](std::ptrdiff_t i) { return (i == 0); }),
-                              "pads_begin: (",
-                              pads_begin,
-                              ") Non-zero padding should not be used along with auto pad modes.");
-        NODE_VALIDATION_CHECK(this,
-                              std::all_of(pads_end.begin(),
-                                          pads_end.end(),
-                                          [](std::ptrdiff_t i) { return (i == 0); }),
-                              "pads_end: (",
-                              pads_end,
-                              ") Non-zero padding should not be used along with auto pad modes.");
-    }
-
     constructor_validate_and_infer_types();
 }
 

--- a/test/type_prop/convolution.cpp
+++ b/test/type_prop/convolution.cpp
@@ -2863,66 +2863,6 @@ TEST(type_prop, conv_v1_partial_rank)
     ASSERT_TRUE(conv->get_output_partial_shape(0).is_dynamic());
 }
 
-TEST(type_prop, conv_v1_incorrect_auto_pad)
-{
-    PartialShape data_batch_shape{
-        0, Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic()};
-    PartialShape filters_shape{PartialShape::dynamic()};
-    Strides window_movement_strides{1, 1};
-    Strides window_dilation_strides{1, 1};
-    CoordinateDiff pads_begin{0, 0};
-    CoordinateDiff pads_end{0, 0};
-
-    auto param0 = make_shared<op::Parameter>(element::f32, data_batch_shape);
-    auto param1 = make_shared<op::Parameter>(element::f32, filters_shape);
-
-    try
-    {
-        auto conv = make_shared<op::v1::Convolution>(param0,
-                                                     param1,
-                                                     window_movement_strides,
-                                                     CoordinateDiff{1, 0},
-                                                     pads_end,
-                                                     window_dilation_strides,
-                                                     op::PadType::VALID);
-
-        FAIL() << "Incorrect padding not detected";
-    }
-    catch (const NodeValidationFailure& error)
-    {
-        EXPECT_HAS_SUBSTRING(
-            error.what(),
-            std::string("Non-zero padding should not be used along with auto pad modes"));
-    }
-    catch (...)
-    {
-        FAIL() << "Deduced type check failed for unexpected reason";
-    }
-
-    try
-    {
-        auto conv = make_shared<op::v1::Convolution>(param0,
-                                                     param1,
-                                                     window_movement_strides,
-                                                     pads_begin,
-                                                     CoordinateDiff{0, -1},
-                                                     window_dilation_strides,
-                                                     op::PadType::VALID);
-
-        FAIL() << "Incorrect padding not detected";
-    }
-    catch (const NodeValidationFailure& error)
-    {
-        EXPECT_HAS_SUBSTRING(
-            error.what(),
-            std::string("Non-zero padding should not be used along with auto pad modes"));
-    }
-    catch (...)
-    {
-        FAIL() << "Deduced type check failed for unexpected reason";
-    }
-}
-
 TEST(type_prop, deformable_conv_incorrect_group)
 {
     const PartialShape data_batch_shape{1, 3, 96, 96};


### PR DESCRIPTION
Reverts NervanaSystems/ngraph#4350

DLDT validation is failing with this PR.