### PR TITLE
If user requests to use prebuilt llvm but prebuilt is the wrong hash then fail

### DIFF
--- a/cmake/external/llvm.cmake
+++ b/cmake/external/llvm.cmake
@@ -51,6 +51,9 @@ if(EXISTS "${VCSREVISION}")
 endif()
 
 if(NEED_TO_BUILD_LLVM)
+    if (NGRAPH_USE_PREBUILT_LLVM)
+        message(FATAL_ERROR "LLVM: prebuilt is the wrong hash, expected ${LLVM_COMMIT_ID}")
+    endif()
     if(NOT NGRAPH_OVERWRITE_LLVM_ROOT)
         message(FATAL_ERROR "nGraph is not allowed overwrite contents at LLVM_ROOT: ${LLVM_ROOT} "
             "Set NGRAPH_OVERWRITE_LLVM_ROOT to ON if you would like to overwrite.")


### PR DESCRIPTION
If the hash is wrong then the compile may fail as it did for me. This tells you early that something is wrong.