### PR TITLE
Add EvaluatorTensor functionality into HostTensor

### DIFF
--- a/src/ngraph/descriptor/tensor.cpp
+++ b/src/ngraph/descriptor/tensor.cpp
@@ -46,19 +46,26 @@ descriptor::Tensor::Tensor(const element::Type& element_type,
 void descriptor::Tensor::set_tensor_type(const element::Type& element_type,
                                          const PartialShape& pshape)
 {
-    NGRAPH_CHECK(pshape.all_non_negative(),
-                 "set_tensor_type called on a PartialShape containing negative dimensions: ",
-                 pshape);
-    if (pshape.is_static())
+    set_element_type(element_type);
+    set_partial_shape(pshape);
+}
+
+void descriptor::Tensor::set_element_type(const element::Type& element_type)
+{
+    m_element_type = element_type;
+}
+
+void descriptor::Tensor::set_partial_shape(const PartialShape& partial_shape)
+{
+    m_partial_shape = partial_shape;
+    if (m_partial_shape.is_static())
     {
-        m_shape = pshape.to_shape();
+        m_shape = m_partial_shape.to_shape();
     }
     else
     {
         m_shape = Shape{};
     }
-    m_partial_shape = pshape;
-    m_element_type = element_type;
 }
 
 const Shape& descriptor::Tensor::get_shape() const

--- a/src/ngraph/descriptor/tensor.hpp
+++ b/src/ngraph/descriptor/tensor.hpp
@@ -51,6 +51,8 @@ namespace ngraph
 
             const std::string& get_name() const;
             void set_tensor_type(const element::Type& element_type, const PartialShape& pshape);
+            void set_element_type(const element::Type& elemenet_type);
+            void set_partial_shape(const PartialShape& partial_shape);
 
             const element::Type& get_element_type() const { return m_element_type; }
             const Shape& get_shape() const;

--- a/src/ngraph/evaluator_tensor.hpp
+++ b/src/ngraph/evaluator_tensor.hpp
@@ -30,6 +30,11 @@ namespace ngraph
     template <typename T>
     class Output;
 
+    namespace runtime
+    {
+        class HostTensor;
+    }
+
     /// \brief A generic handle to (potential) storage with element type and shape information
     class NGRAPH_API EvaluatorTensor
     {
@@ -50,7 +55,7 @@ namespace ngraph
         size_t get_size_in_bytes();
 
         template <element::Type_t ET>
-        typename element_type_traits<ET>::value_type* get_ptr()
+        typename element_type_traits<ET>::value_type* get_data_ptr()
         {
             return static_cast<typename element_type_traits<ET>::value_type*>(get_data_ptr());
         }

--- a/src/ngraph/op/add.cpp
+++ b/src/ngraph/op/add.cpp
@@ -73,13 +73,14 @@ namespace
                           const EvaluatorTensorPtr& out,
                           const op::AutoBroadcastSpec& broadcast_spec)
     {
-        return (ET == arg0->get_element_type()) && (runtime::reference::add(arg0->get_ptr<ET>(),
-                                                                            arg1->get_ptr<ET>(),
-                                                                            out->get_ptr<ET>(),
-                                                                            arg0->get_shape(),
-                                                                            arg1->get_shape(),
-                                                                            broadcast_spec),
-                                                    true);
+        return (ET == arg0->get_element_type()) &&
+               (runtime::reference::add(arg0->get_data_ptr<ET>(),
+                                        arg1->get_data_ptr<ET>(),
+                                        out->get_data_ptr<ET>(),
+                                        arg0->get_shape(),
+                                        arg1->get_shape(),
+                                        broadcast_spec),
+                true);
     }
 
     bool evaluate_add(const EvaluatorTensorPtr& arg0,

--- a/src/ngraph/op/shape_of.cpp
+++ b/src/ngraph/op/shape_of.cpp
@@ -67,7 +67,7 @@ namespace
     inline bool try_evaluate_shape_of(const Shape& shape, const EvaluatorTensorPtr& output_value)
     {
         return (ET == output_value->get_element_type()) &&
-               (runtime::reference::shape_of(shape, output_value->get_ptr<ET>()), true);
+               (runtime::reference::shape_of(shape, output_value->get_data_ptr<ET>()), true);
     }
 
     bool evaluate_shape_of(const EvaluatorTensorPtr& output_value,

--- a/src/ngraph/op/softmax.cpp
+++ b/src/ngraph/op/softmax.cpp
@@ -165,7 +165,8 @@ namespace
                                      const AxisSet& axes)
     {
         return (ET == arg->get_element_type()) &&
-               (runtime::reference::softmax(arg->get_ptr<ET>(), out->get_ptr<ET>(), shape, axes),
+               (runtime::reference::softmax(
+                    arg->get_data_ptr<ET>(), out->get_data_ptr<ET>(), shape, axes),
                 true);
     }
 

--- a/src/ngraph/runtime/host_tensor.cpp
+++ b/src/ngraph/runtime/host_tensor.cpp
@@ -34,51 +34,74 @@ runtime::HostTensor::HostTensor(const ngraph::element::Type& element_type,
                                 void* memory_pointer,
                                 const string& name)
     : runtime::Tensor(std::make_shared<ngraph::descriptor::Tensor>(element_type, shape, name))
-    , m_allocated_buffer_pool(nullptr)
-    , m_aligned_buffer_pool(nullptr)
-
+    , m_memory_pointer(memory_pointer)
 {
-    m_descriptor->set_tensor_layout(
-        std::make_shared<ngraph::descriptor::layout::DenseTensorLayout>(*m_descriptor));
-
-    m_buffer_size = m_descriptor->get_tensor_layout()->get_size() * element_type.size();
-
-    if (memory_pointer != nullptr)
+    if (get_partial_shape().is_static() && get_element_type().is_static())
     {
-        m_aligned_buffer_pool = static_cast<char*>(memory_pointer);
-    }
-    else if (m_buffer_size > 0)
-    {
-        size_t allocation_size = m_buffer_size + alignment;
-        m_allocated_buffer_pool = static_cast<char*>(ngraph_malloc(allocation_size));
-        m_aligned_buffer_pool = m_allocated_buffer_pool;
-        size_t mod = size_t(m_aligned_buffer_pool) % alignment;
-        if (mod != 0)
-        {
-            m_aligned_buffer_pool += (alignment - mod);
-        }
+        allocate_buffer();
     }
 }
 
-runtime::HostTensor::HostTensor(const ngraph::element::Type& element_type,
+runtime::HostTensor::HostTensor(const element::Type& element_type,
                                 const Shape& shape,
-                                const string& name)
+                                const std::string& name)
     : HostTensor(element_type, shape, nullptr, name)
 {
 }
 
-runtime::HostTensor::HostTensor(const ngraph::element::Type& element_type, const Shape& shape)
-    : HostTensor(element_type, shape, nullptr, "")
+runtime::HostTensor::HostTensor(const element::Type& element_type,
+                                const PartialShape& partial_shape,
+                                const std::string& name)
+    : runtime::Tensor(
+          std::make_shared<ngraph::descriptor::Tensor>(element_type, partial_shape, name))
+{
+    // Defer allocation until ptr is requested
+}
+
+runtime::HostTensor::HostTensor(const std::string& name)
+    : HostTensor(element::dynamic, PartialShape::dynamic())
 {
 }
 
-runtime::HostTensor::HostTensor(const ngraph::element::Type& element_type,
-                                const Shape& shape,
-                                void* memory_pointer)
-    : HostTensor(element_type, shape, memory_pointer, "")
+<<<<<<< HEAD
+=======
+runtime::HostTensor::HostTensor(const Output<Node>& value)
+    : HostTensor(value.get_element_type(), value.get_partial_shape(), value.get_node()->get_name())
 {
 }
 
+void runtime::HostTensor::allocate_buffer()
+{
+    NGRAPH_CHECK(get_partial_shape().is_static(),
+                 "Attempt to allocate buffer for tensor with partial shape: ",
+                 get_partial_shape());
+    NGRAPH_CHECK(get_element_type().is_static(),
+                 "Attempt to allocate buffer for tensor with dynamic type: ",
+                 get_element_type());
+    m_descriptor->set_tensor_layout(
+        std::make_shared<ngraph::descriptor::layout::DenseTensorLayout>(*m_descriptor));
+    m_buffer_size = m_descriptor->get_tensor_layout()->get_size() * get_element_type().size();
+    if (m_memory_pointer != nullptr)
+    {
+        m_aligned_buffer_pool = m_memory_pointer;
+    }
+    else
+    {
+        size_t allocation_size = m_buffer_size + alignment;
+        uint8_t* allocated_buffer_pool = static_cast<uint8_t*>(ngraph_malloc(allocation_size));
+        m_allocated_buffer_pool = allocated_buffer_pool;
+        size_t mod = size_t(allocated_buffer_pool) % alignment;
+        if (mod == 0)
+        {
+            m_aligned_buffer_pool = allocated_buffer_pool;
+        }
+        else
+        {
+            m_aligned_buffer_pool = (allocated_buffer_pool + alignment - mod);
+        }
+    }
+}
+>>>>>>> cyphers/outtensor
 runtime::HostTensor::HostTensor(const std::shared_ptr<op::v0::Constant>& constant)
     : HostTensor(
           constant->get_output_element_type(0), constant->get_output_shape(0), constant->get_name())
@@ -96,35 +119,103 @@ runtime::HostTensor::~HostTensor()
 
 void* runtime::HostTensor::get_data_ptr()
 {
+    if (!m_aligned_buffer_pool)
+    {
+        allocate_buffer();
+    }
     return m_aligned_buffer_pool;
 }
 
 const void* runtime::HostTensor::get_data_ptr() const
 {
+    NGRAPH_CHECK(m_aligned_buffer_pool, "Buffer not initialized");
     return m_aligned_buffer_pool;
 }
 
 void runtime::HostTensor::write(const void* source, size_t n)
 {
     event::Duration d1("write", "HostTensor");
-
+    void* target = get_data_ptr();
     if (n != m_buffer_size)
     {
         throw out_of_range("partial tensor write not supported");
     }
+<<<<<<< HEAD
     void* target = get_data_ptr();
+=======
+>>>>>>> cyphers/outtensor
     memcpy(target, source, n);
 }
 
 void runtime::HostTensor::read(void* target, size_t n) const
 {
     event::Duration d1("read", "HostTensor");
+    const void* source = get_data_ptr();
     if (n != m_buffer_size)
     {
         throw out_of_range("partial tensor read access not supported");
     }
+<<<<<<< HEAD
     const void* source = get_data_ptr();
+=======
+>>>>>>> cyphers/outtensor
     memcpy(target, source, n);
+}
+
+bool runtime::HostTensor::get_is_allocated() const
+{
+    return m_aligned_buffer_pool != nullptr;
+}
+
+void runtime::HostTensor::set_element_type(const element::Type& element_type)
+{
+    NGRAPH_CHECK(get_element_type().is_dynamic() || get_element_type() == element_type,
+                 "Can not change a static element type");
+    m_descriptor->set_element_type(element_type);
+}
+
+void runtime::HostTensor::set_shape(const Shape& shape)
+{
+    NGRAPH_CHECK(PartialShape(shape).refines(get_partial_shape()),
+                 "Allocation shape ",
+                 shape,
+                 " must be compatible with the partial shape: ",
+                 get_partial_shape());
+    m_descriptor->set_partial_shape(shape);
+}
+
+void runtime::HostTensor::set_unary(const EvaluatorTensorPtr& arg)
+{
+    set_element_type(arg->get_element_type());
+    set_shape(arg->get_partial_shape().get_shape());
+}
+
+void runtime::HostTensor::set_broadcast(const op::AutoBroadcastSpec& autob,
+                                        const EvaluatorTensorPtr& arg0,
+                                        const EvaluatorTensorPtr& arg1)
+{
+    element::Type element_type = arg0->get_element_type();
+    NGRAPH_CHECK(element::Type::merge(element_type, element_type, arg1->get_element_type()),
+                 "Argument element types are inconsistent.");
+    set_element_type(element_type);
+
+    PartialShape pshape = arg0->get_partial_shape();
+    if (autob.m_type == op::AutoBroadcastType::NONE)
+    {
+        NGRAPH_CHECK(PartialShape::merge_into(pshape, arg1->get_partial_shape()),
+                     "Argument shapes are inconsistent.");
+    }
+    else if (autob.m_type == op::AutoBroadcastType::NUMPY ||
+             autob.m_type == op::AutoBroadcastType::PDPD)
+    {
+        NGRAPH_CHECK(PartialShape::broadcast_merge_into(pshape, arg1->get_partial_shape(), autob),
+                     "Argument shapes are inconsistent.");
+    }
+    else
+    {
+        NGRAPH_CHECK(false, "Unsupported auto broadcast specification");
+    }
+    set_shape(pshape.get_shape());
 }
 
 namespace
@@ -134,32 +225,23 @@ namespace
     {
     public:
         HostTensorEvaluatorTensor(const element::Type& element_type,
-                                  const PartialShape& partial_shape)
+                                  const PartialShape& partial_shape,
+                                  const std::string& name)
             : HostEvaluatorTensor(element_type, partial_shape)
+            , m_name(name)
         {
+            m_host_tensor = make_shared<runtime::HostTensor>(element_type, partial_shape);
         }
         HostTensorEvaluatorTensor(shared_ptr<runtime::HostTensor> host_tensor)
-            : HostEvaluatorTensor(host_tensor->get_element_type(), host_tensor->get_partial_shape())
+            : HostEvaluatorTensor(
+                  host_tensor->get_element_type(), host_tensor->get_partial_shape())
             , m_host_tensor(host_tensor)
         {
         }
-        void* get_data_ptr() override
-        {
-            if (!m_host_tensor)
-            {
-                NGRAPH_CHECK(m_element_type.is_static(),
-                             "Attempt to create host tensor with a dynamic element type: ",
-                             m_element_type);
-                NGRAPH_CHECK(m_partial_shape.is_static(),
-                             "Attempt to create a host tensor with a dynamic shape: ",
-                             m_partial_shape);
-                m_host_tensor =
-                    make_shared<runtime::HostTensor>(m_element_type, m_partial_shape.get_shape());
-            }
-            return m_host_tensor->get_data_ptr();
-        }
+        void* get_data_ptr() override { return m_host_tensor->get_data_ptr(); }
         shared_ptr<runtime::HostTensor> get_host_tensor() override { return m_host_tensor; }
     private:
+        string m_name;
         shared_ptr<runtime::HostTensor> m_host_tensor;
     };
 }
@@ -170,9 +252,8 @@ runtime::HostTensor::HostEvaluatorTensorPtr
     return make_shared<HostTensorEvaluatorTensor>(host_tensor);
 }
 
-runtime::HostTensor::HostEvaluatorTensorPtr
-    runtime::HostTensor::create_evaluator_tensor(const element::Type& element_type,
-                                                 const PartialShape& partial_shape)
+runtime::HostTensor::HostEvaluatorTensorPtr runtime::HostTensor::create_evaluator_tensor(
+    const element::Type& element_type, const PartialShape& partial_shape, const string& name)
 {
-    return make_shared<HostTensorEvaluatorTensor>(element_type, partial_shape);
+    return make_shared<HostTensorEvaluatorTensor>(element_type, partial_shape, name);
 }

--- a/src/ngraph/runtime/host_tensor.cpp
+++ b/src/ngraph/runtime/host_tensor.cpp
@@ -63,8 +63,6 @@ runtime::HostTensor::HostTensor(const std::string& name)
 {
 }
 
-<<<<<<< HEAD
-=======
 runtime::HostTensor::HostTensor(const Output<Node>& value)
     : HostTensor(value.get_element_type(), value.get_partial_shape(), value.get_node()->get_name())
 {
@@ -101,7 +99,6 @@ void runtime::HostTensor::allocate_buffer()
         }
     }
 }
->>>>>>> cyphers/outtensor
 runtime::HostTensor::HostTensor(const std::shared_ptr<op::v0::Constant>& constant)
     : HostTensor(
           constant->get_output_element_type(0), constant->get_output_shape(0), constant->get_name())
@@ -140,10 +137,6 @@ void runtime::HostTensor::write(const void* source, size_t n)
     {
         throw out_of_range("partial tensor write not supported");
     }
-<<<<<<< HEAD
-    void* target = get_data_ptr();
-=======
->>>>>>> cyphers/outtensor
     memcpy(target, source, n);
 }
 
@@ -155,10 +148,6 @@ void runtime::HostTensor::read(void* target, size_t n) const
     {
         throw out_of_range("partial tensor read access not supported");
     }
-<<<<<<< HEAD
-    const void* source = get_data_ptr();
-=======
->>>>>>> cyphers/outtensor
     memcpy(target, source, n);
 }
 
@@ -233,8 +222,7 @@ namespace
             m_host_tensor = make_shared<runtime::HostTensor>(element_type, partial_shape);
         }
         HostTensorEvaluatorTensor(shared_ptr<runtime::HostTensor> host_tensor)
-            : HostEvaluatorTensor(
-                  host_tensor->get_element_type(), host_tensor->get_partial_shape())
+            : HostEvaluatorTensor(host_tensor->get_element_type(), host_tensor->get_partial_shape())
             , m_host_tensor(host_tensor)
         {
         }

--- a/src/ngraph/runtime/host_tensor.hpp
+++ b/src/ngraph/runtime/host_tensor.hpp
@@ -41,15 +41,22 @@ namespace ngraph
 class NGRAPH_API ngraph::runtime::HostTensor : public ngraph::runtime::Tensor
 {
 public:
-    HostTensor(const ngraph::element::Type& element_type,
-               const Shape& shape,
-               const std::string& name);
-    HostTensor(const ngraph::element::Type& element_type,
+    HostTensor(const element::Type& element_type,
                const Shape& shape,
                void* memory_pointer,
+<<<<<<< HEAD
                const std::string& name);
     HostTensor(const ngraph::element::Type& element_type, const Shape& shape);
     HostTensor(const ngraph::element::Type& element_type, const Shape& shape, void* memory_pointer);
+=======
+               const std::string& name = "");
+    HostTensor(const element::Type& element_type, const Shape& shape, const std::string& name = "");
+    HostTensor(const element::Type& element_type,
+               const PartialShape& partial_shape,
+               const std::string& name = "'");
+    HostTensor(const std::string& name);
+    HostTensor(const Output<Node>&);
+>>>>>>> cyphers/outtensor
     HostTensor(const std::shared_ptr<op::v0::Constant>& constant);
     virtual ~HostTensor() override;
 
@@ -90,6 +97,23 @@ public:
     /// \param n Number of bytes to read, must be integral number of elements.
     void read(void* p, size_t n) const override;
 
+    bool get_is_allocated() const;
+    /// \brief Set the element type. Must be compatible with the current element type.
+    /// \param element_type The element type
+    void set_element_type(const element::Type& element_type);
+    /// \brief Set the actual shape of the tensor compatibly with the partial shape.
+    /// \param shape The shape being set
+    void set_shape(const Shape& shape);
+    /// \brief Set the shape of a node from an input
+    /// \param arg The input argument
+    void set_unary(const EvaluatorTensorPtr& arg);
+    /// \brief Set the shape of the tensor using broadcast rules
+    /// \param autob The broadcast mode
+    /// \param arg0 The first argument
+    /// \param arg1 The second argument
+    void set_broadcast(const op::AutoBroadcastSpec& autob,
+                       const EvaluatorTensorPtr& arg0,
+                       const EvaluatorTensorPtr& arg1);
     class NGRAPH_API HostEvaluatorTensor : public EvaluatorTensor
     {
     protected:
@@ -98,21 +122,26 @@ public:
     public:
         virtual std::shared_ptr<HostTensor> get_host_tensor() = 0;
     };
+
     using HostEvaluatorTensorPtr = std::shared_ptr<HostEvaluatorTensor>;
+    using HostEvaluatorTensorVector = std::vector<HostEvaluatorTensorPtr>;
     /// \brief Get an evaluator tensor that uses this host tensor for data
     static HostEvaluatorTensorPtr create_evaluator_tensor(std::shared_ptr<HostTensor> host_tensor);
     /// \brief Get an evaluator tensor that creates a host tensor on demand
     /// \param element_type Constraint for element type
     /// \param partial_shape Constraint for partial shape
     static HostEvaluatorTensorPtr create_evaluator_tensor(const element::Type& element_type,
-                                                          const PartialShape& partial_shape);
+                                                          const PartialShape& partial_shape,
+                                                          const std::string& name = "");
 
 private:
+    void allocate_buffer();
     HostTensor(const HostTensor&) = delete;
     HostTensor(HostTensor&&) = delete;
     HostTensor& operator=(const HostTensor&) = delete;
 
-    char* m_allocated_buffer_pool;
-    char* m_aligned_buffer_pool;
+    void* m_memory_pointer{nullptr};
+    void* m_allocated_buffer_pool{nullptr};
+    void* m_aligned_buffer_pool{nullptr};
     size_t m_buffer_size;
 };

--- a/src/ngraph/runtime/host_tensor.hpp
+++ b/src/ngraph/runtime/host_tensor.hpp
@@ -44,11 +44,6 @@ public:
     HostTensor(const element::Type& element_type,
                const Shape& shape,
                void* memory_pointer,
-<<<<<<< HEAD
-               const std::string& name);
-    HostTensor(const ngraph::element::Type& element_type, const Shape& shape);
-    HostTensor(const ngraph::element::Type& element_type, const Shape& shape, void* memory_pointer);
-=======
                const std::string& name = "");
     HostTensor(const element::Type& element_type, const Shape& shape, const std::string& name = "");
     HostTensor(const element::Type& element_type,
@@ -56,7 +51,6 @@ public:
                const std::string& name = "'");
     HostTensor(const std::string& name);
     HostTensor(const Output<Node>&);
->>>>>>> cyphers/outtensor
     HostTensor(const std::shared_ptr<op::v0::Constant>& constant);
     virtual ~HostTensor() override;
 


### PR DESCRIPTION
- Constructors for partial shape
- Set compatible shape/element type
- Change EvaluatorTensor::get_ptr to get_data_ptr for compatibility
Will require #4619 before EvaluatorTensor can be replaced