### PR TITLE
Fix mlir build

### DIFF
--- a/src/contrib/mlir/runtime/cpu/cpu_runtime.hpp
+++ b/src/contrib/mlir/runtime/cpu/cpu_runtime.hpp
@@ -38,7 +38,7 @@ namespace ngraph
                 void* allocatedPtr;
                 void* alignedPtr;
                 int64_t offset;
-                int64_t shapeAndStrides[];
+                int64_t shapeAndStrides[1];
             };
 
             struct UnrankedMemRef


### PR DESCRIPTION
I use build command
`cmake .. -DCMAKE_BUILD_TYPE=Release -DNGRAPH_ONNX_IMPORT_ENABLE=ON -DNGRAPH_ONNXIFI_ENABLE=ON -DNGRAPH_CPU_ENABLE=TRUE -DNGRAPH_USE_PREBUILT_LLVM=TRUE -DNGRAPH_MLIR_ENABLE=TRUE -DNGRAPH_DEX_ONLY=ON -DNGRAPH_USE_PREBUILT_MLIR=0 -DCMAKE_INSTALL_PREFIX=~/ngraph/BUILD-GCC/ngraph_dist`
using clang 6.0
I get the error
```
In file included from /home/rkimball/dev/ngraph/src/contrib/mlir/runtime/cpu/cpu_callbacks.cpp:22:
/home/rkimball/dev/ngraph/src/contrib/mlir/runtime/cpu/cpu_runtime.hpp:41:25: error: flexible array members are a C99
      feature [-Werror,-Wc99-extensions]
                int64_t shapeAndStrides[];
                        ^
In file included from /home/rkimball/dev/ngraph/src/contrib/mlir/runtime/cpu/cpu_runtime.cpp:20:
/home/rkimball/dev/ngraph/src/contrib/mlir/runtime/cpu/cpu_runtime.hpp:41:25: error: flexible array members are a C99
      feature [-Werror,-Wc99-extensions]
                int64_t shapeAndStrides[];
                        ^
1 error generated.
```