### PR TITLE
Add Black to CI

### DIFF
--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -1,3 +1,4 @@
+black
 flake8
 flake8-comprehensions
 flake8-docstrings

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -21,6 +21,7 @@ commands=
   {envbindir}/pip install --no-index --pre --find-links=dist/ ngraph-core
   flake8 {posargs:src/ examples/ setup.py}
   flake8 --ignore=D100,D101,D102,D103,D104,D105,D107,W503 test/  # ignore lack of docs in tests
+  black --check --line-length=100 {posargs:src/ examples/ test/}
   mypy --config-file=tox.ini {posargs:src/ examples/}
   pytest --backend={env:NGRAPH_BACKEND} {posargs:test/}
 


### PR DESCRIPTION
`black` code formatter requires Python 3.6
