### PR TITLE
Fix unsqueeze file name

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -448,7 +448,7 @@ set(MULTI_TEST_SRC
     backend/topk.in.cpp
     backend/transpose.in.cpp
     backend/unhandled_op.in.cpp
-    backend/unsqueeze.cpp
+    backend/unsqueeze.in.cpp
     backend/validate_call.in.cpp
     backend/zero_sized.in.cpp
 )

--- a/test/backend/unsqueeze.in.cpp
+++ b/test/backend/unsqueeze.in.cpp
@@ -53,7 +53,7 @@ NGRAPH_TEST(${BACKEND_NAME}, unsqueeze)
         make_shared<ngraph::op::Constant>(element::i64, Shape{2}, vector<int64_t>{1, 2});
     auto squeeze = make_shared<op::Unsqueeze>(data_node, axes_node);
 
-    auto function = make_shared<Function>(NodeVector{squeeze}, ParameterVector{data_node});
+    auto function = make_shared<Function>(OutputVector{squeeze}, ParameterVector{data_node});
     auto test_case = ngraph::test::NgraphTestCase(function, "${BACKEND_NAME}");
 
     auto data = vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};


### PR DESCRIPTION
The unsqueeze test was only generated for a single backend instead of all backends