### PR TITLE
Normalize formatting for pattern matcher

### DIFF
--- a/src/ngraph/pattern/matcher.cpp
+++ b/src/ngraph/pattern/matcher.cpp
@@ -24,295 +24,295 @@
 #include "ngraph/op/get_output_element.hpp"
 #include "ngraph/op/parameter.hpp"
 
-namespace ngraph
+using namespace std;
+using namespace ngraph;
+
+pattern::MatcherState::MatcherState(Matcher* matcher)
+    : m_matcher(matcher)
+    , m_pattern_value_map(matcher->m_pattern_map)
+    , m_watermark(matcher->m_matched_list.size())
+    , m_capture_size(matcher->m_pattern_value_maps.size())
 {
-    namespace pattern
+}
+
+Output<Node> pattern::Matcher::make_node_output(const shared_ptr<Node>& node)
+{
+    return node->get_output_size() == 1 ? node->output(0)
+                                        : make_shared<op::AnyOutput>(node)->output(0);
+}
+
+pattern::Matcher::Matcher(shared_ptr<Node> pattern_node)
+    : m_pattern_node(make_node_output(pattern_node))
+{
+}
+
+pattern::Matcher::Matcher(shared_ptr<Node> pattern_node, const string& name)
+    : m_pattern_node(make_node_output(pattern_node))
+    , m_name(name)
+{
+}
+
+pattern::Matcher::Matcher(shared_ptr<Node> pattern_node, const string& name, bool strict_mode)
+    : Matcher(make_node_output(pattern_node), name, strict_mode)
+{
+}
+
+pattern::MatcherState::~MatcherState()
+{
+    if (m_restore)
     {
-        MatcherState::MatcherState(Matcher* matcher)
-            : m_matcher(matcher)
-            , m_pattern_value_map(matcher->m_pattern_map)
-            , m_watermark(matcher->m_matched_list.size())
-            , m_capture_size(matcher->m_pattern_value_maps.size())
+        if (!m_matcher->m_matched_list.empty())
         {
+            m_matcher->m_matched_list.erase(m_matcher->m_matched_list.begin() + m_watermark,
+                                            m_matcher->m_matched_list.end());
         }
 
-        namespace
+        if (!m_pattern_value_maps.empty())
         {
-            Output<Node> make_node_output(const std::shared_ptr<Node>& node)
-            {
-                return node->get_output_size() == 1
-                           ? node->output(0)
-                           : std::make_shared<op::AnyOutput>(node)->output(0);
-            }
+            m_matcher->m_pattern_value_maps.erase(m_pattern_value_maps.begin() + m_capture_size,
+                                                  m_pattern_value_maps.end());
         }
 
-        Matcher::Matcher(std::shared_ptr<Node> pattern_node)
-            : m_pattern_node(make_node_output(pattern_node))
+        m_matcher->m_pattern_map = m_pattern_value_map;
+    }
+}
+
+bool pattern::MatcherState::finish(bool is_successful)
+{
+    m_restore = !is_successful;
+    return is_successful;
+}
+
+pattern::PatternMap pattern::Matcher::get_pattern_map() const
+{
+    return as_pattern_map(m_pattern_map);
+}
+
+size_t pattern::Matcher::add_node(Output<Node> value)
+{
+    size_t result = m_matched_list.size();
+    m_matched_list.push_back(value);
+    return result;
+}
+
+shared_ptr<Node> pattern::Matcher::get_match_root()
+{
+    return m_match_root.get_node_shared_ptr();
+}
+
+pattern::MatcherState pattern::Matcher::start_match()
+{
+    return MatcherState(this);
+}
+
+Output<Node> pattern::Matcher::get_match_value()
+{
+    return m_match_root;
+}
+
+void pattern::Matcher::capture(const set<Node*>& static_nodes)
+{
+    m_pattern_value_maps.push_back(m_pattern_map);
+    m_pattern_map.clear();
+    for (auto key_value : m_pattern_value_maps.back())
+    {
+        if (static_nodes.count(key_value.first.get()) > 0)
         {
-        }
-
-        Matcher::Matcher(std::shared_ptr<Node> pattern_node, const std::string& name)
-            : m_pattern_node(make_node_output(pattern_node))
-            , m_name(name)
-        {
-        }
-
-        Matcher::Matcher(std::shared_ptr<Node> pattern_node,
-                         const std::string& name,
-                         bool strict_mode)
-            : Matcher(make_node_output(pattern_node), name, strict_mode)
-        {
-        }
-
-        MatcherState::~MatcherState()
-        {
-            if (m_restore)
-            {
-                if (!m_matcher->m_matched_list.empty())
-                {
-                    m_matcher->m_matched_list.erase(m_matcher->m_matched_list.begin() + m_watermark,
-                                                    m_matcher->m_matched_list.end());
-                }
-
-                if (!m_pattern_value_maps.empty())
-                {
-                    m_matcher->m_pattern_value_maps.erase(
-                        m_pattern_value_maps.begin() + m_capture_size, m_pattern_value_maps.end());
-                }
-
-                m_matcher->m_pattern_map = m_pattern_value_map;
-            }
-        }
-
-        bool MatcherState::finish(bool is_successful)
-        {
-            m_restore = !is_successful;
-            return is_successful;
-        }
-        PatternMap Matcher::get_pattern_map() const { return as_pattern_map(m_pattern_map); }
-        size_t Matcher::add_node(Output<Node> value)
-        {
-            size_t result = m_matched_list.size();
-            m_matched_list.push_back(value);
-            return result;
-        }
-
-        std::shared_ptr<Node> Matcher::get_match_root()
-        {
-            return m_match_root.get_node_shared_ptr();
-        }
-
-        MatcherState Matcher::start_match() { return MatcherState(this); }
-        Output<Node> Matcher::get_match_value() { return m_match_root; }
-        void Matcher::capture(const std::set<Node*>& static_nodes)
-        {
-            m_pattern_value_maps.push_back(m_pattern_map);
-            m_pattern_map.clear();
-            for (auto key_value : m_pattern_value_maps.back())
-            {
-                if (static_nodes.count(key_value.first.get()) > 0)
-                {
-                    m_pattern_map.insert(key_value);
-                }
-            }
-        }
-        bool Matcher::is_contained_match(const NodeVector& exclusions, bool ignore_unused)
-        {
-            if (exclusions.empty())
-            {
-                NodeVector label_exclusions;
-                for (auto entry : m_pattern_map)
-                {
-                    // leaf label
-                    if (entry.first->get_input_size() == 0)
-                    {
-                        label_exclusions.push_back(entry.second.get_node_shared_ptr());
-                    }
-                }
-                return ngraph::get_subgraph_outputs(
-                           get_matched_nodes(), label_exclusions, ignore_unused)
-                           .size() < 2;
-            }
-
-            return ngraph::get_subgraph_outputs(get_matched_nodes(), exclusions).size() < 2;
-        }
-
-        bool Matcher::match_value(const ngraph::Output<Node>& pattern_value,
-                                  const ngraph::Output<Node>& graph_value)
-        {
-            std::shared_ptr<Node> pattern_node = pattern_value.get_node_shared_ptr();
-            std::shared_ptr<Node> graph_node = graph_value.get_node_shared_ptr();
-
-            // This env var allows one to specify node name patterns to abort pattern matching
-            // at particular nodes. The upshot is that one can quickly zero in on an offending
-            // fusion by disabling individual fusions or optimizations that use Matcher.
-            static const std::string node_skip_cregex = getenv_string("NGRAPH_FAIL_MATCH_AT");
-            if (!node_skip_cregex.empty())
-            {
-                static const std::regex node_skip_regex(node_skip_cregex);
-                if (std::regex_match(graph_node->get_name(), node_skip_regex))
-                {
-                    NGRAPH_DEBUG << "[MATCHER] Aborting at " << *graph_node
-                                 << " due to NGRAPH_MATCHER_SKIP set to " << node_skip_cregex;
-                    return false;
-                }
-            }
-            return pattern_node->match_value(this, pattern_value, graph_value);
-        }
-
-        bool Matcher::match_permutation(const OutputVector& pattern_args, const OutputVector& args)
-        {
-            for (size_t i = 0; i < args.size(); i++)
-            {
-                if (!match_value(pattern_args.at(i), args.at(i)))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        bool Matcher::match_arguments(Node* pattern_node, const std::shared_ptr<Node>& graph_node)
-        {
-            NGRAPH_DEBUG << "[MATCHER] Match arguments at " << *graph_node << " for pattern "
-                         << *pattern_node;
-
-            auto args = graph_node->input_values();
-            auto pattern_args = pattern_node->input_values();
-
-            if (args.size() != pattern_args.size())
-            {
-                NGRAPH_DEBUG << "[MATCHER] Aborting at " << *graph_node << " for pattern "
-                             << *pattern_node;
-                return false;
-            }
-
-            if (graph_node->is_commutative())
-            {
-                // TODO: [nikolayk] we don't really have to use lexicographically-based perms,
-                // heap's algo should be faster
-                std::sort(begin(pattern_args),
-                          end(pattern_args),
-                          [](const ngraph::Output<ngraph::Node>& n1,
-                             const ngraph::Output<ngraph::Node>& n2) { return n1 < n2; });
-                do
-                {
-                    auto saved = start_match();
-                    if (match_permutation(pattern_args, args))
-                    {
-                        return saved.finish(true);
-                    }
-                } while (std::next_permutation(
-                    begin(pattern_args),
-                    end(pattern_args),
-                    [](const ngraph::Output<ngraph::Node>& n1,
-                       const ngraph::Output<ngraph::Node>& n2) { return n1 < n2; }));
-            }
-            else
-            {
-                return match_permutation(pattern_args, args);
-            }
-
-            NGRAPH_DEBUG << "[MATCHER] Aborting at " << *graph_node << " for pattern "
-                         << *pattern_node;
-            return false;
-        }
-
-        bool Matcher::match(const Output<Node>& graph_value)
-        {
-            // clear our state
-            m_matched_list.clear();
-            return match(graph_value, PatternValueMap{});
-        }
-
-        bool Matcher::match(std::shared_ptr<Node> node) { return match(node->output(0)); }
-        bool Matcher::match(const Output<Node>& graph_value,
-                            const PatternValueMap& previous_matches)
-        {
-            // clear our state
-            m_match_root.reset();
-            m_pattern_map.clear();
-            m_matched_list.clear();
-
-            // insert previous matches
-            m_pattern_map.insert(previous_matches.cbegin(), previous_matches.cend());
-            auto saved = start_match();
-            bool is_match = saved.finish(match_value(m_pattern_node, graph_value));
-            if (is_match)
-            {
-                m_match_root = graph_value;
-            }
-            return is_match;
-        }
-
-        bool Matcher::match(const Output<Node>& graph_value, const PatternMap& previous_matches)
-        {
-            return match(graph_value, as_pattern_value_map(previous_matches));
-        }
-
-        namespace
-        {
-            std::set<std::shared_ptr<Node>>
-                as_node_set(const std::set<std::shared_ptr<op::Label>>& label_set)
-            {
-                std::set<std::shared_ptr<Node>> result;
-                for (auto label : label_set)
-                {
-                    result.insert(label);
-                }
-                return result;
-            }
-        }
-
-        RecurrentMatcher::RecurrentMatcher(
-            const Output<Node>& initial_pattern,
-            const Output<Node>& pattern,
-            const std::shared_ptr<Node>& rpattern,
-            const std::set<std::shared_ptr<op::Label>>& correlated_patterns)
-            : RecurrentMatcher(initial_pattern, pattern, rpattern, as_node_set(correlated_patterns))
-        {
-        }
-
-        bool RecurrentMatcher::match(Output<Node> graph)
-        {
-            bool matched = false;
-            Matcher m_initial(m_initial_pattern);
-            Matcher m_repeat(m_pattern);
-            Matcher& m = m_initial;
-            PatternValueMap previous_matches;
-            m_matches.clear();
-            m_match_root = graph;
-
-            // try to match one cell (i.e. pattern)
-            while (m.match(graph, previous_matches))
-            {
-                matched = true;
-                // move to the next cell
-                graph = m.get_pattern_value_map()[m_recurrent_pattern];
-
-                // copy bound nodes for the current pattern graph into a global matches map
-                for (auto cur_match : m.get_pattern_value_map())
-                {
-                    m_matches[cur_match.first].push_back(cur_match.second);
-                }
-
-                // pre-populate the pattern map for the next cell with the bound nodes
-                // from the current match. Only bound nodes whose labels are in
-                // correlated_patterns are pre-populated. Skip other labels are
-                // unbounded by default
-                for (auto cor_pat : m_correlated_patterns)
-                {
-                    previous_matches[cor_pat] = m.get_pattern_value_map()[cor_pat];
-                }
-                m = m_repeat;
-            }
-
-            if (!matched)
-            {
-                m_match_root.reset();
-            }
-
-            return matched;
+            m_pattern_map.insert(key_value);
         }
     }
+}
+
+bool pattern::Matcher::is_contained_match(const NodeVector& exclusions, bool ignore_unused)
+{
+    if (exclusions.empty())
+    {
+        NodeVector label_exclusions;
+        for (auto entry : m_pattern_map)
+        {
+            // leaf label
+            if (entry.first->get_input_size() == 0)
+            {
+                label_exclusions.push_back(entry.second.get_node_shared_ptr());
+            }
+        }
+        return get_subgraph_outputs(get_matched_nodes(), label_exclusions, ignore_unused).size() <
+               2;
+    }
+
+    return get_subgraph_outputs(get_matched_nodes(), exclusions).size() < 2;
+}
+
+bool pattern::Matcher::match_value(const Output<Node>& pattern_value,
+                                   const Output<Node>& graph_value)
+{
+    shared_ptr<Node> pattern_node = pattern_value.get_node_shared_ptr();
+    shared_ptr<Node> graph_node = graph_value.get_node_shared_ptr();
+
+    // This env var allows one to specify node name patterns to abort pattern matching
+    // at particular nodes. The upshot is that one can quickly zero in on an offending
+    // fusion by disabling individual fusions or optimizations that use Matcher.
+    static const string node_skip_cregex = getenv_string("NGRAPH_FAIL_MATCH_AT");
+    if (!node_skip_cregex.empty())
+    {
+        static const regex node_skip_regex(node_skip_cregex);
+        if (regex_match(graph_node->get_name(), node_skip_regex))
+        {
+            NGRAPH_DEBUG << "[MATCHER] Aborting at " << *graph_node
+                         << " due to NGRAPH_MATCHER_SKIP set to " << node_skip_cregex;
+            return false;
+        }
+    }
+    return pattern_node->match_value(this, pattern_value, graph_value);
+}
+
+bool pattern::Matcher::match_permutation(const OutputVector& pattern_args, const OutputVector& args)
+{
+    for (size_t i = 0; i < args.size(); i++)
+    {
+        if (!match_value(pattern_args.at(i), args.at(i)))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool pattern::Matcher::match_arguments(Node* pattern_node, const shared_ptr<Node>& graph_node)
+{
+    NGRAPH_DEBUG << "[MATCHER] Match arguments at " << *graph_node << " for pattern "
+                 << *pattern_node;
+
+    auto args = graph_node->input_values();
+    auto pattern_args = pattern_node->input_values();
+
+    if (args.size() != pattern_args.size())
+    {
+        NGRAPH_DEBUG << "[MATCHER] Aborting at " << *graph_node << " for pattern " << *pattern_node;
+        return false;
+    }
+
+    if (graph_node->is_commutative())
+    {
+        // TODO: [nikolayk] we don't really have to use lexicographically-based perms,
+        // heap's algo should be faster
+        sort(begin(pattern_args),
+             end(pattern_args),
+             [](const Output<Node>& n1, const Output<Node>& n2) { return n1 < n2; });
+        do
+        {
+            auto saved = start_match();
+            if (match_permutation(pattern_args, args))
+            {
+                return saved.finish(true);
+            }
+        } while (next_permutation(
+            begin(pattern_args),
+            end(pattern_args),
+            [](const Output<Node>& n1, const Output<Node>& n2) { return n1 < n2; }));
+    }
+    else
+    {
+        return match_permutation(pattern_args, args);
+    }
+
+    NGRAPH_DEBUG << "[MATCHER] Aborting at " << *graph_node << " for pattern " << *pattern_node;
+    return false;
+}
+
+bool pattern::Matcher::match(const Output<Node>& graph_value)
+{
+    // clear our state
+    m_matched_list.clear();
+    return match(graph_value, PatternValueMap{});
+}
+
+bool pattern::Matcher::match(shared_ptr<Node> node)
+{
+    return match(node->output(0));
+}
+
+bool pattern::Matcher::match(const Output<Node>& graph_value,
+                             const PatternValueMap& previous_matches)
+{
+    // clear our state
+    m_match_root.reset();
+    m_pattern_map.clear();
+    m_matched_list.clear();
+
+    // insert previous matches
+    m_pattern_map.insert(previous_matches.cbegin(), previous_matches.cend());
+    auto saved = start_match();
+    bool is_match = saved.finish(match_value(m_pattern_node, graph_value));
+    if (is_match)
+    {
+        m_match_root = graph_value;
+    }
+    return is_match;
+}
+
+bool pattern::Matcher::match(const Output<Node>& graph_value, const PatternMap& previous_matches)
+{
+    return match(graph_value, as_pattern_value_map(previous_matches));
+}
+
+set<shared_ptr<Node>>
+    pattern::RecurrentMatcher::as_node_set(const set<shared_ptr<op::Label>>& label_set)
+{
+    set<shared_ptr<Node>> result;
+    for (auto label : label_set)
+    {
+        result.insert(label);
+    }
+    return result;
+}
+
+pattern::RecurrentMatcher::RecurrentMatcher(const Output<Node>& initial_pattern,
+                                            const Output<Node>& pattern,
+                                            const shared_ptr<Node>& rpattern,
+                                            const set<shared_ptr<op::Label>>& correlated_patterns)
+    : RecurrentMatcher(initial_pattern, pattern, rpattern, as_node_set(correlated_patterns))
+{
+}
+
+bool pattern::RecurrentMatcher::match(Output<Node> graph)
+{
+    bool matched = false;
+    Matcher m_initial(m_initial_pattern);
+    Matcher m_repeat(m_pattern);
+    Matcher& m = m_initial;
+    PatternValueMap previous_matches;
+    m_matches.clear();
+    m_match_root = graph;
+
+    // try to match one cell (i.e. pattern)
+    while (m.match(graph, previous_matches))
+    {
+        matched = true;
+        // move to the next cell
+        graph = m.get_pattern_value_map()[m_recurrent_pattern];
+
+        // copy bound nodes for the current pattern graph into a global matches map
+        for (auto cur_match : m.get_pattern_value_map())
+        {
+            m_matches[cur_match.first].push_back(cur_match.second);
+        }
+
+        // pre-populate the pattern map for the next cell with the bound nodes
+        // from the current match. Only bound nodes whose labels are in
+        // correlated_patterns are pre-populated. Skip other labels are
+        // unbounded by default
+        for (auto cor_pat : m_correlated_patterns)
+        {
+            previous_matches[cor_pat] = m.get_pattern_value_map()[cor_pat];
+        }
+        m = m_repeat;
+    }
+
+    if (!matched)
+    {
+        m_match_root.reset();
+    }
+
+    return matched;
 }

--- a/src/ngraph/pattern/matcher.hpp
+++ b/src/ngraph/pattern/matcher.hpp
@@ -38,248 +38,246 @@ namespace ngraph
     namespace pattern
     {
         class Matcher;
-
-        class NGRAPH_API MatcherState
-        {
-        public:
-            MatcherState(Matcher*);
-            bool finish(bool is_successful);
-            ~MatcherState();
-
-        protected:
-            Matcher* m_matcher;
-            PatternValueMap m_pattern_value_map;
-            PatternValueMaps m_pattern_value_maps;
-            size_t m_watermark;
-            size_t m_capture_size;
-            bool m_restore{true};
-        };
-
-        /// Matcher looks for node patterns in a computation graph. The patterns are described by an
-        /// automaton that is described by an extended computation graph. The matcher executes
-        /// by attempting to match the start node of the pattern to a computation graph value
-        /// (output of a Node). In addition to determing if a match occurs, a pattern node may add
-        /// graph nodes to a list of matched nodes, associate nodes with graph values, and start
-        /// submatches. Submatches add match state changes to the enclosing match if the submatch
-        /// succeeds; otherwise the state is reverted.
-        ///
-        /// The default match behavior of a pattern node with a graph nodes is that the computation
-        /// graph value is added to the end of the matched value list and the match succeeds if the
-        /// node/pattern types match and the input values match. In the case of a commutative node,
-        /// the inputs can match in any order. If the matcher is in strict mode, the graph value
-        /// element type and shape must also match.
-        ///
-        /// Pattern nodes that have different match behavior are in ngraph::pattern::op and have
-        /// descriptions of their match behavior.
-        class NGRAPH_API Matcher
-        {
-        public:
-            using PatternMap = ngraph::pattern::PatternMap;
-
-            // Avoid implicit string construction from nullptr.
-            Matcher(const std::shared_ptr<Node> pattern_node, std::nullptr_t name) = delete;
-
-            Matcher() {}
-            Matcher(Output<Node>& pattern_node)
-                : m_pattern_node{pattern_node}
-            {
-            }
-
-            Matcher(Output<Node>& pattern_node, const std::string& name)
-                : m_pattern_node(pattern_node)
-                , m_name{name}
-            {
-            }
-
-            /// \brief Constructs a Matcher object
-            ///
-            /// \param pattern_node is a pattern sub graph that will be matched against input graphs
-            /// \param name is a string which is used for logging and disabling a matcher
-            /// \param strict_mode forces a matcher to consider shapes and ET of nodes
-            Matcher(const Output<Node>& pattern_node, const std::string& name, bool strict_mode)
-                : m_pattern_node(pattern_node)
-                , m_name(name)
-                , m_strict_mode(strict_mode)
-            {
-            }
-
-            // Some matches should start on a node rather than an output. These three constructors
-            // are transition until we work out the right way to do that.
-            Matcher(std::shared_ptr<Node> pattern_node);
-            Matcher(std::shared_ptr<Node> pattern_node, const std::string& name);
-            Matcher(std::shared_ptr<Node> pattern_node, const std::string& name, bool strict_mode);
-
-            virtual ~Matcher() {}
-            /// \brief Matches a pattern to \p graph_node
-            ///
-            /// \param graph_value is an input graph to be matched against
-            bool match(const Output<Node>& graph_value);
-
-            bool match(std::shared_ptr<Node> graph_node);
-
-            /// \brief Matches a pattern to \p graph_node
-            ///
-            /// \param graph_value is an input graph to be matched against
-            /// \param previous_matches contains previous mappings from labels to nodes to use
-            bool match(const Output<Node>& graph_value, const PatternMap& previous_matches);
-            bool match(const Output<Node>& graph_value, const PatternValueMap& previous_matches);
-
-            template <typename T>
-            static std::shared_ptr<T> unique_match(std::shared_ptr<Node> node)
-            {
-                std::shared_ptr<T> matched;
-                for (auto arg : node->get_arguments())
-                {
-                    if (auto t_casted = as_type_ptr<T>(arg))
-                    {
-                        if (matched)
-                        {
-                            throw ngraph_error("There's more than two arguments of the same type");
-                        }
-                        else
-                        {
-                            matched = t_casted;
-                        }
-                    }
-                }
-                return matched;
-            }
-
-            bool is_contained_match(const NodeVector& exclusions = {}, bool ignore_unused = true);
-            const NodeVector get_matched_nodes() { return as_node_vector(m_matched_list); }
-            const OutputVector& get_matched_values() const { return m_matched_list; }
-            OutputVector& get_matched_values() { return m_matched_list; }
-            void reset() {}
-            const std::string& get_name() { return m_name; }
-            std::shared_ptr<Node> get_pattern() { return m_pattern_node.as_single_output_node(); }
-            Output<Node> get_pattern_value() { return m_pattern_node; }
-            std::shared_ptr<Node> get_match_root();
-            Output<Node> get_match_value();
-            PatternMap get_pattern_map() const;
-            PatternValueMap& get_pattern_value_map() { return m_pattern_map; }
-            PatternValueMaps& get_pattern_value_maps() { return m_pattern_value_maps; }
-            /// \brief Low-level helper to match recurring patterns
-            ///
-            /// \param graph is a graph to be matched against
-            /// \param pattern is a recurring pattern
-            /// \param rpattern specifies a node to recur from next
-            /// \param patterns a map from labels to matches
-
-            size_t add_node(Output<Node> node);
-
-            bool virtual match_value(const ngraph::Output<Node>& pattern_value,
-                                     const ngraph::Output<Node>& graph_value);
-
-            bool is_strict_mode() { return m_strict_mode; }
-            virtual bool match_arguments(Node* pattern_node,
-                                         const std::shared_ptr<Node>& graph_node);
-
-            void capture(const std::set<Node*>& static_nodes);
-
-            size_t get_number_of_recurrent_matches() const { return m_pattern_value_maps.size(); }
-            NodeVector get_bound_nodes_for_pattern(const Output<Node>& pattern) const;
-            size_t get_number_of_bound_labels() const;
-            /// \brief Try a match
-            MatcherState start_match();
-
-            Output<Node> m_match_root;
-            Output<Node> m_pattern_node;
-            PatternValueMap m_pattern_map;
-            PatternValueMaps m_pattern_value_maps;
-            OutputVector m_matched_list;
-
-        protected:
-            bool match_permutation(const OutputVector& pattern_args, const OutputVector& args);
-
-            std::string m_name{"unnamed"};
-            bool m_strict_mode{false};
-        };
-
-        class NGRAPH_API RecurrentMatcher
-        {
-        public:
-            /// \brief Constructs a RecurrentMatcher object. Reccurent Matchers are used to match
-            ///        repeating patterns (e.g. RNN, LSTM, GRU cells)
-            ///
-            /// \param initial_pattern is a pattern sub graph describing the initial cell
-            /// \param pattern is a pattern sub graph describing an individual cell
-            /// \param rpattern is a (recurring) label to denote which node the next match should
-            ///                 start at
-            /// \param correlated_patterns is a set of labels whose bound nodes must remain the same
-            ///                            across all cells
-            RecurrentMatcher(const Output<Node>& initial_pattern,
-                             const Output<Node>& pattern,
-                             const std::shared_ptr<Node>& rpattern,
-                             const std::set<std::shared_ptr<Node>>& correlated_patterns)
-                : m_initial_pattern(initial_pattern)
-                , m_pattern(pattern)
-                , m_recurrent_pattern(rpattern)
-                , m_correlated_patterns(correlated_patterns)
-            {
-            }
-
-            /// \brief Constructs a RecurrentMatcher object. Reccurent Matchers are used to match
-            ///        repeating patterns (e.g. RNN, LSTM, GRU cells)
-            ///
-            /// \param pattern is a pattern sub graph describing an individual cell
-            /// \param rpattern is a (recurring) label to denote which node the next match should
-            ///                 start at
-            /// \param correlated_patterns is a set of labels whose bound nodes must remain the same
-            ///                            across all cells
-            RecurrentMatcher(const Output<Node>& pattern,
-                             const std::shared_ptr<Node>& rpattern,
-                             const std::set<std::shared_ptr<Node>>& correlated_patterns)
-                : RecurrentMatcher(pattern, pattern, rpattern, correlated_patterns)
-            {
-            }
-
-            RecurrentMatcher(const Output<Node>& initial_pattern,
-                             const Output<Node>& pattern,
-                             const std::shared_ptr<Node>& rpattern,
-                             const std::set<std::shared_ptr<op::Label>>& correlated_patterns);
-
-            RecurrentMatcher(const Output<Node>& pattern,
-                             const std::shared_ptr<Node>& rpattern,
-                             const std::set<std::shared_ptr<op::Label>>& correlated_patterns)
-                : RecurrentMatcher(pattern, pattern, rpattern, correlated_patterns)
-            {
-            }
-
-            /// \brief Returns a vector of bound nodes for a given label (used in a pattern
-            /// describing an individual cell
-            NodeVector get_bound_nodes_for_pattern(const std::shared_ptr<Node>& pattern) const
-            {
-                if (m_matches.count(pattern) == 0)
-                {
-                    throw ngraph_error("No bound nodes for a given label");
-                }
-
-                return as_node_vector(m_matches.at(pattern));
-            }
-
-            size_t get_number_of_recurrent_matches() const
-            {
-                if (m_matches.size() == 0)
-                {
-                    return 0;
-                }
-
-                return (*m_matches.begin()).second.size();
-            }
-
-            size_t get_number_of_bound_labels() const { return m_matches.size(); }
-            /// \brief Tries to match a pattern for an individual cell to a given \p graph
-            bool match(Output<Node> graph);
-
-            std::shared_ptr<Node> get_match_root() { return m_match_root.get_node_shared_ptr(); }
-            Output<Node> get_match_value() { return m_match_root; }
-        private:
-            Output<Node> m_initial_pattern;
-            Output<Node> m_pattern;
-            std::shared_ptr<Node> m_recurrent_pattern;
-            const std::set<std::shared_ptr<Node>> m_correlated_patterns;
-            RPatternValueMap m_matches;
-            Output<Node> m_match_root;
-        };
+        class MatcherState;
+        class RecurrentMatcher;
     }
 }
+
+class NGRAPH_API ngraph::pattern::MatcherState
+{
+public:
+    MatcherState(Matcher*);
+    bool finish(bool is_successful);
+    ~MatcherState();
+
+protected:
+    Matcher* m_matcher;
+    PatternValueMap m_pattern_value_map;
+    PatternValueMaps m_pattern_value_maps;
+    size_t m_watermark;
+    size_t m_capture_size;
+    bool m_restore{true};
+};
+
+/// Matcher looks for node patterns in a computation graph. The patterns are described by an
+/// automaton that is described by an extended computation graph. The matcher executes
+/// by attempting to match the start node of the pattern to a computation graph value
+/// (output of a Node). In addition to determing if a match occurs, a pattern node may add
+/// graph nodes to a list of matched nodes, associate nodes with graph values, and start
+/// submatches. Submatches add match state changes to the enclosing match if the submatch
+/// succeeds; otherwise the state is reverted.
+///
+/// The default match behavior of a pattern node with a graph nodes is that the computation
+/// graph value is added to the end of the matched value list and the match succeeds if the
+/// node/pattern types match and the input values match. In the case of a commutative node,
+/// the inputs can match in any order. If the matcher is in strict mode, the graph value
+/// element type and shape must also match.
+///
+/// Pattern nodes that have different match behavior are in ngraph::pattern::op and have
+/// descriptions of their match behavior.
+class NGRAPH_API ngraph::pattern::Matcher
+{
+public:
+    using PatternMap = ngraph::pattern::PatternMap;
+
+    // Avoid implicit string construction from nullptr.
+    Matcher(const std::shared_ptr<Node> pattern_node, std::nullptr_t name) = delete;
+
+    Matcher() {}
+    Matcher(Output<Node>& pattern_node)
+        : m_pattern_node{pattern_node}
+    {
+    }
+
+    Matcher(Output<Node>& pattern_node, const std::string& name)
+        : m_pattern_node(pattern_node)
+        , m_name{name}
+    {
+    }
+
+    /// \brief Constructs a Matcher object
+    ///
+    /// \param pattern_node is a pattern sub graph that will be matched against input graphs
+    /// \param name is a string which is used for logging and disabling a matcher
+    /// \param strict_mode forces a matcher to consider shapes and ET of nodes
+    Matcher(const Output<Node>& pattern_node, const std::string& name, bool strict_mode)
+        : m_pattern_node(pattern_node)
+        , m_name(name)
+        , m_strict_mode(strict_mode)
+    {
+    }
+
+    // Some matches should start on a node rather than an output. These three constructors
+    // are transition until we work out the right way to do that.
+    Matcher(std::shared_ptr<Node> pattern_node);
+    Matcher(std::shared_ptr<Node> pattern_node, const std::string& name);
+    Matcher(std::shared_ptr<Node> pattern_node, const std::string& name, bool strict_mode);
+
+    virtual ~Matcher() {}
+    /// \brief Matches a pattern to \p graph_node
+    ///
+    /// \param graph_value is an input graph to be matched against
+    bool match(const Output<Node>& graph_value);
+
+    bool match(std::shared_ptr<Node> graph_node);
+
+    /// \brief Matches a pattern to \p graph_node
+    ///
+    /// \param graph_value is an input graph to be matched against
+    /// \param previous_matches contains previous mappings from labels to nodes to use
+    bool match(const Output<Node>& graph_value, const PatternMap& previous_matches);
+    bool match(const Output<Node>& graph_value, const PatternValueMap& previous_matches);
+
+    template <typename T>
+    static std::shared_ptr<T> unique_match(std::shared_ptr<Node> node)
+    {
+        std::shared_ptr<T> matched;
+        for (auto arg : node->get_arguments())
+        {
+            if (auto t_casted = as_type_ptr<T>(arg))
+            {
+                if (matched)
+                {
+                    throw ngraph_error("There's more than two arguments of the same type");
+                }
+                else
+                {
+                    matched = t_casted;
+                }
+            }
+        }
+        return matched;
+    }
+
+    bool is_contained_match(const NodeVector& exclusions = {}, bool ignore_unused = true);
+    const NodeVector get_matched_nodes() { return as_node_vector(m_matched_list); }
+    const OutputVector& get_matched_values() const { return m_matched_list; }
+    OutputVector& get_matched_values() { return m_matched_list; }
+    void reset() {}
+    const std::string& get_name() { return m_name; }
+    std::shared_ptr<Node> get_pattern() { return m_pattern_node.as_single_output_node(); }
+    Output<Node> get_pattern_value() { return m_pattern_node; }
+    std::shared_ptr<Node> get_match_root();
+    Output<Node> get_match_value();
+    PatternMap get_pattern_map() const;
+    PatternValueMap& get_pattern_value_map() { return m_pattern_map; }
+    PatternValueMaps& get_pattern_value_maps() { return m_pattern_value_maps; }
+    size_t add_node(Output<Node> node);
+
+    bool virtual match_value(const ngraph::Output<Node>& pattern_value,
+                             const ngraph::Output<Node>& graph_value);
+
+    bool is_strict_mode() { return m_strict_mode; }
+    virtual bool match_arguments(Node* pattern_node, const std::shared_ptr<Node>& graph_node);
+
+    void capture(const std::set<Node*>& static_nodes);
+
+    size_t get_number_of_recurrent_matches() const { return m_pattern_value_maps.size(); }
+    NodeVector get_bound_nodes_for_pattern(const Output<Node>& pattern) const;
+    size_t get_number_of_bound_labels() const;
+    /// \brief Try a match
+    MatcherState start_match();
+
+    Output<Node> m_match_root;
+    Output<Node> m_pattern_node;
+    PatternValueMap m_pattern_map;
+    PatternValueMaps m_pattern_value_maps;
+    OutputVector m_matched_list;
+
+protected:
+    bool match_permutation(const OutputVector& pattern_args, const OutputVector& args);
+    Output<Node> make_node_output(const std::shared_ptr<Node>& node);
+
+    std::string m_name{"unnamed"};
+    bool m_strict_mode{false};
+};
+
+class NGRAPH_API ngraph::pattern::RecurrentMatcher
+{
+public:
+    /// \brief Constructs a RecurrentMatcher object. Reccurent Matchers are used to match
+    ///        repeating patterns (e.g. RNN, LSTM, GRU cells)
+    ///
+    /// \param initial_pattern is a pattern sub graph describing the initial cell
+    /// \param pattern is a pattern sub graph describing an individual cell
+    /// \param rpattern is a (recurring) label to denote which node the next match should
+    ///                 start at
+    /// \param correlated_patterns is a set of labels whose bound nodes must remain the same
+    ///                            across all cells
+    RecurrentMatcher(const Output<Node>& initial_pattern,
+                     const Output<Node>& pattern,
+                     const std::shared_ptr<Node>& rpattern,
+                     const std::set<std::shared_ptr<Node>>& correlated_patterns)
+        : m_initial_pattern(initial_pattern)
+        , m_pattern(pattern)
+        , m_recurrent_pattern(rpattern)
+        , m_correlated_patterns(correlated_patterns)
+    {
+    }
+
+    /// \brief Constructs a RecurrentMatcher object. Reccurent Matchers are used to match
+    ///        repeating patterns (e.g. RNN, LSTM, GRU cells)
+    ///
+    /// \param pattern is a pattern sub graph describing an individual cell
+    /// \param rpattern is a (recurring) label to denote which node the next match should
+    ///                 start at
+    /// \param correlated_patterns is a set of labels whose bound nodes must remain the same
+    ///                            across all cells
+    RecurrentMatcher(const Output<Node>& pattern,
+                     const std::shared_ptr<Node>& rpattern,
+                     const std::set<std::shared_ptr<Node>>& correlated_patterns)
+        : RecurrentMatcher(pattern, pattern, rpattern, correlated_patterns)
+    {
+    }
+
+    RecurrentMatcher(const Output<Node>& initial_pattern,
+                     const Output<Node>& pattern,
+                     const std::shared_ptr<Node>& rpattern,
+                     const std::set<std::shared_ptr<op::Label>>& correlated_patterns);
+
+    RecurrentMatcher(const Output<Node>& pattern,
+                     const std::shared_ptr<Node>& rpattern,
+                     const std::set<std::shared_ptr<op::Label>>& correlated_patterns)
+        : RecurrentMatcher(pattern, pattern, rpattern, correlated_patterns)
+    {
+    }
+
+    /// \brief Returns a vector of bound nodes for a given label (used in a pattern
+    /// describing an individual cell
+    NodeVector get_bound_nodes_for_pattern(const std::shared_ptr<Node>& pattern) const
+    {
+        if (m_matches.count(pattern) == 0)
+        {
+            throw ngraph_error("No bound nodes for a given label");
+        }
+
+        return as_node_vector(m_matches.at(pattern));
+    }
+
+    size_t get_number_of_recurrent_matches() const
+    {
+        if (m_matches.size() == 0)
+        {
+            return 0;
+        }
+
+        return (*m_matches.begin()).second.size();
+    }
+
+    size_t get_number_of_bound_labels() const { return m_matches.size(); }
+    /// \brief Tries to match a pattern for an individual cell to a given \p graph
+    bool match(Output<Node> graph);
+
+    std::shared_ptr<Node> get_match_root() { return m_match_root.get_node_shared_ptr(); }
+    Output<Node> get_match_value() { return m_match_root; }
+private:
+    std::set<std::shared_ptr<Node>>
+        as_node_set(const std::set<std::shared_ptr<op::Label>>& label_set);
+
+    Output<Node> m_initial_pattern;
+    Output<Node> m_pattern;
+    std::shared_ptr<Node> m_recurrent_pattern;
+    const std::set<std::shared_ptr<Node>> m_correlated_patterns;
+    RPatternValueMap m_matches;
+    Output<Node> m_match_root;
+};

--- a/src/ngraph/pattern/op/any.hpp
+++ b/src/ngraph/pattern/op/any.hpp
@@ -25,50 +25,50 @@ namespace ngraph
     {
         namespace op
         {
-            /// The graph value is to the matched value list. If the predicate is true for the node
-            /// and the arguments match, the match succeeds.
-            class NGRAPH_API Any : public Pattern
-            {
-            public:
-                static constexpr NodeTypeInfo type_info{"patternAny", 0};
-                const NodeTypeInfo& get_type_info() const override;
-                /// \brief creates a Any node containing a sub-pattern described by \sa type and \sa
-                ///        shape.
-                Any(const element::Type& type,
-                    const PartialShape& s,
-                    ValuePredicate pred,
-                    const OutputVector& wrapped_values)
-                    : Pattern(wrapped_values, pred)
-                {
-                    set_output_type(0, type, s);
-                }
-                Any(const element::Type& type,
-                    const PartialShape& s,
-                    NodePredicate pred,
-                    const NodeVector& wrapped_values)
-                    : Any(type, s, as_value_predicate(pred), as_output_vector(wrapped_values))
-                {
-                }
-                /// \brief creates a Any node containing a sub-pattern described by the type and
-                ///        shape of \sa node.
-                Any(const Output<Node>& node,
-                    ValuePredicate pred,
-                    const OutputVector& wrapped_values)
-                    : Any(node.get_element_type(), node.get_partial_shape(), pred, wrapped_values)
-                {
-                }
-                Any(const Output<Node>& node, NodePredicate pred, const NodeVector& wrapped_values)
-                    : Any(node.get_element_type(),
-                          node.get_partial_shape(),
-                          as_value_predicate(pred),
-                          as_output_vector(wrapped_values))
-                {
-                }
-
-                bool match_value(pattern::Matcher* matcher,
-                                 const Output<Node>& pattern_value,
-                                 const Output<Node>& graph_value) override;
-            };
+            class Any;
         }
     }
 }
+
+/// The graph value is to the matched value list. If the predicate is true for the node
+/// and the arguments match, the match succeeds.
+class NGRAPH_API ngraph::pattern::op::Any : public Pattern
+{
+public:
+    static constexpr NodeTypeInfo type_info{"patternAny", 0};
+    const NodeTypeInfo& get_type_info() const override;
+    /// \brief creates a Any node containing a sub-pattern described by \sa type and \sa
+    ///        shape.
+    Any(const element::Type& type,
+        const PartialShape& s,
+        ValuePredicate pred,
+        const OutputVector& wrapped_values)
+        : Pattern(wrapped_values, pred)
+    {
+        set_output_type(0, type, s);
+    }
+    Any(const element::Type& type,
+        const PartialShape& s,
+        NodePredicate pred,
+        const NodeVector& wrapped_values)
+        : Any(type, s, as_value_predicate(pred), as_output_vector(wrapped_values))
+    {
+    }
+    /// \brief creates a Any node containing a sub-pattern described by the type and
+    ///        shape of \sa node.
+    Any(const Output<Node>& node, ValuePredicate pred, const OutputVector& wrapped_values)
+        : Any(node.get_element_type(), node.get_partial_shape(), pred, wrapped_values)
+    {
+    }
+    Any(const Output<Node>& node, NodePredicate pred, const NodeVector& wrapped_values)
+        : Any(node.get_element_type(),
+              node.get_partial_shape(),
+              as_value_predicate(pred),
+              as_output_vector(wrapped_values))
+    {
+    }
+
+    bool match_value(pattern::Matcher* matcher,
+                     const Output<Node>& pattern_value,
+                     const Output<Node>& graph_value) override;
+};

--- a/src/ngraph/pattern/op/any_of.hpp
+++ b/src/ngraph/pattern/op/any_of.hpp
@@ -25,63 +25,59 @@ namespace ngraph
     {
         namespace op
         {
-            /// The graph value is added to the matched values list. If the predicate is true for
-            /// the
-            /// graph node, a submatch is performed on the input of AnyOf and each input of the
-            /// graph node. The first match that succeeds results in a successful match. Otherwise
-            /// the match fails.
-            ///
-            /// AnyOf may be given a type and shape for use in strict mode.
-            class NGRAPH_API AnyOf : public Pattern
-            {
-            public:
-                static constexpr NodeTypeInfo type_info{"patternAnyOf", 0};
-                const NodeTypeInfo& get_type_info() const override;
-                /// \brief creates a AnyOf node containing a sub-pattern described by \sa type and
-                ///        \sa shape.
-                AnyOf(const element::Type& type,
-                      const PartialShape& s,
-                      ValuePredicate pred,
-                      const OutputVector& wrapped_values)
-                    : Pattern(wrapped_values, pred)
-                {
-                    if (wrapped_values.size() != 1)
-                    {
-                        throw ngraph_error("AnyOf expects exactly one argument");
-                    }
-                    set_output_type(0, type, s);
-                }
-                AnyOf(const element::Type& type,
-                      const PartialShape& s,
-                      NodePredicate pred,
-                      const NodeVector& wrapped_values)
-                    : AnyOf(type,
-                            s,
-                            [pred](const Output<Node>& value) {
-                                return pred(value.as_single_output_node());
-                            },
-                            as_output_vector(wrapped_values))
-                {
-                }
-
-                /// \brief creates a AnyOf node containing a sub-pattern described by the type and
-                ///        shape of \sa node.
-                AnyOf(const Output<Node>& node,
-                      ValuePredicate pred,
-                      const OutputVector& wrapped_values)
-                    : AnyOf(node.get_element_type(), node.get_partial_shape(), pred, wrapped_values)
-                {
-                }
-                AnyOf(std::shared_ptr<Node> node,
-                      NodePredicate pred,
-                      const NodeVector& wrapped_values)
-                    : AnyOf(node, as_value_predicate(pred), as_output_vector(wrapped_values))
-                {
-                }
-                bool match_value(Matcher* matcher,
-                                 const Output<Node>& pattern_value,
-                                 const Output<Node>& graph_value) override;
-            };
+            class AnyOf;
         }
     }
 }
+
+/// The graph value is added to the matched values list. If the predicate is true for
+/// the
+/// graph node, a submatch is performed on the input of AnyOf and each input of the
+/// graph node. The first match that succeeds results in a successful match. Otherwise
+/// the match fails.
+///
+/// AnyOf may be given a type and shape for use in strict mode.
+class NGRAPH_API ngraph::pattern::op::AnyOf : public Pattern
+{
+public:
+    static constexpr NodeTypeInfo type_info{"patternAnyOf", 0};
+    const NodeTypeInfo& get_type_info() const override;
+    /// \brief creates a AnyOf node containing a sub-pattern described by \sa type and
+    ///        \sa shape.
+    AnyOf(const element::Type& type,
+          const PartialShape& s,
+          ValuePredicate pred,
+          const OutputVector& wrapped_values)
+        : Pattern(wrapped_values, pred)
+    {
+        if (wrapped_values.size() != 1)
+        {
+            throw ngraph_error("AnyOf expects exactly one argument");
+        }
+        set_output_type(0, type, s);
+    }
+    AnyOf(const element::Type& type,
+          const PartialShape& s,
+          NodePredicate pred,
+          const NodeVector& wrapped_values)
+        : AnyOf(type,
+                s,
+                [pred](const Output<Node>& value) { return pred(value.as_single_output_node()); },
+                as_output_vector(wrapped_values))
+    {
+    }
+
+    /// \brief creates a AnyOf node containing a sub-pattern described by the type and
+    ///        shape of \sa node.
+    AnyOf(const Output<Node>& node, ValuePredicate pred, const OutputVector& wrapped_values)
+        : AnyOf(node.get_element_type(), node.get_partial_shape(), pred, wrapped_values)
+    {
+    }
+    AnyOf(std::shared_ptr<Node> node, NodePredicate pred, const NodeVector& wrapped_values)
+        : AnyOf(node, as_value_predicate(pred), as_output_vector(wrapped_values))
+    {
+    }
+    bool match_value(Matcher* matcher,
+                     const Output<Node>& pattern_value,
+                     const Output<Node>& graph_value) override;
+};

--- a/src/ngraph/pattern/op/any_output.hpp
+++ b/src/ngraph/pattern/op/any_output.hpp
@@ -25,23 +25,25 @@ namespace ngraph
     {
         namespace op
         {
-            /// Matches any output of a node
-            class NGRAPH_API AnyOutput : public Pattern
-            {
-            public:
-                static constexpr NodeTypeInfo type_info{"patternAnyOutput", 0};
-                const NodeTypeInfo& get_type_info() const override;
-                /// \brief creates an AnyOutput node matching any output of a node
-                /// \param node The node to match
-                AnyOutput(const std::shared_ptr<Node>& pattern)
-                    : Pattern({pattern->output(0)})
-                {
-                }
-
-                bool match_value(pattern::Matcher* matcher,
-                                 const Output<Node>& pattern_value,
-                                 const Output<Node>& graph_value) override;
-            };
+            class AnyOutput;
         }
     }
 }
+
+/// Matches any output of a node
+class NGRAPH_API ngraph::pattern::op::AnyOutput : public Pattern
+{
+public:
+    static constexpr NodeTypeInfo type_info{"patternAnyOutput", 0};
+    const NodeTypeInfo& get_type_info() const override;
+    /// \brief creates an AnyOutput node matching any output of a node
+    /// \param node The node to match
+    AnyOutput(const std::shared_ptr<Node>& pattern)
+        : Pattern({pattern->output(0)})
+    {
+    }
+
+    bool match_value(pattern::Matcher* matcher,
+                     const Output<Node>& pattern_value,
+                     const Output<Node>& graph_value) override;
+};

--- a/src/ngraph/pattern/op/branch.hpp
+++ b/src/ngraph/pattern/op/branch.hpp
@@ -25,50 +25,51 @@ namespace ngraph
     {
         namespace op
         {
-            /// A branch adds a loop to the pattern. The branch match is successful if the
-            /// destination node pattern matches the graph value. The destination node is a node in
-            /// the pattern graph that will not have been created some time after the Branch node is
-            /// created; use set_destination to add it.
-            ///
-            /// The branch destination is not stored as a shared pointer to prevent reference
-            /// cycles. Thus the destination node must be referenced in some other way to prevent it
-            /// from being deleted.
-            class NGRAPH_API Branch : public Pattern
-            {
-            public:
-                static constexpr NodeTypeInfo type_info{"patternBranch", 0};
-                const NodeTypeInfo& get_type_info() const override;
-                /// \brief Creates a Branch pattern
-                /// \param pattern the destinationing pattern
-                /// \param labels Labels where the destination may occur
-                Branch()
-                    : Pattern(OutputVector{})
-                {
-                    set_output_type(0, element::f32, Shape{});
-                }
-
-                void set_destination(const Output<Node>& destination)
-                {
-                    m_destination_node = destination.get_node();
-                    m_destination_index = destination.get_index();
-                }
-
-                Output<Node> get_destination() const
-                {
-                    return m_destination_node == nullptr
-                               ? Output<Node>()
-                               : Output<Node>{m_destination_node->shared_from_this(),
-                                              m_destination_index};
-                }
-
-                bool match_value(pattern::Matcher* matcher,
-                                 const Output<Node>& pattern_value,
-                                 const Output<Node>& graph_value) override;
-
-            protected:
-                Node* m_destination_node{nullptr};
-                size_t m_destination_index{0};
-            };
+            class Branch;
         }
     }
 }
+
+/// A branch adds a loop to the pattern. The branch match is successful if the
+/// destination node pattern matches the graph value. The destination node is a node in
+/// the pattern graph that will not have been created some time after the Branch node is
+/// created; use set_destination to add it.
+///
+/// The branch destination is not stored as a shared pointer to prevent reference
+/// cycles. Thus the destination node must be referenced in some other way to prevent it
+/// from being deleted.
+class NGRAPH_API ngraph::pattern::op::Branch : public Pattern
+{
+public:
+    static constexpr NodeTypeInfo type_info{"patternBranch", 0};
+    const NodeTypeInfo& get_type_info() const override;
+    /// \brief Creates a Branch pattern
+    /// \param pattern the destinationing pattern
+    /// \param labels Labels where the destination may occur
+    Branch()
+        : Pattern(OutputVector{})
+    {
+        set_output_type(0, element::f32, Shape{});
+    }
+
+    void set_destination(const Output<Node>& destination)
+    {
+        m_destination_node = destination.get_node();
+        m_destination_index = destination.get_index();
+    }
+
+    Output<Node> get_destination() const
+    {
+        return m_destination_node == nullptr
+                   ? Output<Node>()
+                   : Output<Node>{m_destination_node->shared_from_this(), m_destination_index};
+    }
+
+    bool match_value(pattern::Matcher* matcher,
+                     const Output<Node>& pattern_value,
+                     const Output<Node>& graph_value) override;
+
+protected:
+    Node* m_destination_node{nullptr};
+    size_t m_destination_index{0};
+};

--- a/src/ngraph/pattern/op/capture.hpp
+++ b/src/ngraph/pattern/op/capture.hpp
@@ -25,35 +25,33 @@ namespace ngraph
     {
         namespace op
         {
-            /// Experimental for support of recurrent matches.
-            ///
-            /// Capture adds the pattern value map to a list of pattern value maps and resets
-            /// matches for pattern nodes not in the static node list. The match always succeeds.
-            class NGRAPH_API Capture : public Pattern
-            {
-            public:
-                static constexpr NodeTypeInfo type_info{"patternCapture", 0};
-                const NodeTypeInfo& get_type_info() const override;
-                Capture(const Output<Node>& arg)
-                    : Pattern({arg})
-                {
-                    set_output_type(0, arg.get_element_type(), arg.get_partial_shape());
-                }
-
-                /// \brief static nodes are retained after a capture. All other nodes are dropped
-                std::set<Node*> get_static_nodes() { return m_static_nodes; }
-                void set_static_nodes(const std::set<Node*>& static_nodes)
-                {
-                    m_static_nodes = static_nodes;
-                }
-
-                virtual bool match_value(pattern::Matcher* matcher,
-                                         const Output<Node>& pattern_value,
-                                         const Output<Node>& graph_value) override;
-
-            protected:
-                std::set<Node*> m_static_nodes;
-            };
+            class Capture;
         }
     }
 }
+
+/// Experimental for support of recurrent matches.
+///
+/// Capture adds the pattern value map to a list of pattern value maps and resets
+/// matches for pattern nodes not in the static node list. The match always succeeds.
+class NGRAPH_API ngraph::pattern::op::Capture : public Pattern
+{
+public:
+    static constexpr NodeTypeInfo type_info{"patternCapture", 0};
+    const NodeTypeInfo& get_type_info() const override;
+    Capture(const Output<Node>& arg)
+        : Pattern({arg})
+    {
+        set_output_type(0, arg.get_element_type(), arg.get_partial_shape());
+    }
+
+    /// \brief static nodes are retained after a capture. All other nodes are dropped
+    std::set<Node*> get_static_nodes() { return m_static_nodes; }
+    void set_static_nodes(const std::set<Node*>& static_nodes) { m_static_nodes = static_nodes; }
+    virtual bool match_value(pattern::Matcher* matcher,
+                             const Output<Node>& pattern_value,
+                             const Output<Node>& graph_value) override;
+
+protected:
+    std::set<Node*> m_static_nodes;
+};

--- a/src/ngraph/pattern/op/label.hpp
+++ b/src/ngraph/pattern/op/label.hpp
@@ -37,7 +37,7 @@ namespace ngraph
 /// value. Otherwise, the label is associated with the graph value and the match
 /// succeeds if the pattern input matches the graph value.
 ///
-/// DEPRECATED: If no inputs are given to Label, a True node is serves as the input. If
+/// DEPRECATED: If no inputs are given to Label, a True node serves as the input. If
 /// more than one inputs are given, an Or pattern of the inputs serves as the input.
 class NGRAPH_API ngraph::pattern::op::Label : public Pattern
 {

--- a/src/ngraph/pattern/op/label.hpp
+++ b/src/ngraph/pattern/op/label.hpp
@@ -25,121 +25,117 @@ namespace ngraph
     {
         namespace op
         {
-            /// Fails if the predicate returns false on the graph value.
-            ///
-            /// The graph value is added to the matched values list. If the Label is already
-            /// associated with a value, the match succeeds if the value is the same as the graph
-            /// value. Otherwise, the label is associated with the graph value and the match
-            /// succeeds if the pattern input matches the graph value.
-            ///
-            /// DEPRECATED: If no inputs are given to Label, a True node is serves as the input. If
-            /// more than one inputs are given, an Or pattern of the inputs serves as the input.
-            class NGRAPH_API Label : public Pattern
-            {
-            public:
-                static constexpr NodeTypeInfo type_info{"patternLabel", 0};
-                const NodeTypeInfo& get_type_info() const override;
-                /// \brief creates a Label node containing a sub-pattern described by \sa type and
-                ///        \sa shape.
-                ///
-                /// this Label node can be bound only to the nodes in the input graph
-                /// that match the pattern specified by \sa wrapped_nodes
-                /// Example:
-                /// \code{.cpp}
-                /// auto add = a + b; // a and b are op::Parameter in this example
-                /// auto label = std::make_shared<pattern::op::Label>(element::f32,
-                ///                                                   Shape{2,2},
-                ///                                                   nullptr,
-                ///                                                   OutputVector{add});
-                /// \endcode
-                Label(const element::Type& type,
-                      const PartialShape& s,
-                      const ValuePredicate pred,
-                      const OutputVector& wrapped_values)
-                    : Pattern(OutputVector{wrap_values(wrapped_values)}, pred)
-                {
-                    set_output_type(0, type, s);
-                }
-
-                Label(const element::Type& type, const PartialShape& s)
-                    : Label(type, s, [](const Output<Node>&) { return true; }, OutputVector())
-                {
-                }
-
-                Label(const element::Type& type, const PartialShape& s, ValuePredicate pred)
-                    : Label(type, s, pred, OutputVector{})
-                {
-                }
-
-                Label(const element::Type& type, const PartialShape& s, NodePredicate pred)
-                    : Label(type, s, as_value_predicate(pred), OutputVector{})
-                {
-                }
-
-                Label(const element::Type& type,
-                      const PartialShape& s,
-                      const NodePredicate pred,
-                      const NodeVector& wrapped_values)
-                    : Label(type, s, as_value_predicate(pred), as_output_vector(wrapped_values))
-                {
-                }
-
-                /// \brief creates a Label node containing a sub-pattern described by the type and
-                ///        shape of \sa node.
-                ///
-                /// this Label node can be bound only to the nodes in the input graph
-                /// that match the pattern specified by \sa wrapped_values
-                /// Example:
-                /// \code{.cpp}
-                /// auto add = a + b; // a and b are op::Parameter in this example
-                /// auto label = std::make_shared<pattern::op::Label>(add,
-                ///                                                   nullptr,
-                ///                                                   OutputVector{add});
-                /// \endcode
-                Label(const Output<Node>& value,
-                      const ValuePredicate pred,
-                      const OutputVector& wrapped_values)
-                    : Label(
-                          value.get_element_type(), value.get_partial_shape(), pred, wrapped_values)
-                {
-                }
-                Label(const Output<Node>& value, const ValuePredicate pred)
-                    : Label(
-                          value.get_element_type(), value.get_partial_shape(), pred, OutputVector{})
-                {
-                }
-
-                Label(const Output<Node>& value, const NodePredicate pred)
-                    : Label(value.get_element_type(),
-                            value.get_partial_shape(),
-                            as_value_predicate(pred),
-                            OutputVector{})
-                {
-                }
-                Label(const Output<Node>& value)
-                    : Label(value.get_element_type(),
-                            value.get_partial_shape(),
-                            [](const Output<Node>&) { return true; },
-                            OutputVector{})
-                {
-                }
-                Label(const Output<Node>& node,
-                      const NodePredicate pred,
-                      const NodeVector& wrapped_values)
-                    : Label(node.get_element_type(),
-                            node.get_partial_shape(),
-                            as_value_predicate(pred),
-                            as_output_vector(wrapped_values))
-                {
-                }
-
-                bool match_value(Matcher* matcher,
-                                 const Output<Node>& pattern_value,
-                                 const Output<Node>& graph_value) override;
-
-            protected:
-                static Output<Node> wrap_values(const OutputVector& wrapped_values);
-            };
+            class Label;
         }
     }
 }
+
+/// Fails if the predicate returns false on the graph value.
+///
+/// The graph value is added to the matched values list. If the Label is already
+/// associated with a value, the match succeeds if the value is the same as the graph
+/// value. Otherwise, the label is associated with the graph value and the match
+/// succeeds if the pattern input matches the graph value.
+///
+/// DEPRECATED: If no inputs are given to Label, a True node is serves as the input. If
+/// more than one inputs are given, an Or pattern of the inputs serves as the input.
+class NGRAPH_API ngraph::pattern::op::Label : public Pattern
+{
+public:
+    static constexpr NodeTypeInfo type_info{"patternLabel", 0};
+    const NodeTypeInfo& get_type_info() const override;
+    /// \brief creates a Label node containing a sub-pattern described by \sa type and
+    ///        \sa shape.
+    ///
+    /// this Label node can be bound only to the nodes in the input graph
+    /// that match the pattern specified by \sa wrapped_nodes
+    /// Example:
+    /// \code{.cpp}
+    /// auto add = a + b; // a and b are op::Parameter in this example
+    /// auto label = std::make_shared<pattern::op::Label>(element::f32,
+    ///                                                   Shape{2,2},
+    ///                                                   nullptr,
+    ///                                                   OutputVector{add});
+    /// \endcode
+    Label(const element::Type& type,
+          const PartialShape& s,
+          const ValuePredicate pred,
+          const OutputVector& wrapped_values)
+        : Pattern(OutputVector{wrap_values(wrapped_values)}, pred)
+    {
+        set_output_type(0, type, s);
+    }
+
+    Label(const element::Type& type, const PartialShape& s)
+        : Label(type, s, [](const Output<Node>&) { return true; }, OutputVector())
+    {
+    }
+
+    Label(const element::Type& type, const PartialShape& s, ValuePredicate pred)
+        : Label(type, s, pred, OutputVector{})
+    {
+    }
+
+    Label(const element::Type& type, const PartialShape& s, NodePredicate pred)
+        : Label(type, s, as_value_predicate(pred), OutputVector{})
+    {
+    }
+
+    Label(const element::Type& type,
+          const PartialShape& s,
+          const NodePredicate pred,
+          const NodeVector& wrapped_values)
+        : Label(type, s, as_value_predicate(pred), as_output_vector(wrapped_values))
+    {
+    }
+
+    /// \brief creates a Label node containing a sub-pattern described by the type and
+    ///        shape of \sa node.
+    ///
+    /// this Label node can be bound only to the nodes in the input graph
+    /// that match the pattern specified by \sa wrapped_values
+    /// Example:
+    /// \code{.cpp}
+    /// auto add = a + b; // a and b are op::Parameter in this example
+    /// auto label = std::make_shared<pattern::op::Label>(add,
+    ///                                                   nullptr,
+    ///                                                   OutputVector{add});
+    /// \endcode
+    Label(const Output<Node>& value, const ValuePredicate pred, const OutputVector& wrapped_values)
+        : Label(value.get_element_type(), value.get_partial_shape(), pred, wrapped_values)
+    {
+    }
+    Label(const Output<Node>& value, const ValuePredicate pred)
+        : Label(value.get_element_type(), value.get_partial_shape(), pred, OutputVector{})
+    {
+    }
+
+    Label(const Output<Node>& value, const NodePredicate pred)
+        : Label(value.get_element_type(),
+                value.get_partial_shape(),
+                as_value_predicate(pred),
+                OutputVector{})
+    {
+    }
+    Label(const Output<Node>& value)
+        : Label(value.get_element_type(),
+                value.get_partial_shape(),
+                [](const Output<Node>&) { return true; },
+                OutputVector{})
+    {
+    }
+    Label(const Output<Node>& node, const NodePredicate pred, const NodeVector& wrapped_values)
+        : Label(node.get_element_type(),
+                node.get_partial_shape(),
+                as_value_predicate(pred),
+                as_output_vector(wrapped_values))
+    {
+    }
+
+    bool match_value(Matcher* matcher,
+                     const Output<Node>& pattern_value,
+                     const Output<Node>& graph_value) override;
+
+protected:
+    static Output<Node> wrap_values(const OutputVector& wrapped_values);
+};

--- a/src/ngraph/pattern/op/or.hpp
+++ b/src/ngraph/pattern/op/or.hpp
@@ -25,25 +25,27 @@ namespace ngraph
     {
         namespace op
         {
-            /// A submatch on the graph value is performed on each input to the Or; the match
-            /// succeeds on the first match. Otherwise the match fails.
-            class NGRAPH_API Or : public Pattern
-            {
-            public:
-                static constexpr NodeTypeInfo type_info{"patternOr", 0};
-                const NodeTypeInfo& get_type_info() const override;
-                /// \brief creates an Or node matching one of several sub-patterns in order. Does
-                /// not add node to match list.
-                /// \param patterns The patterns to try for matching
-                Or(const OutputVector& patterns)
-                    : Pattern(patterns)
-                {
-                }
-
-                bool match_value(pattern::Matcher* matcher,
-                                 const Output<Node>& pattern_value,
-                                 const Output<Node>& graph_value) override;
-            };
+            class Or;
         }
     }
 }
+
+/// A submatch on the graph value is performed on each input to the Or; the match
+/// succeeds on the first match. Otherwise the match fails.
+class NGRAPH_API ngraph::pattern::op::Or : public Pattern
+{
+public:
+    static constexpr NodeTypeInfo type_info{"patternOr", 0};
+    const NodeTypeInfo& get_type_info() const override;
+    /// \brief creates an Or node matching one of several sub-patterns in order. Does
+    /// not add node to match list.
+    /// \param patterns The patterns to try for matching
+    Or(const OutputVector& patterns)
+        : Pattern(patterns)
+    {
+    }
+
+    bool match_value(pattern::Matcher* matcher,
+                     const Output<Node>& pattern_value,
+                     const Output<Node>& graph_value) override;
+};

--- a/src/ngraph/pattern/op/pattern.hpp
+++ b/src/ngraph/pattern/op/pattern.hpp
@@ -27,6 +27,7 @@ namespace ngraph
         namespace op
         {
             class Label;
+            class Pattern;
         }
 
         class Matcher;
@@ -56,39 +57,39 @@ namespace ngraph
 
             NGRAPH_API
             ValuePredicate as_value_predicate(NodePredicate pred);
-
-            class NGRAPH_API Pattern : public Node
-            {
-            public:
-                /// \brief \p a base class for \sa Skip and \sa Label
-                ///
-                Pattern(const OutputVector& patterns, ValuePredicate pred)
-                    : Node(patterns)
-                    , m_predicate(pred)
-                {
-                    if (!m_predicate)
-                    {
-                        m_predicate = [](const Output<Node>&) { return true; };
-                    }
-                }
-
-                Pattern(const OutputVector& patterns)
-                    : Pattern(patterns, nullptr)
-                {
-                }
-
-                virtual std::shared_ptr<Node>
-                    copy_with_new_args(const NodeVector& /* new_args */) const override
-                {
-                    throw ngraph_error("Uncopyable");
-                }
-
-                ValuePredicate get_predicate() const;
-
-                bool is_pattern() const override { return true; }
-            protected:
-                ValuePredicate m_predicate;
-            };
         }
     }
 }
+
+class NGRAPH_API ngraph::pattern::op::Pattern : public Node
+{
+public:
+    /// \brief \p a base class for \sa Skip and \sa Label
+    ///
+    Pattern(const OutputVector& patterns, ValuePredicate pred)
+        : Node(patterns)
+        , m_predicate(pred)
+    {
+        if (!m_predicate)
+        {
+            m_predicate = [](const Output<Node>&) { return true; };
+        }
+    }
+
+    Pattern(const OutputVector& patterns)
+        : Pattern(patterns, nullptr)
+    {
+    }
+
+    virtual std::shared_ptr<Node>
+        copy_with_new_args(const NodeVector& /* new_args */) const override
+    {
+        throw ngraph_error("Uncopyable");
+    }
+
+    ValuePredicate get_predicate() const;
+
+    bool is_pattern() const override { return true; }
+protected:
+    ValuePredicate m_predicate;
+};

--- a/src/ngraph/pattern/op/skip.hpp
+++ b/src/ngraph/pattern/op/skip.hpp
@@ -25,30 +25,32 @@ namespace ngraph
     {
         namespace op
         {
-            /// The graph value is added to the matched value list. If the predicate is true, the
-            /// match succeeds if the arguments match; if the predicate is false, the match succeeds
-            /// if the pattern input matches the graph value.
-            class NGRAPH_API Skip : public Pattern
-            {
-            public:
-                static constexpr NodeTypeInfo type_info{"patternSkip", 0};
-                const NodeTypeInfo& get_type_info() const override;
-                Skip(const Output<Node>& arg, ValuePredicate pred)
-                    : Pattern({arg}, pred)
-                {
-                    set_output_type(0, arg.get_element_type(), arg.get_partial_shape());
-                }
-
-                Skip(const Output<Node>& arg, NodePredicate pred = nullptr)
-                    : Pattern({arg}, as_value_predicate(pred))
-                {
-                    set_output_type(0, arg.get_element_type(), arg.get_partial_shape());
-                }
-
-                virtual bool match_value(pattern::Matcher* matcher,
-                                         const Output<Node>& pattern_value,
-                                         const Output<Node>& graph_value) override;
-            };
+            class Skip;
         }
     }
 }
+
+/// The graph value is added to the matched value list. If the predicate is true, the
+/// match succeeds if the arguments match; if the predicate is false, the match succeeds
+/// if the pattern input matches the graph value.
+class NGRAPH_API ngraph::pattern::op::Skip : public Pattern
+{
+public:
+    static constexpr NodeTypeInfo type_info{"patternSkip", 0};
+    const NodeTypeInfo& get_type_info() const override;
+    Skip(const Output<Node>& arg, ValuePredicate pred)
+        : Pattern({arg}, pred)
+    {
+        set_output_type(0, arg.get_element_type(), arg.get_partial_shape());
+    }
+
+    Skip(const Output<Node>& arg, NodePredicate pred = nullptr)
+        : Pattern({arg}, as_value_predicate(pred))
+    {
+        set_output_type(0, arg.get_element_type(), arg.get_partial_shape());
+    }
+
+    virtual bool match_value(pattern::Matcher* matcher,
+                             const Output<Node>& pattern_value,
+                             const Output<Node>& graph_value) override;
+};

--- a/src/ngraph/pattern/op/true.hpp
+++ b/src/ngraph/pattern/op/true.hpp
@@ -25,21 +25,23 @@ namespace ngraph
     {
         namespace op
         {
-            /// \brief The match always succeeds.
-            class NGRAPH_API True : public Pattern
-            {
-            public:
-                static constexpr NodeTypeInfo type_info{"patternTrue", 0};
-                const NodeTypeInfo& get_type_info() const override;
-                /// \brief Always matches, does not add node to match list.
-                True()
-                    : Pattern(OutputVector{})
-                {
-                }
-                bool match_value(pattern::Matcher* matcher,
-                                 const Output<Node>& pattern_value,
-                                 const Output<Node>& graph_value) override;
-            };
+            class True;
         }
     }
 }
+
+/// \brief The match always succeeds.
+class NGRAPH_API ngraph::pattern::op::True : public Pattern
+{
+public:
+    static constexpr NodeTypeInfo type_info{"patternTrue", 0};
+    const NodeTypeInfo& get_type_info() const override;
+    /// \brief Always matches, does not add node to match list.
+    True()
+        : Pattern(OutputVector{})
+    {
+    }
+    bool match_value(pattern::Matcher* matcher,
+                     const Output<Node>& pattern_value,
+                     const Output<Node>& graph_value) override;
+};


### PR DESCRIPTION
This just changes formatting/indenting for the pattern matcher. Make sure you hide whitespace changes when reviewing.